### PR TITLE
Fix A/B test issues in Varnish config

### DIFF
--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -198,7 +198,7 @@ sub vcl_recv {
     return(pass);
   }
 
-  if (!req.http.Cookie:ABTest-Example) {
+  if (req.http.Cookie !~ "ABTest-Example") {
     if (randombool(5,10)) {
        set req.http.X-ABTest-Example = "A";
     } else {

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -200,13 +200,13 @@ sub vcl_recv {
 
   if (req.http.Cookie !~ "ABTest-Example") {
     if (randombool(5,10)) {
-       set req.http.X-ABTest-Example = "A";
+       set req.http.GOVUK-ABTest-Example = "A";
     } else {
-       set req.http.X-ABTest-Example = "B";
+       set req.http.GOVUK-ABTest-Example = "B";
     }
   } else {
     # Set the value of the header to whatever decision was previously made
-    set req.http.X-ABTest-Example = req.http.Cookie:ABTest-Example;
+    set req.http.GOVUK-ABTest-Example = req.http.Cookie:ABTest-Example;
   }
 
   return(lookup);
@@ -277,7 +277,7 @@ sub vcl_deliver {
   if (req.http.Cookie !~ "ABTest-Example") {
     # Set a fairly short cookie expiry because this is just an A/B test demo.
     # We should choose a longer expiry for a real A/B test.
-    add resp.http.Set-Cookie = "ABTest-Example=" req.http.X-ABTest-Example "; expires=" now + 1d;
+    add resp.http.Set-Cookie = "ABTest-Example=" req.http.GOVUK-ABTest-Example "; expires=" now + 1d;
   }
 
 #FASTLY deliver


### PR DESCRIPTION
Two commits to address @alexmuller's comments on #13, which I merged too early:

- Make cookie check consistent in `vcl_recv` and `vcl_deliver`
- Rename header because the 'X-' prefix is deprecated, following [RFC 6648|https://tools.ietf.org/html/rfc6648]

https://trello.com/c/QyDbSiR9/289-allow-a-b-testing-cookies-to-be-set

I'll rename the header in alphagov/frontend#1099 as well.