### PR TITLE
Pre-empt request changes in vcl_recv before purge

### DIFF
--- a/vcl_templates/assets.vcl.erb
+++ b/vcl_templates/assets.vcl.erb
@@ -141,11 +141,9 @@ acl purge_ip_whitelist {
 sub vcl_recv {
 
   # Allow FASTLYPURGE from IPs defined in the ACL only, else return a HTTP 403
-  if (req.request == "FASTLYPURGE") {
-    if (client.ip ~ purge_ip_whitelist) {
-      return (lookup);
-    }
-    error 403 "Forbidden";
+  if (req.request == "FASTLYPURGE"
+    && !(client.ip ~ purge_ip_whitelist)) {
+      error 403 "Forbidden";
   }
 
   # Force SSL.

--- a/vcl_templates/bouncer.vcl.erb
+++ b/vcl_templates/bouncer.vcl.erb
@@ -57,14 +57,10 @@ acl purge_ip_whitelist {
 sub vcl_recv {
 
   # Allow FASTLYPURGE from IPs defined in the ACL only, else return a HTTP 403
-  if (req.request == "FASTLYPURGE") {
-    if (client.ip ~ purge_ip_whitelist) {
-      return (lookup);
-    }
-    error 403 "Forbidden";
+  if (req.request == "FASTLYPURGE"
+    && !(client.ip ~ purge_ip_whitelist)) {
+      error 403 "Forbidden";
   }
-
-
 
   # Append to XFF. Unsure about this restart condition?
   if (!req.http.Fastly-FF) {

--- a/vcl_templates/performanceplatform.vcl.erb
+++ b/vcl_templates/performanceplatform.vcl.erb
@@ -67,11 +67,9 @@ acl purge_ip_whitelist {
 sub vcl_recv {
 
   # Allow FASTLYPURGE from IPs defined in the ACL only, else return a HTTP 403
-  if (req.request == "FASTLYPURGE") {
-    if (client.ip ~ purge_ip_whitelist) {
-      return (lookup);
-    }
-    error 403 "Forbidden";
+  if (req.request == "FASTLYPURGE"
+    && !(client.ip ~ purge_ip_whitelist)) {
+      error 403 "Forbidden";
   }
 
   # Force SSL.

--- a/vcl_templates/performanceplatform_admin.vcl.erb
+++ b/vcl_templates/performanceplatform_admin.vcl.erb
@@ -68,11 +68,9 @@ acl purge_ip_whitelist {
 sub vcl_recv {
 
   # Allow FASTLYPURGE from IPs defined in the ACL only, else return a HTTP 403
-  if (req.request == "FASTLYPURGE") {
-    if (client.ip ~ purge_ip_whitelist) {
-      return (lookup);
-    }
-    error 403 "Forbidden";
+  if (req.request == "FASTLYPURGE"
+    && !(client.ip ~ purge_ip_whitelist)) {
+      error 403 "Forbidden";
   }
 
   # Force SSL.

--- a/vcl_templates/performanceplatform_stagecraft.vcl.erb
+++ b/vcl_templates/performanceplatform_stagecraft.vcl.erb
@@ -68,11 +68,9 @@ acl purge_ip_whitelist {
 sub vcl_recv {
 
   # Allow FASTLYPURGE from IPs defined in the ACL only, else return a HTTP 403
-  if (req.request == "FASTLYPURGE") {
-    if (client.ip ~ purge_ip_whitelist) {
-      return (lookup);
-    }
-    error 403 "Forbidden";
+  if (req.request == "FASTLYPURGE"
+    && !(client.ip ~ purge_ip_whitelist)) {
+      error 403 "Forbidden";
   }
 
   # Force SSL.

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -141,11 +141,9 @@ acl purge_ip_whitelist {
 sub vcl_recv {
 
   # Allow FASTLYPURGE from IPs defined in the ACL only, else return a HTTP 403
-  if (req.request == "FASTLYPURGE") {
-    if (client.ip ~ purge_ip_whitelist) {
-      return (lookup);
-    }
-    error 403 "Forbidden";
+  if (req.request == "FASTLYPURGE"
+    && !(client.ip ~ purge_ip_whitelist)) {
+      error 403 "Forbidden";
   }
 
   # Check whether the remote IP address is in the list of blocked IPs


### PR DESCRIPTION
The previous logic for accepting a purge only from a predefined whitelist of
IP addresses was potentially flawed in that vcl_recv might further modify an
acceptable FASTLYPURGE request before it is performed at the edge, yet the
current logic would return a lookup immediately after this logic had
applied. This meant that if the request was ever changed in vcl_recv, it
would be returned instantly rather than the remainder of logic in the VCL
being performed.

Fixes this in order to futureproof vcl_recv to some extent, as well as neaten up
the purge conditional in to fewer lines.
