### PR TITLE
Invert the A/B split logic to improve readability

### DIFF
--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -200,9 +200,9 @@ sub vcl_recv {
 
   if (req.http.Cookie !~ "ABTest-Example") {
     if (randombool(5,10)) {
-       set req.http.GOVUK-ABTest-Example = "A";
+      set req.http.GOVUK-ABTest-Example = "B";
     } else {
-       set req.http.GOVUK-ABTest-Example = "B";
+      set req.http.GOVUK-ABTest-Example = "A";
     }
   } else {
     # Set the value of the header to whatever decision was previously made


### PR DESCRIPTION
This change flips the A/B fraction calculation so it calculates the fraction of users in the B group, to be consistent with how we talk about A/B tests.

We usually talk about A/B tests in terms of the fraction of users who see the B version, which is the newer version. So "0%" would mean the experiment hasn't started yet, and "100%" would mean that everyone is being shown the new version.