### PR TITLE
Maintain one list of Fastly cache node IPs

### DIFF
--- a/vcl_templates/assets.vcl.erb
+++ b/vcl_templates/assets.vcl.erb
@@ -1,3 +1,5 @@
+include purge_ip_whitelist
+
 backend F_origin {
     .connect_timeout = 5s;
     .dynamic = true;
@@ -111,31 +113,6 @@ backend sick_force_grace {
     .interval = 365d;
     .initial = 0;
   }
-}
-
-
-acl purge_ip_whitelist {
-  "37.26.93.252";     # Skyscape mirrors
-  "31.210.241.100";   # Carrenza mirrors
-<% if environment == 'staging' %>
-  "31.210.245.70";    # Carrenza Staging
-<% elsif environment == 'production' %>
-  "31.210.245.86";    # Carrenza Production
-<% end %>
-  "23.235.32.0"/20;   # Fastly cache node
-  "43.249.72.0"/22;   # Fastly cache node
-  "103.244.50.0"/24;  # Fastly cache node
-  "103.245.222.0"/23; # Fastly cache node
-  "103.245.224.0"/24; # Fastly cache node
-  "104.156.80.0"/20;  # Fastly cache node
-  "151.101.0.0"/16;   # Fastly cache node
-  "157.52.64.0"/18;   # Fastly cache node
-  "172.111.64.0"/18;  # Fastly cache node
-  "185.31.16.0"/22;   # Fastly cache node
-  "199.27.72.0"/21;   # Fastly cache node
-  "199.232.0.0"/16;   # Fastly cache node
-  "202.21.128.0"/24;  # Fastly cache node
-  "203.57.145.0"/24;  # Fastly cache node
 }
 
 sub vcl_recv {

--- a/vcl_templates/performanceplatform.vcl.erb
+++ b/vcl_templates/performanceplatform.vcl.erb
@@ -1,3 +1,5 @@
+include purge_ip_whitelist
+
 backend F_origin {
     .connect_timeout = 5s;
     .dynamic = true;
@@ -42,26 +44,6 @@ backend sick_force_grace {
     .interval = 365d;
     .initial = 0;
   }
-}
-
-
-acl purge_ip_whitelist {
-  "37.26.93.252";     # Skyscape mirrors
-  "31.210.241.100";   # Carrenza mirrors
-  "23.235.32.0"/20;   # Fastly cache node
-  "43.249.72.0"/22;   # Fastly cache node
-  "103.244.50.0"/24;  # Fastly cache node
-  "103.245.222.0"/23; # Fastly cache node
-  "103.245.224.0"/24; # Fastly cache node
-  "104.156.80.0"/20;  # Fastly cache node
-  "151.101.0.0"/16;   # Fastly cache node
-  "157.52.64.0"/18;   # Fastly cache node
-  "172.111.64.0"/18;  # Fastly cache node
-  "185.31.16.0"/22;   # Fastly cache node
-  "199.27.72.0"/21;   # Fastly cache node
-  "199.232.0.0"/16;   # Fastly cache node
-  "202.21.128.0"/24;  # Fastly cache node
-  "203.57.145.0"/24;  # Fastly cache node
 }
 
 sub vcl_recv {

--- a/vcl_templates/performanceplatform_admin.vcl.erb
+++ b/vcl_templates/performanceplatform_admin.vcl.erb
@@ -1,3 +1,5 @@
+include purge_ip_whitelist
+
 backend F_backend_origin {
     .connect_timeout = 5s;
     .dynamic = true;
@@ -43,26 +45,6 @@ backend sick_force_grace {
     .interval = 365d;
     .initial = 0;
   }
-}
-
-
-acl purge_ip_whitelist {
-  "37.26.93.252";     # Skyscape mirrors
-  "31.210.241.100";   # Carrenza mirrors
-  "23.235.32.0"/20;   # Fastly cache node
-  "43.249.72.0"/22;   # Fastly cache node
-  "103.244.50.0"/24;  # Fastly cache node
-  "103.245.222.0"/23; # Fastly cache node
-  "103.245.224.0"/24; # Fastly cache node
-  "104.156.80.0"/20;  # Fastly cache node
-  "151.101.0.0"/16;   # Fastly cache node
-  "157.52.64.0"/18;   # Fastly cache node
-  "172.111.64.0"/18;  # Fastly cache node
-  "185.31.16.0"/22;   # Fastly cache node
-  "199.27.72.0"/21;   # Fastly cache node
-  "199.232.0.0"/16;   # Fastly cache node
-  "202.21.128.0"/24;  # Fastly cache node
-  "203.57.145.0"/24;  # Fastly cache node
 }
 
 sub vcl_recv {

--- a/vcl_templates/performanceplatform_stagecraft.vcl.erb
+++ b/vcl_templates/performanceplatform_stagecraft.vcl.erb
@@ -1,3 +1,5 @@
+include purge_ip_whitelist
+
 backend F_api_origin {
     .connect_timeout = 5s;
     .dynamic = true;
@@ -43,26 +45,6 @@ backend sick_force_grace {
     .interval = 365d;
     .initial = 0;
   }
-}
-
-
-acl purge_ip_whitelist {
-  "37.26.93.252";     # Skyscape mirrors
-  "31.210.241.100";   # Carrenza mirrors
-  "23.235.32.0"/20;   # Fastly cache node
-  "43.249.72.0"/22;   # Fastly cache node
-  "103.244.50.0"/24;  # Fastly cache node
-  "103.245.222.0"/23; # Fastly cache node
-  "103.245.224.0"/24; # Fastly cache node
-  "104.156.80.0"/20;  # Fastly cache node
-  "151.101.0.0"/16;   # Fastly cache node
-  "157.52.64.0"/18;   # Fastly cache node
-  "172.111.64.0"/18;  # Fastly cache node
-  "185.31.16.0"/22;   # Fastly cache node
-  "199.27.72.0"/21;   # Fastly cache node
-  "199.232.0.0"/16;   # Fastly cache node
-  "202.21.128.0"/24;  # Fastly cache node
-  "203.57.145.0"/24;  # Fastly cache node
 }
 
 sub vcl_recv {

--- a/vcl_templates/purge_ip_whitelist.vcl.erb
+++ b/vcl_templates/purge_ip_whitelist.vcl.erb
@@ -1,0 +1,23 @@
+acl purge_ip_whitelist {
+  "37.26.93.252";     # Skyscape mirrors
+  "31.210.241.100";   # Carrenza mirrors
+<% if environment == 'staging' %>
+  "31.210.245.70";    # Carrenza Staging
+<% elsif environment == 'production' %>
+  "31.210.245.86";    # Carrenza Production
+<% end %>
+  "23.235.32.0"/20;   # Fastly cache node
+  "43.249.72.0"/22;   # Fastly cache node
+  "103.244.50.0"/24;  # Fastly cache node
+  "103.245.222.0"/23; # Fastly cache node
+  "103.245.224.0"/24; # Fastly cache node
+  "104.156.80.0"/20;  # Fastly cache node
+  "151.101.0.0"/16;   # Fastly cache node
+  "157.52.64.0"/18;   # Fastly cache node
+  "172.111.64.0"/18;  # Fastly cache node
+  "185.31.16.0"/22;   # Fastly cache node
+  "199.27.72.0"/21;   # Fastly cache node
+  "199.232.0.0"/16;   # Fastly cache node
+  "202.21.128.0"/24;  # Fastly cache node
+  "203.57.145.0"/24;  # Fastly cache node
+}

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -1,3 +1,5 @@
+include purge_ip_whitelist
+
 backend F_origin {
     .connect_timeout = 5s;
     .dynamic = true;
@@ -111,31 +113,6 @@ backend sick_force_grace {
     .interval = 365d;
     .initial = 0;
   }
-}
-
-
-acl purge_ip_whitelist {
-  "37.26.93.252";     # Skyscape mirrors
-  "31.210.241.100";   # Carrenza mirrors
-<% if environment == 'staging' %>
-  "31.210.245.70";    # Carrenza Staging
-<% elsif environment == 'production' %>
-  "31.210.245.86";    # Carrenza Production
-<% end %>
-  "23.235.32.0"/20;   # Fastly cache node
-  "43.249.72.0"/22;   # Fastly cache node
-  "103.244.50.0"/24;  # Fastly cache node
-  "103.245.222.0"/23; # Fastly cache node
-  "103.245.224.0"/24; # Fastly cache node
-  "104.156.80.0"/20;  # Fastly cache node
-  "151.101.0.0"/16;   # Fastly cache node
-  "157.52.64.0"/18;   # Fastly cache node
-  "172.111.64.0"/18;  # Fastly cache node
-  "185.31.16.0"/22;   # Fastly cache node
-  "199.27.72.0"/21;   # Fastly cache node
-  "199.232.0.0"/16;   # Fastly cache node
-  "202.21.128.0"/24;  # Fastly cache node
-  "203.57.145.0"/24;  # Fastly cache node
 }
 
 sub vcl_recv {


### PR DESCRIPTION
Rather than maintain a list of Fastly cache node IP addresses in multiple
VCL files, maintain them in one and drag them in using Varnish includes.

This PR is a bit work-in-progress, because I've nowhere to test these out,
but they should work fine. Some testing your side would be very kind :)
