### PR TITLE
Configure A/B testing cookies and headers

### DIFF
--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -198,6 +198,17 @@ sub vcl_recv {
     return(pass);
   }
 
+  if (!req.http.Cookie:ABTest-Example) {
+    if (randombool(5,10)) {
+       set req.http.X-ABTest-Example = "A";
+    } else {
+       set req.http.X-ABTest-Example = "B";
+    }
+  } else {
+    # Set the value of the header to whatever decision was previously made
+    set req.http.X-ABTest-Example = req.http.Cookie:ABTest-Example;
+  }
+
   return(lookup);
 }
 
@@ -262,6 +273,13 @@ sub vcl_miss {
 }
 
 sub vcl_deliver {
+  # Set the A/B cookie
+  if (req.http.Cookie !~ "ABTest-Example") {
+    # Set a fairly short cookie expiry because this is just an A/B test demo.
+    # We should choose a longer expiry for a real A/B test.
+    add resp.http.Set-Cookie = "ABTest-Example=" req.http.X-ABTest-Example "; expires=" now + 1d;
+  }
+
 #FASTLY deliver
 }
 


### PR DESCRIPTION
Add Varnish config specifically for the 'frontend' app, and configure it to set cookies and headers for an A/B test.

The A/B testing approach follows https://www.fastly.com/blog/ab-testing-edge, and uses a mixture of cookies and custom headers:

- Users are placed into A/B buckets in the Varnish config, rather than in the app. This means that a user can visit the site for the first time and be assigned an A/B testing cookie without their request necessarily hitting the app server, because the response comes from the cache and the cookie was added by Varnish
- The cookie is transformed into a custom header in Varnish, and we vary by that header. This means that the CDN and the govuk Varnish just cache two versions of the page - one for each A/B test variant. This avoids varying by cookie, which would cause Varnish to cache a version for each user.

I've split this into two commits to separate the boilerplate from the A/B config changes. The boilerplate is quite extensive, unfortunately - I copied it from the [Fastly docs](https://docs.fastly.com/guides/vcl/mixing-and-matching-fastly-vcl-with-custom-vcl), and it seems consistent with some of the other apps' custom Varnish config.

@carvil, @tijmenb and @alexmuller - could you take a look to see whether you agree with the approach and the implementation?

https://trello.com/c/QyDbSiR9/289-allow-a-b-testing-cookies-to-be-set