### PR TITLE
Remove custom markers from VCL

### DIFF
--- a/vcl_templates/assets.vcl.erb
+++ b/vcl_templates/assets.vcl.erb
@@ -1,4 +1,3 @@
-# >> custom backends
 backend F_origin {
     .connect_timeout = 5s;
     .dynamic = true;
@@ -114,7 +113,6 @@ backend sick_force_grace {
   }
 }
 
-# << custom backends
 
 acl purge_ip_whitelist {
   "37.26.90.227";     # Platform 1 production
@@ -137,7 +135,6 @@ acl purge_ip_whitelist {
 
 sub vcl_recv {
 
-  # >> custom recv
   # Allow FASTLYPURGE from IPs defined in the ACL only, else return a HTTP 403
   if (req.request == "FASTLYPURGE") {
     if (client.ip ~ purge_ip_whitelist) {
@@ -145,9 +142,7 @@ sub vcl_recv {
     }
     error 403 "Forbidden";
   }
-  # << custom recv
 
-  # >> normally from `request settings` UI
   # Force SSL.
   if (!req.http.Fastly-SSL) {
      error 801 "Force SSL";
@@ -155,9 +150,7 @@ sub vcl_recv {
 
   # Serve from stale for 24 hours if origin is sick
   set req.grace = 24h;
-  # << normally from `request settings` UI
 
-  # >> custom recv
   # Default backend.
   set req.backend = F_origin;
 <% if environment == 'staging' %>
@@ -188,23 +181,19 @@ sub vcl_recv {
 
   # Unspoofable original client address.
   set req.http.True-Client-IP = req.http.Fastly-Client-IP;
-  # << custom recv
 
 #FASTLY recv
 
-  # >> not reproduced by macro
   if (req.request != "HEAD" && req.request != "GET" && req.request != "FASTLYPURGE") {
     return(pass);
   }
 
   return(lookup);
-  # << not reproduced by macro
 }
 
 sub vcl_fetch {
 #FASTLY fetch
 
-  # >> custom
   if ((beresp.status >= 500 && beresp.status <= 599) && req.restarts < 3 && (req.request == "GET" || req.request == "HEAD") && !beresp.http.No-Fallback) {
     set beresp.saintmode = 5s;
     return (restart);
@@ -214,9 +203,7 @@ sub vcl_fetch {
     # Keep stale for origin
     set beresp.grace = 24h;
   }
-  # << custom
 
-  # >> not reproduced by macro
   if(req.restarts > 0 ) {
     set beresp.http.Fastly-Restarts = req.restarts;
   }
@@ -230,13 +217,9 @@ sub vcl_fetch {
     return (pass);
   }
 
-  # << not reproduced by macro
-  # >> custom
   if (beresp.http.Cache-Control ~ "no-(store|cache)") {
     return (pass);
   }
-  # << custom
-  # >> not reproduced by macro
 
   if (beresp.status >= 500 && beresp.status <= 599) {
     set req.http.Fastly-Cachetype = "ERROR";
@@ -251,14 +234,11 @@ sub vcl_fetch {
     # apply the default ttl
     set beresp.ttl = <%= config['default_ttl'] %>s;
   }
-  # << not reproduced by macro
 
-  # >> custom
   # Override default.vcl behaviour of return(pass).
   if (beresp.http.Set-Cookie) {
     return (deliver);
   }
-  # << custom
 }
 
 sub vcl_hit {
@@ -296,10 +276,6 @@ sub vcl_error {
 
 #FASTLY error
 }
-
-# <<
-# pipe cannot be included.
-# >>
 
 sub vcl_pass {
 #FASTLY pass

--- a/vcl_templates/bouncer.vcl.erb
+++ b/vcl_templates/bouncer.vcl.erb
@@ -1,4 +1,3 @@
-# >> custom backends
 
 backend F_origin0 {
     .connect_timeout = 1s;
@@ -49,7 +48,6 @@ backend sick_force_grace {
   }
 }
 
-# << custom backends
 
 acl purge_ip_whitelist {
   "80.194.77.90";    # Aviation House
@@ -58,7 +56,6 @@ acl purge_ip_whitelist {
 
 sub vcl_recv {
 
-  # >> custom recv
   # Allow FASTLYPURGE from IPs defined in the ACL only, else return a HTTP 403
   if (req.request == "FASTLYPURGE") {
     if (client.ip ~ purge_ip_whitelist) {
@@ -67,9 +64,7 @@ sub vcl_recv {
     error 403 "Forbidden";
   }
 
-  # << custom recv
 
-  # >> normally from `request settings` UI
 
   # Append to XFF. Unsure about this restart condition?
   if (!req.http.Fastly-FF) {
@@ -80,9 +75,7 @@ sub vcl_recv {
 
   # Keep stale.
   set req.grace = 86400s;
-  # << normally from `request settings` UI
 
-  # >> custom recv
   # Default backend.
   set req.backend = F_origin0;
 
@@ -101,23 +94,19 @@ sub vcl_recv {
     set req.backend = F_origin1;
   }
 
-  # << custom recv
 
 #FASTLY recv
 
-  # >> not reproduced by macro
   if (req.request != "HEAD" && req.request != "GET" && req.request != "PURGE") {
     return(pass);
   }
 
   return(lookup);
-  # << not reproduced by macro
 }
 
 sub vcl_fetch {
 #FASTLY fetch
 
-  # >> not reproduced by macro
 
   set beresp.grace = 86400s;
 
@@ -153,7 +142,6 @@ sub vcl_fetch {
     # apply the default ttl
     set beresp.ttl = 3600s;
   }
-  # << not reproduced by macro
 }
 
 sub vcl_hit {
@@ -200,9 +188,7 @@ sub vcl_error {
 #FASTLY error
 }
 
-# <<
 # pipe cannot be included.
-# >>
 
 sub vcl_pass {
 #FASTLY pass

--- a/vcl_templates/performanceplatform.vcl.erb
+++ b/vcl_templates/performanceplatform.vcl.erb
@@ -1,4 +1,3 @@
-# >> custom backends
 backend F_origin {
     .connect_timeout = 5s;
     .dynamic = true;
@@ -45,7 +44,6 @@ backend sick_force_grace {
   }
 }
 
-# << custom backends
 
 acl purge_ip_whitelist {
   "37.26.90.227";     # Platform 1 production
@@ -63,7 +61,6 @@ acl purge_ip_whitelist {
 
 sub vcl_recv {
 
-  # >> custom recv
   # Allow FASTLYPURGE from IPs defined in the ACL only, else return a HTTP 403
   if (req.request == "FASTLYPURGE") {
     if (client.ip ~ purge_ip_whitelist) {
@@ -71,9 +68,7 @@ sub vcl_recv {
     }
     error 403 "Forbidden";
   }
-  # << custom recv
 
-  # >> normally from `request settings` UI
   # Force SSL.
   if (!req.http.Fastly-SSL) {
      error 801 "Force SSL";
@@ -81,9 +76,7 @@ sub vcl_recv {
 
   # Serve from stale for 24 hours if origin is sick
   set req.grace = 24h;
-  # << normally from `request settings` UI
 
-  # >> custom recv
   # Default backend.
   set req.backend = F_origin;
 
@@ -94,7 +87,6 @@ sub vcl_recv {
 
   # Serve from stale for 24 hours if origin is sick
   set req.grace = 24h;
-  # << normally from `request settings` UI
 
   # Unspoofable original client address
   set req.http.True-Client-IP = req.http.Fastly-Client-IP;
@@ -120,23 +112,19 @@ sub vcl_recv {
   if (!req.http.GOVUK-Request-Id) {
     set req.http.GOVUK-Request-Id = server.identity "-" req.xid;
   }
-  # << custom recv
 
 #FASTLY recv
 
-  # >> not reproduced by macro
   if (req.request != "HEAD" && req.request != "GET" && req.request != "FASTLYPURGE") {
     return(pass);
   }
 
   return(lookup);
-  # << not reproduced by macro
 }
 
 sub vcl_fetch {
 #FASTLY fetch
 
-  # >> custom
   if ((beresp.status >= 500 && beresp.status <= 599) && req.restarts < 3 && (req.request == "GET" || req.request == "HEAD") && !beresp.http.No-Fallback) {
     set beresp.saintmode = 5s;
     return (restart);
@@ -146,9 +134,7 @@ sub vcl_fetch {
     # Keep stale for origin
     set beresp.grace = 24h;
   }
-  # << custom
 
-  # >> not reproduced by macro
   if(req.restarts > 0 ) {
     set beresp.http.Fastly-Restarts = req.restarts;
   }
@@ -162,13 +148,9 @@ sub vcl_fetch {
     return (pass);
   }
 
-  # << not reproduced by macro
-  # >> custom
   if (beresp.http.Cache-Control ~ "no-(store|cache)") {
     return (pass);
   }
-  # << custom
-  # >> not reproduced by macro
 
   if (beresp.status >= 500 && beresp.status <= 599) {
     set req.http.Fastly-Cachetype = "ERROR";
@@ -183,14 +165,11 @@ sub vcl_fetch {
     # apply the default ttl
     set beresp.ttl = <%= config['default_ttl'] %>s;
   }
-  # << not reproduced by macro
 
-  # >> custom
   # Override default.vcl behaviour of return(pass).
   if (beresp.http.Set-Cookie) {
     return (deliver);
   }
-  # << custom
 }
 
 sub vcl_hit {
@@ -235,9 +214,7 @@ sub vcl_error {
 #FASTLY error
 }
 
-# <<
 # pipe cannot be included.
-# >>
 
 sub vcl_pass {
 #FASTLY pass

--- a/vcl_templates/performanceplatform_admin.vcl.erb
+++ b/vcl_templates/performanceplatform_admin.vcl.erb
@@ -1,4 +1,3 @@
-# >> custom backends
 backend F_backend_origin {
     .connect_timeout = 5s;
     .dynamic = true;
@@ -46,7 +45,6 @@ backend sick_force_grace {
   }
 }
 
-# << custom backends
 
 acl purge_ip_whitelist {
   "37.26.90.227";     # Platform 1 production
@@ -64,7 +62,6 @@ acl purge_ip_whitelist {
 
 sub vcl_recv {
 
-  # >> custom recv
   # Allow FASTLYPURGE from IPs defined in the ACL only, else return a HTTP 403
   if (req.request == "FASTLYPURGE") {
     if (client.ip ~ purge_ip_whitelist) {
@@ -72,9 +69,7 @@ sub vcl_recv {
     }
     error 403 "Forbidden";
   }
-  # << custom recv
 
-  # >> normally from `request settings` UI
   # Force SSL.
   if (!req.http.Fastly-SSL) {
      error 801 "Force SSL";
@@ -82,9 +77,7 @@ sub vcl_recv {
 
   # Serve from stale for 24 hours if origin is sick
   set req.grace = 24h;
-  # << normally from `request settings` UI
 
-  # >> custom recv
   set req.backend = F_backend_origin;
   set req.http.host = "performanceplatform-admin.<%= config['origin_domain_suffix'] %>";
 
@@ -100,23 +93,19 @@ sub vcl_recv {
   if (!req.http.GOVUK-Request-Id) {
     set req.http.GOVUK-Request-Id = server.identity "-" req.xid;
   }
-  # << custom recv
 
 #FASTLY recv
 
-  # >> not reproduced by macro
   if (req.request != "HEAD" && req.request != "GET" && req.request != "FASTLYPURGE") {
     return(pass);
   }
 
   return(lookup);
-  # << not reproduced by macro
 }
 
 sub vcl_fetch {
 #FASTLY fetch
 
-  # >> custom
   if ((beresp.status >= 500 && beresp.status <= 599) && req.restarts < 3 && (req.request == "GET" || req.request == "HEAD") && !beresp.http.No-Fallback) {
     set beresp.saintmode = 5s;
     return (restart);
@@ -126,9 +115,7 @@ sub vcl_fetch {
     # Keep stale for origin
     set beresp.grace = 24h;
   }
-  # << custom
 
-  # >> not reproduced by macro
   if(req.restarts > 0 ) {
     set beresp.http.Fastly-Restarts = req.restarts;
   }
@@ -142,13 +129,9 @@ sub vcl_fetch {
     return (pass);
   }
 
-  # << not reproduced by macro
-  # >> custom
   if (beresp.http.Cache-Control ~ "no-(store|cache)") {
     return (pass);
   }
-  # << custom
-  # >> not reproduced by macro
 
   if (beresp.status >= 500 && beresp.status <= 599) {
     set req.http.Fastly-Cachetype = "ERROR";
@@ -163,14 +146,11 @@ sub vcl_fetch {
     # apply the default ttl
     set beresp.ttl = <%= config['default_ttl'] %>s;
   }
-  # << not reproduced by macro
 
-  # >> custom
   # Override default.vcl behaviour of return(pass).
   if (beresp.http.Set-Cookie) {
     return (deliver);
   }
-  # << custom
 }
 
 sub vcl_hit {
@@ -224,9 +204,7 @@ sub vcl_error {
 #FASTLY error
 }
 
-# <<
 # pipe cannot be included.
-# >>
 
 sub vcl_pass {
 #FASTLY pass

--- a/vcl_templates/performanceplatform_stagecraft.vcl.erb
+++ b/vcl_templates/performanceplatform_stagecraft.vcl.erb
@@ -1,4 +1,3 @@
-# >> custom backends
 backend F_api_origin {
     .connect_timeout = 5s;
     .dynamic = true;
@@ -46,7 +45,6 @@ backend sick_force_grace {
   }
 }
 
-# << custom backends
 
 acl purge_ip_whitelist {
   "37.26.90.227";     # Platform 1 production
@@ -64,7 +62,6 @@ acl purge_ip_whitelist {
 
 sub vcl_recv {
 
-  # >> custom recv
   # Allow FASTLYPURGE from IPs defined in the ACL only, else return a HTTP 403
   if (req.request == "FASTLYPURGE") {
     if (client.ip ~ purge_ip_whitelist) {
@@ -72,9 +69,7 @@ sub vcl_recv {
     }
     error 403 "Forbidden";
   }
-  # << custom recv
 
-  # >> normally from `request settings` UI
   # Force SSL.
   if (!req.http.Fastly-SSL) {
      error 801 "Force SSL";
@@ -82,9 +77,7 @@ sub vcl_recv {
 
   # Serve from stale for 24 hours if origin is sick
   set req.grace = 24h;
-  # << normally from `request settings` UI
 
-  # >> custom recv
 	set req.backend = F_api_origin;
 	set req.http.host = "stagecraft.<%= config['origin_domain_suffix'] %>";
 
@@ -100,23 +93,19 @@ sub vcl_recv {
   if (!req.http.GOVUK-Request-Id) {
     set req.http.GOVUK-Request-Id = server.identity "-" req.xid;
   }
-  # << custom recv
 
 #FASTLY recv
 
-  # >> not reproduced by macro
   if (req.request != "HEAD" && req.request != "GET" && req.request != "FASTLYPURGE") {
     return(pass);
   }
 
   return(lookup);
-  # << not reproduced by macro
 }
 
 sub vcl_fetch {
 #FASTLY fetch
 
-  # >> custom
   if ((beresp.status >= 500 && beresp.status <= 599) && req.restarts < 3 && (req.request == "GET" || req.request == "HEAD") && !beresp.http.No-Fallback) {
     set beresp.saintmode = 5s;
     return (restart);
@@ -126,9 +115,7 @@ sub vcl_fetch {
     # Keep stale for origin
     set beresp.grace = 24h;
   }
-  # << custom
 
-  # >> not reproduced by macro
   if(req.restarts > 0 ) {
     set beresp.http.Fastly-Restarts = req.restarts;
   }
@@ -142,13 +129,9 @@ sub vcl_fetch {
     return (pass);
   }
 
-  # << not reproduced by macro
-  # >> custom
   if (beresp.http.Cache-Control ~ "no-(store|cache)") {
     return (pass);
   }
-  # << custom
-  # >> not reproduced by macro
 
   if (beresp.status >= 500 && beresp.status <= 599) {
     set req.http.Fastly-Cachetype = "ERROR";
@@ -163,14 +146,11 @@ sub vcl_fetch {
     # apply the default ttl
     set beresp.ttl = <%= config['default_ttl'] %>s;
   }
-  # << not reproduced by macro
 
-  # >> custom
   # Override default.vcl behaviour of return(pass).
   if (beresp.http.Set-Cookie) {
     return (deliver);
   }
-  # << custom
 }
 
 sub vcl_hit {
@@ -224,9 +204,7 @@ sub vcl_error {
 #FASTLY error
 }
 
-# <<
 # pipe cannot be included.
-# >>
 
 sub vcl_pass {
 #FASTLY pass

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -1,4 +1,3 @@
-# >> custom backends
 backend F_origin {
     .connect_timeout = 5s;
     .dynamic = true;
@@ -114,7 +113,6 @@ backend sick_force_grace {
   }
 }
 
-# << custom backends
 
 acl purge_ip_whitelist {
   "37.26.90.227";     # Platform 1 production
@@ -137,7 +135,6 @@ acl purge_ip_whitelist {
 
 sub vcl_recv {
 
-  # >> custom recv
   # Allow FASTLYPURGE from IPs defined in the ACL only, else return a HTTP 403
   if (req.request == "FASTLYPURGE") {
     if (client.ip ~ purge_ip_whitelist) {
@@ -150,9 +147,7 @@ sub vcl_recv {
   if (table.lookup(ip_address_blacklist, client.ip)) {
     error 403 "Forbidden";
   }
-  # << custom recv
 
-  # >> normally from `request settings` UI
   # Force SSL.
   if (!req.http.Fastly-SSL) {
      error 801 "Force SSL";
@@ -160,9 +155,7 @@ sub vcl_recv {
 
   # Serve from stale for 24 hours if origin is sick
   set req.grace = 24h;
-  # << normally from `request settings` UI
 
-  # >> custom recv
   # Default backend.
   set req.backend = F_origin;
   set req.http.Fastly-Backend-Name = "origin";
@@ -193,23 +186,19 @@ sub vcl_recv {
 
   # Unspoofable original client address.
   set req.http.True-Client-IP = req.http.Fastly-Client-IP;
-  # << custom recv
 
 #FASTLY recv
 
-  # >> not reproduced by macro
   if (req.request != "HEAD" && req.request != "GET" && req.request != "FASTLYPURGE") {
     return(pass);
   }
 
   return(lookup);
-  # << not reproduced by macro
 }
 
 sub vcl_fetch {
 #FASTLY fetch
 
-  # >> custom
   set beresp.http.Fastly-Backend-Name = req.http.Fastly-Backend-Name;
 
   if ((beresp.status >= 500 && beresp.status <= 599) && req.restarts < 3 && (req.request == "GET" || req.request == "HEAD") && !beresp.http.No-Fallback) {
@@ -221,9 +210,7 @@ sub vcl_fetch {
     # Keep stale for origin
     set beresp.grace = 24h;
   }
-  # << custom
 
-  # >> not reproduced by macro
   if(req.restarts > 0 ) {
     set beresp.http.Fastly-Restarts = req.restarts;
   }
@@ -237,13 +224,9 @@ sub vcl_fetch {
     return (pass);
   }
 
-  # << not reproduced by macro
-  # >> custom
   if (beresp.http.Cache-Control ~ "no-(store|cache)") {
     return (pass);
   }
-  # << custom
-  # >> not reproduced by macro
 
   if (beresp.status >= 500 && beresp.status <= 599) {
     set req.http.Fastly-Cachetype = "ERROR";
@@ -258,14 +241,11 @@ sub vcl_fetch {
     # apply the default ttl
     set beresp.ttl = <%= config['default_ttl'] %>s;
   }
-  # << not reproduced by macro
 
-  # >> custom
   # Override default.vcl behaviour of return(pass).
   if (beresp.http.Set-Cookie) {
     return (deliver);
   }
-  # << custom
 }
 
 sub vcl_hit {
@@ -321,9 +301,7 @@ sub vcl_error {
 #FASTLY error
 }
 
-# <<
 # pipe cannot be included.
-# >>
 
 sub vcl_pass {
 #FASTLY pass


### PR DESCRIPTION
These were introduced in 255a629 and 03cb1fc5 to help demarcate our
customisations from Fastly's default VCL configuration. I think they may
also appear in Fastly's default VCL configuration.

While I agree with the original reasons for adding these, in practice
these markers have moved around and I think they're no longer
accurate, i.e. they're misleading. I also think they hamper readability
to a small extent.