### PR TITLE
Make the raw domain HTTPS upgrade HSTS compatible and set 10 sec max-age

### DIFF
--- a/vcl_templates/tldredirect.vcl.erb
+++ b/vcl_templates/tldredirect.vcl.erb
@@ -9,6 +9,14 @@ backend dummy {
 }
 
 sub vcl_recv {
+
+  # Force SSL.
+  if (!req.http.Fastly-SSL) {
+    error 801 "Force SSL";
+  } else {
+    error 802 "Redirect GOV.UK";
+  }
+
   return(error);
 }
 
@@ -25,9 +33,20 @@ sub vcl_deliver {
 }
 
 sub vcl_error {
-  set obj.status = 301;
-  set obj.response = "Moved Permanently";
-  set obj.http.Location = "https://www.gov.uk" req.url;
+  if (obj.status == 801) {
+    set obj.status = 301;
+    set obj.response = "Moved Permanently";
+    set obj.http.Location = "https://" req.http.host req.url;
+    set obj.http.Fastly-Backend-Name = "force_ssl";
+  }
+
+  if (obj.status == 802) {
+    set obj.status = 301;
+    set obj.response = "Moved Permanently";
+    set obj.http.Location = "https://www.gov.uk" req.url;
+    set obj.http.Strict-Transport-Security = "max-age=10";
+  }
+
   synthetic {""};
   return (deliver);
 }


### PR DESCRIPTION
This is the first 2 steps in https://github.com/alphagov/govuk-cdn-config/issues/14
It copies the code from `servicegovuk.vcl.erb` to redirect http://gov.uk/whatever to https://gov.uk/whatever and it sets a 10 second max-age to limit the damage if anything goes wrong.

I don't have a fastly account to test this against, so it's a little speculative.