### PR TITLE
Make our VCL configuration more consistent

### DIFF
--- a/vcl_templates/apt.vcl.erb
+++ b/vcl_templates/apt.vcl.erb
@@ -3,16 +3,16 @@ backend F_apt {
     .connect_timeout = 1s;
     .dynamic = true;
     .port = "<%= config.fetch('apt_port', 80) %>";
-    .host = "<%= config['apt_hostname'] %>";
+    .host = "<%= config.fetch('apt_hostname') %>";
     .first_byte_timeout = 15s;
     .max_connections = 200;
     .between_bytes_timeout = 10s;
-    .share_key = "<%= config['service_id'] %>";
+    .share_key = "<%= config.fetch('service_id') %>";
 
     .probe = {
         .request =
           "HEAD / HTTP/1.1"
-          "Host: <%= config['apt_hostname'] %>"
+          "Host: <%= config.fetch('apt_hostname') %>"
           "Connection: close";
         .window = 5;
         .threshold = 1;

--- a/vcl_templates/assets.vcl.erb
+++ b/vcl_templates/assets.vcl.erb
@@ -32,7 +32,7 @@ backend F_origin {
         .timeout = 5s;
         .initial = 1;
         .expected_response = 200;
-        .interval = 60s;
+        .interval = 10s;
       }
 }
 # Mirror backend for provider 0

--- a/vcl_templates/assets.vcl.erb
+++ b/vcl_templates/assets.vcl.erb
@@ -15,13 +15,13 @@ backend F_origin {
     <%- if config['ssl_ciphers'] -%>
     .ssl_ciphers = "<%= config['ssl_ciphers'] -%>";
     <%- end -%>
-    .ssl_cert_hostname = "<%= config.fetch('ssl_cert_hostname', config['origin_hostname']) %>";
-    .ssl_sni_hostname = "<%= config.fetch('ssl_sni_hostname', config['origin_hostname']) %>";
+    .ssl_cert_hostname = "<%= config.fetch('ssl_cert_hostname', config.fetch('origin_hostname')) %>";
+    .ssl_sni_hostname = "<%= config.fetch('ssl_sni_hostname', config.fetch('origin_hostname')) %>";
 
     .probe = {
         .request =
             "HEAD /__canary__ HTTP/1.1"
-            "Host: <%= environment == 'staging' ? 'assets.digital.cabinet-office.gov.uk' : config['origin_hostname'] %>"
+            "Host: <%= environment == 'staging' ? 'assets.digital.cabinet-office.gov.uk' : config.fetch('origin_hostname') %>"
             "User-Agent: Fastly healthcheck (git version: <%= config['git_version'] %>)"
 <% if config['rate_limit_token'] %>
             "Rate-Limit-Token: <%= config['rate_limit_token'] %>"
@@ -40,11 +40,11 @@ backend F_mirror0 {
     .connect_timeout = 1s;
     .dynamic = true;
     .port = "<%= config.fetch('provider0_mirror_port', 443) %>";
-    .host = "<%= config['provider0_mirror_hostname'] %>";
+    .host = "<%= config.fetch('provider0_mirror_hostname') %>";
     .first_byte_timeout = 15s;
     .max_connections = 200;
     .between_bytes_timeout = 10s;
-    .share_key = "<%= config['service_id'] %>";
+    .share_key = "<%= config.fetch('service_id') %>";
 
     .ssl = true;
     .ssl_check_cert = <%= config['disable_tls_validation'] ? 'never' : 'always' %>;
@@ -52,13 +52,13 @@ backend F_mirror0 {
     <%- if config['ssl_ciphers'] -%>
     .ssl_ciphers = "<%= config['ssl_ciphers'] -%>";
     <%- end -%>
-    .ssl_cert_hostname = "<%= config.fetch('ssl_cert_hostname', config['provider0_mirror_hostname']) %>";
-    .ssl_sni_hostname = "<%= config.fetch('ssl_sni_hostname', config['provider0_mirror_hostname']) %>";
+    .ssl_cert_hostname = "<%= config.fetch('ssl_cert_hostname', config.fetch('provider0_mirror_hostname')) %>";
+    .ssl_sni_hostname = "<%= config.fetch('ssl_sni_hostname', config.fetch('provider0_mirror_hostname')) %>";
 
     .probe = {
         .request =
             "HEAD /__canary__ HTTP/1.1"
-            "Host: <%= config['provider0_mirror_hostname'] %>"
+            "Host: <%= config.fetch('provider0_mirror_hostname') %>"
             "User-Agent: Fastly healthcheck (git version: <%= config['git_version'] %>)"
             "Connection: close";
         .threshold = 1;
@@ -74,11 +74,11 @@ backend F_mirror1 {
     .connect_timeout = 1s;
     .dynamic = true;
     .port = "<%= config.fetch('provider1_mirror_port', 443) %>";
-    .host = "<%= config['provider1_mirror_hostname'] %>";
+    .host = "<%= config.fetch('provider1_mirror_hostname') %>";
     .first_byte_timeout = 15s;
     .max_connections = 200;
     .between_bytes_timeout = 10s;
-    .share_key = "<%= config['service_id'] %>";
+    .share_key = "<%= config.fetch('service_id') %>";
 
     .ssl = true;
     .ssl_check_cert = <%= config['disable_tls_validation'] ? 'never' : 'always' %>;
@@ -86,13 +86,13 @@ backend F_mirror1 {
     <%- if config['ssl_ciphers'] -%>
     .ssl_ciphers = "<%= config['ssl_ciphers'] -%>";
     <%- end -%>
-    .ssl_cert_hostname = "<%= config.fetch('ssl_cert_hostname', config['provider1_mirror_hostname']) %>";
-    .ssl_sni_hostname = "<%= config.fetch('ssl_sni_hostname', config['provider1_mirror_hostname']) %>";
+    .ssl_cert_hostname = "<%= config.fetch('ssl_cert_hostname', config.fetch('provider1_mirror_hostname')) %>";
+    .ssl_sni_hostname = "<%= config.fetch('ssl_sni_hostname', config.fetch('provider1_mirror_hostname')) %>";
 
     .probe = {
         .request =
             "HEAD /__canary__ HTTP/1.1"
-            "Host: <%= config['provider1_mirror_hostname'] %>"
+            "Host: <%= config.fetch('provider1_mirror_hostname') %>"
             "User-Agent: Fastly healthcheck (git version: <%= config['git_version'] %>)"
             "Connection: close";
         .threshold = 1;
@@ -177,13 +177,13 @@ sub vcl_recv {
     set req.http.Fastly-Failover = "1";
 
     set req.backend = F_mirror0;
-    set req.http.host = "<%= config['provider0_mirror_hostname'] %>";
+    set req.http.host = "<%= config.fetch('provider0_mirror_hostname') %>";
   }
 
   # FIXME: Prefer a fallback director if we move to Varnish 3
   if (req.restarts > 2) {
     set req.backend = F_mirror1;
-    set req.http.host = "<%= config['provider1_mirror_hostname'] %>";
+    set req.http.host = "<%= config.fetch('provider1_mirror_hostname') %>";
   }
 
   # Unspoofable original client address.
@@ -249,7 +249,7 @@ sub vcl_fetch {
     # keep the ttl here
   } else {
     # apply the default ttl
-    set beresp.ttl = <%= config['default_ttl'] %>s;
+    set beresp.ttl = <%= config.fetch('default_ttl') %>s;
   }
   # << not reproduced by macro
 

--- a/vcl_templates/performanceplatform.vcl.erb
+++ b/vcl_templates/performanceplatform.vcl.erb
@@ -4,9 +4,9 @@ backend F_origin {
     .dynamic = true;
     .port = "<%= config.fetch('origin_port', 443) %>";
     .host = "<%= config['origin_hostname'] %>";
-    .first_byte_timeout = 120s;
+    .first_byte_timeout = 15s;
     .max_connections = 200;
-    .between_bytes_timeout = 120s;
+    .between_bytes_timeout = 10s;
     .share_key = "<%= config['service_id'] %>";
 
     .ssl = true;

--- a/vcl_templates/performanceplatform.vcl.erb
+++ b/vcl_templates/performanceplatform.vcl.erb
@@ -3,11 +3,11 @@ backend F_origin {
     .connect_timeout = 5s;
     .dynamic = true;
     .port = "<%= config.fetch('origin_port', 443) %>";
-    .host = "<%= config['origin_hostname'] %>";
+    .host = "<%= config.fetch('origin_hostname') %>";
     .first_byte_timeout = 15s;
     .max_connections = 200;
     .between_bytes_timeout = 10s;
-    .share_key = "<%= config['service_id'] %>";
+    .share_key = "<%= config.fetch('service_id') %>";
 
     .ssl = true;
     .ssl_check_cert = <%= config['disable_tls_validation'] ? 'never' : 'always' %>;
@@ -15,13 +15,13 @@ backend F_origin {
     <%- if config['ssl_ciphers'] -%>
     .ssl_ciphers = "<%= config['ssl_ciphers'] -%>";
     <%- end -%>
-    .ssl_cert_hostname = "<%= config.fetch('ssl_cert_hostname', config['origin_hostname']) %>";
-    .ssl_sni_hostname = "<%= config.fetch('ssl_sni_hostname', config['origin_hostname']) %>";
+    .ssl_cert_hostname = "<%= config.fetch('ssl_cert_hostname', config.fetch('origin_hostname')) %>";
+    .ssl_sni_hostname = "<%= config.fetch('ssl_sni_hostname', config.fetch('origin_hostname')) %>";
 
     .probe = {
         .request =
             "HEAD / HTTP/1.1"
-            "Host: <%= config['origin_hostname'] %>"
+            "Host: <%= config.fetch('origin_hostname') %>"
             "User-Agent: Fastly healthcheck (git version: <%= config['git_version'] %>)"
 <% if config['rate_limit_token'] %>
             "Rate-Limit-Token: <%= config['rate_limit_token'] %>"
@@ -101,9 +101,9 @@ sub vcl_recv {
 
   # Route request to application depending on HTTP method used
   if (req.request ~ "^(PUT|POST|DELETE)$") {
-    set req.http.Host = "backdrop-write.<%= config['domain_suffix'] %>";
+    set req.http.Host = "backdrop-write.<%= config.fetch('domain_suffix') %>";
   } else if (req.request ~ "^(GET|HEAD|OPTIONS)$") {
-    set req.http.Host = "backdrop-read.<%= config['domain_suffix'] %>";
+    set req.http.Host = "backdrop-read.<%= config.fetch('domain_suffix') %>";
   } else {
     error 405 "Method not allowed";
   }
@@ -181,7 +181,7 @@ sub vcl_fetch {
     # keep the ttl here
   } else {
     # apply the default ttl
-    set beresp.ttl = <%= config['default_ttl'] %>s;
+    set beresp.ttl = <%= config.fetch('default_ttl') %>s;
   }
   # << not reproduced by macro
 

--- a/vcl_templates/performanceplatform_admin.vcl.erb
+++ b/vcl_templates/performanceplatform_admin.vcl.erb
@@ -3,11 +3,11 @@ backend F_backend_origin {
     .connect_timeout = 5s;
     .dynamic = true;
     .port = "<%= config.fetch('origin_port', 443) %>";
-    .host = "backend.<%= config['origin_domain_suffix'] %>";
+    .host = "backend.<%= config.fetch('origin_domain_suffix') %>";
     .first_byte_timeout = 15s;
     .max_connections = 200;
     .between_bytes_timeout = 10s;
-    .share_key = "<%= config['service_id'] %>";
+    .share_key = "<%= config.fetch('service_id') %>";
 
     .ssl = true;
     .ssl_check_cert = <%= config['disable_tls_validation'] ? 'never' : 'always' %>;
@@ -15,13 +15,13 @@ backend F_backend_origin {
     <%- if config['ssl_ciphers'] -%>
     .ssl_ciphers = "<%= config['ssl_ciphers'] -%>";
     <%- end -%>
-    .ssl_cert_hostname = "<%= config.fetch('ssl_cert_hostname', "backend.#{config['origin_domain_suffix']}") %>";
-    .ssl_sni_hostname = "<%= config.fetch('ssl_sni_hostname', "backend.#{config['origin_domain_suffix']}") %>";
+    .ssl_cert_hostname = "<%= config.fetch('ssl_cert_hostname', "backend.#{config.fetch('origin_domain_suffix')}") %>";
+    .ssl_sni_hostname = "<%= config.fetch('ssl_sni_hostname', "backend.#{config.fetch('origin_domain_suffix')}") %>";
 
     .probe = {
         .request =
             "HEAD /_status HTTP/1.1"
-            "Host: performanceplatform-admin.<%= config['origin_domain_suffix'] %>"
+            "Host: performanceplatform-admin.<%= config.fetch('origin_domain_suffix') %>"
             "User-Agent: Fastly healthcheck (git version: <%= config['git_version'] %>)"
 <% if config['rate_limit_token'] %>
             "Rate-Limit-Token: <%= config['rate_limit_token'] %>"
@@ -86,7 +86,7 @@ sub vcl_recv {
 
   # >> custom recv
   set req.backend = F_backend_origin;
-  set req.http.host = "performanceplatform-admin.<%= config['origin_domain_suffix'] %>";
+  set req.http.host = "performanceplatform-admin.<%= config.fetch('origin_domain_suffix') %>";
 
   # Serve stale if it exists.
   if (req.restarts > 0) {
@@ -161,7 +161,7 @@ sub vcl_fetch {
     # keep the ttl here
   } else {
     # apply the default ttl
-    set beresp.ttl = <%= config['default_ttl'] %>s;
+    set beresp.ttl = <%= config.fetch('default_ttl') %>s;
   }
   # << not reproduced by macro
 

--- a/vcl_templates/performanceplatform_admin.vcl.erb
+++ b/vcl_templates/performanceplatform_admin.vcl.erb
@@ -4,9 +4,9 @@ backend F_backend_origin {
     .dynamic = true;
     .port = "<%= config.fetch('origin_port', 443) %>";
     .host = "backend.<%= config['origin_domain_suffix'] %>";
-    .first_byte_timeout = 120s;
+    .first_byte_timeout = 15s;
     .max_connections = 200;
-    .between_bytes_timeout = 120s;
+    .between_bytes_timeout = 10s;
     .share_key = "<%= config['service_id'] %>";
 
     .ssl = true;

--- a/vcl_templates/performanceplatform_stagecraft.vcl.erb
+++ b/vcl_templates/performanceplatform_stagecraft.vcl.erb
@@ -4,9 +4,9 @@ backend F_api_origin {
     .dynamic = true;
     .port = "<%= config.fetch('origin_port', 443) %>";
     .host = "api.<%= config['origin_domain_suffix'] %>";
-    .first_byte_timeout = 120s;
+    .first_byte_timeout = 15s;
     .max_connections = 200;
-    .between_bytes_timeout = 120s;
+    .between_bytes_timeout = 10s;
     .share_key = "<%= config['service_id'] %>";
 
     .ssl = true;

--- a/vcl_templates/performanceplatform_stagecraft.vcl.erb
+++ b/vcl_templates/performanceplatform_stagecraft.vcl.erb
@@ -3,11 +3,11 @@ backend F_api_origin {
     .connect_timeout = 5s;
     .dynamic = true;
     .port = "<%= config.fetch('origin_port', 443) %>";
-    .host = "api.<%= config['origin_domain_suffix'] %>";
+    .host = "api.<%= config.fetch('origin_domain_suffix') %>";
     .first_byte_timeout = 15s;
     .max_connections = 200;
     .between_bytes_timeout = 10s;
-    .share_key = "<%= config['service_id'] %>";
+    .share_key = "<%= config.fetch('service_id') %>";
 
     .ssl = true;
     .ssl_check_cert = <%= config['disable_tls_validation'] ? 'never' : 'always' %>;
@@ -21,7 +21,7 @@ backend F_api_origin {
     .probe = {
         .request =
             "HEAD /_status HTTP/1.1"
-            "Host: stagecraft.<%= config['origin_domain_suffix'] %>"
+            "Host: stagecraft.<%= config.fetch('origin_domain_suffix') %>"
             "User-Agent: Fastly healthcheck (git version: <%= config['git_version'] %>)"
 <% if config['rate_limit_token'] %>
             "Rate-Limit-Token: <%= config['rate_limit_token'] %>"
@@ -86,7 +86,7 @@ sub vcl_recv {
 
   # >> custom recv
 	set req.backend = F_api_origin;
-	set req.http.host = "stagecraft.<%= config['origin_domain_suffix'] %>";
+	set req.http.host = "stagecraft.<%= config.fetch('origin_domain_suffix') %>";
 
   # Serve stale if it exists.
   if (req.restarts > 0) {
@@ -161,7 +161,7 @@ sub vcl_fetch {
     # keep the ttl here
   } else {
     # apply the default ttl
-    set beresp.ttl = <%= config['default_ttl'] %>s;
+    set beresp.ttl = <%= config.fetch('default_ttl') %>s;
   }
   # << not reproduced by macro
 

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -3,11 +3,11 @@ backend F_origin {
     .connect_timeout = 5s;
     .dynamic = true;
     .port = "<%= config.fetch('origin_port', 443) %>";
-    .host = "<%= config['origin_hostname'] %>";
+    .host = "<%= config.fetch('origin_hostname') %>";
     .first_byte_timeout = 15s;
     .max_connections = 200;
     .between_bytes_timeout = 10s;
-    .share_key = "<%= config['service_id'] %>";
+    .share_key = "<%= config.fetch('service_id') %>";
 
     .ssl = true;
     .ssl_check_cert = <%= config['disable_tls_validation'] ? 'never' : 'always' %>;
@@ -15,13 +15,13 @@ backend F_origin {
     <%- if config['ssl_ciphers'] -%>
     .ssl_ciphers = "<%= config['ssl_ciphers'] -%>";
     <%- end -%>
-    .ssl_cert_hostname = "<%= config.fetch('ssl_cert_hostname', config['origin_hostname']) %>";
-    .ssl_sni_hostname = "<%= config.fetch('ssl_sni_hostname', config['origin_hostname']) %>";
+    .ssl_cert_hostname = "<%= config.fetch('ssl_cert_hostname', config.fetch('origin_hostname')) %>";
+    .ssl_sni_hostname = "<%= config.fetch('ssl_sni_hostname', config.fetch('origin_hostname')) %>";
 
     .probe = {
         .request =
             "HEAD / HTTP/1.1"
-            "Host: <%= config['origin_hostname'] %>"
+            "Host: <%= config.fetch('origin_hostname') %>"
             "User-Agent: Fastly healthcheck (git version: <%= config['git_version'] %>)"
 <% if config['rate_limit_token'] %>
             "Rate-Limit-Token: <%= config['rate_limit_token'] %>"
@@ -40,11 +40,11 @@ backend F_mirror0 {
     .connect_timeout = 1s;
     .dynamic = true;
     .port = "<%= config.fetch('provider0_mirror_port', 443) %>";
-    .host = "<%= config['provider0_mirror_hostname'] %>";
+    .host = "<%= config.fetch('provider0_mirror_hostname') %>";
     .first_byte_timeout = 15s;
     .max_connections = 200;
     .between_bytes_timeout = 10s;
-    .share_key = "<%= config['service_id'] %>";
+    .share_key = "<%= config.fetch('service_id') %>";
 
     .ssl = true;
     .ssl_check_cert = <%= config['disable_tls_validation'] ? 'never' : 'always' %>;
@@ -52,13 +52,13 @@ backend F_mirror0 {
     <%- if config['ssl_ciphers'] -%>
     .ssl_ciphers = "<%= config['ssl_ciphers'] -%>";
     <%- end -%>
-    .ssl_cert_hostname = "<%= config.fetch('ssl_cert_hostname', config['provider0_mirror_hostname']) %>";
-    .ssl_sni_hostname = "<%= config.fetch('ssl_sni_hostname', config['provider0_mirror_hostname']) %>";
+    .ssl_cert_hostname = "<%= config.fetch('ssl_cert_hostname', config.fetch('provider0_mirror_hostname')) %>";
+    .ssl_sni_hostname = "<%= config.fetch('ssl_sni_hostname', config.fetch('provider0_mirror_hostname')) %>";
 
     .probe = {
         .request =
             "HEAD / HTTP/1.1"
-            "Host: <%= config['provider0_mirror_hostname'] %>"
+            "Host: <%= config.fetch('provider0_mirror_hostname') %>"
             "User-Agent: Fastly healthcheck (git version: <%= config['git_version'] %>)"
             "Connection: close";
         .threshold = 1;
@@ -74,11 +74,11 @@ backend F_mirror1 {
     .connect_timeout = 1s;
     .dynamic = true;
     .port = "<%= config.fetch('provider1_mirror_port', 443) %>";
-    .host = "<%= config['provider1_mirror_hostname'] %>";
+    .host = "<%= config.fetch('provider1_mirror_hostname') %>";
     .first_byte_timeout = 15s;
     .max_connections = 200;
     .between_bytes_timeout = 10s;
-    .share_key = "<%= config['service_id'] %>";
+    .share_key = "<%= config.fetch('service_id') %>";
 
     .ssl = true;
     .ssl_check_cert = <%= config['disable_tls_validation'] ? 'never' : 'always' %>;
@@ -86,13 +86,13 @@ backend F_mirror1 {
     <%- if config['ssl_ciphers'] -%>
     .ssl_ciphers = "<%= config['ssl_ciphers'] -%>";
     <%- end -%>
-    .ssl_cert_hostname = "<%= config.fetch('ssl_cert_hostname', config['provider1_mirror_hostname']) %>";
-    .ssl_sni_hostname = "<%= config.fetch('ssl_sni_hostname', config['provider1_mirror_hostname']) %>";
+    .ssl_cert_hostname = "<%= config.fetch('ssl_cert_hostname', config.fetch('provider1_mirror_hostname')) %>";
+    .ssl_sni_hostname = "<%= config.fetch('ssl_sni_hostname', config.fetch('provider1_mirror_hostname')) %>";
 
     .probe = {
         .request =
             "HEAD / HTTP/1.1"
-            "Host: <%= config['provider1_mirror_hostname'] %>"
+            "Host: <%= config.fetch('provider1_mirror_hostname') %>"
             "User-Agent: Fastly healthcheck (git version: <%= config['git_version'] %>)"
             "Connection: close";
         .threshold = 1;
@@ -180,14 +180,14 @@ sub vcl_recv {
     set req.http.Fastly-Failover = "1";
 
     set req.backend = F_mirror0;
-    set req.http.host = "<%= config['provider0_mirror_hostname'] %>";
+    set req.http.host = "<%= config.fetch('provider0_mirror_hostname') %>";
     set req.http.Fastly-Backend-Name = "mirror0";
   }
 
   # FIXME: Prefer a fallback director if we move to Varnish 3
   if (req.restarts > 2) {
     set req.backend = F_mirror1;
-    set req.http.host = "<%= config['provider1_mirror_hostname'] %>";
+    set req.http.host = "<%= config.fetch('provider1_mirror_hostname') %>";
     set req.http.Fastly-Backend-Name = "mirror1";
   }
 
@@ -256,7 +256,7 @@ sub vcl_fetch {
     # keep the ttl here
   } else {
     # apply the default ttl
-    set beresp.ttl = <%= config['default_ttl'] %>s;
+    set beresp.ttl = <%= config.fetch('default_ttl') %>s;
   }
   # << not reproduced by macro
 

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -4,9 +4,9 @@ backend F_origin {
     .dynamic = true;
     .port = "<%= config.fetch('origin_port', 443) %>";
     .host = "<%= config['origin_hostname'] %>";
-    .first_byte_timeout = 120s;
+    .first_byte_timeout = 15s;
     .max_connections = 200;
-    .between_bytes_timeout = 120s;
+    .between_bytes_timeout = 10s;
     .share_key = "<%= config['service_id'] %>";
 
     .ssl = true;


### PR DESCRIPTION
Our timeouts when connecting to the origin are different in our `www`,
`assets` and `performanceplatform*` services.

Make them consistent, using these values:

    first_byte_timeout = 15s
    between_bytes_timeout = 10s

These seem more appropriate than the previous values of 120s, used for
for both timeouts, in the `www` service:

- 15 seconds is long enough to make a user wait (referring to the first
  byte timeout); in that case it's probably best to failover to the
  mirror

- Nginx, which we use at origin, already buffers proxied requests from
  upstreams, so it's unlikely that more than 10 seconds would pass
  between bytes for reasons other than networking:
  http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_request_buffering

Also set the probe interval to 10 seconds, which seems more sensible
than the previous interval of 60 seconds used by the `assets` service.
This should allow us to detect when origin is unhealthy more quickly.
We did the same for the `www` service in 574e48b.

* * *

Also, make the `host` and `share_key` parameters mandatory in the assets service.