### PR TITLE
Allow PATCH requests to backdrop-write

### DIFF
--- a/vcl_templates/performanceplatform.vcl.erb
+++ b/vcl_templates/performanceplatform.vcl.erb
@@ -97,7 +97,7 @@ sub vcl_recv {
   set req.http.True-Client-IP = req.http.Fastly-Client-IP;
 
   # Route request to application depending on HTTP method used
-  if (req.request ~ "^(PUT|POST|DELETE)$") {
+  if (req.request ~ "^(PATCH|PUT|POST|DELETE)$") {
     set req.http.Host = "backdrop-write.<%= config.fetch('domain_suffix') %>";
   } else if (req.request ~ "^(GET|HEAD|OPTIONS)$") {
     set req.http.Host = "backdrop-read.<%= config.fetch('domain_suffix') %>";


### PR DESCRIPTION
backdrop-write now offers a PATCH route, allowing attributes in Mongo documents (data set collections) to be updated. This PR configures Fastly to allow PATCH requests to be routed through.