### PR TITLE
Only set the A/B example cookie if users visit the A/B test page

### DIFF
--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -282,7 +282,10 @@ sub vcl_miss {
 
 sub vcl_deliver {
   # Set the A/B cookie
-  if (req.http.Cookie !~ "ABTest-Example") {
+  # Only set the A/B example cookie if the request is to the A/B test page. This
+  # ensures that most visitors to the site aren't assigned an irrelevant test
+  # cookie.
+  if (req.url ~ "^/help/ab-testing" && req.http.Cookie !~ "ABTest-Example") {
     # Set a fairly short cookie expiry because this is just an A/B test demo.
     # We should choose a longer expiry for a real A/B test.
     add resp.http.Set-Cookie = "ABTest-Example=" req.http.GOVUK-ABTest-Example "; expires=" now + 1d;


### PR DESCRIPTION
The A/B example cookie is only used for testing purposes. It's not relevant to most users, and setting it on every response is excessive.

Trello: https://trello.com/c/g4C5JaTU/355-only-set-the-abtest-example-cookie-if-the-user-visits-the-example-a-b-test-page-to-prevent-us-from-setting-the-cookie-for-every-