### PR TITLE
Treat any non-200 from a mirror as a 503

### DIFF
--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -233,6 +233,14 @@ sub vcl_fetch {
     return (pass);
   }
 
+  # The only valid status from our mirrors is a 200. They cannot return e.g.
+  # a 301 status code. All errors from the mirrors are set to 503 as they
+  # cannot know whether or not a page actually exists (e.g. /search is a valid
+  # URL but the mirror cannot return it).
+  if (beresp.status != 200 && beresp.http.Fastly-Backend-Name ~ "mirror") {
+    set beresp.status = 503;
+  }
+
   if (beresp.status >= 500 && beresp.status <= 599) {
     set req.http.Fastly-Cachetype = "ERROR";
     set beresp.ttl = 1s;


### PR DESCRIPTION
In order to improve UX responses from the mirror should either return a 200 status code (found) or a 503 (service not available). This is because there are many URLs that the mirrors do not cache that are valid (for example, `/search`). In these cases whilst it is technically correct to return a 404 this is likely to confuse a user who would assume they have mis-typed the URL rather than, as is the case, hit the website during an outage. The user response we would like to encourage in this case is retrying in a little while once the site has returned.

To return 503s for non-200 responses we have changed the varnish configuration for fastly so that any response from a mirror which isn't a 200 has its status code set to 503.