### PR TITLE
Ensure the GOV.UK mirror stores the original version of the A/B test

### DIFF
--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -198,15 +198,18 @@ sub vcl_recv {
     return(pass);
   }
 
-  if (req.http.Cookie !~ "ABTest-Example") {
+  # Make sure the original 'A' version is stored in the GOV.UK Mirror
+  if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker" {
+    set req.http.GOVUK-ABTest-Example = "A";
+  } else if (req.http.Cookie ~ "ABTest-Example") {
+    # Set the value of the header to whatever decision was previously made
+    set req.http.GOVUK-ABTest-Example = req.http.Cookie:ABTest-Example;
+  } else {
     if (randombool(5,10)) {
       set req.http.GOVUK-ABTest-Example = "B";
     } else {
       set req.http.GOVUK-ABTest-Example = "A";
     }
-  } else {
-    # Set the value of the header to whatever decision was previously made
-    set req.http.GOVUK-ABTest-Example = req.http.Cookie:ABTest-Example;
   }
 
   return(lookup);
@@ -285,7 +288,9 @@ sub vcl_deliver {
   # Only set the A/B example cookie if the request is to the A/B test page. This
   # ensures that most visitors to the site aren't assigned an irrelevant test
   # cookie.
-  if (req.url ~ "^/help/ab-testing" && req.http.Cookie !~ "ABTest-Example") {
+  if (req.url ~ "^/help/ab-testing"
+    && req.http.User-Agent !~ "^GOV\.UK Crawler Worker"
+    && req.http.Cookie !~ "ABTest-Example") {
     # Set a fairly short cookie expiry because this is just an A/B test demo.
     # We should choose a longer expiry for a real A/B test.
     add resp.http.Set-Cookie = "ABTest-Example=" req.http.GOVUK-ABTest-Example "; expires=" now + 1d;


### PR DESCRIPTION
Identify requests from the mirror's crawler worker, and set the request header such that it only ever sees the original 'A' version of the example A/B test.

This is in preparation for the real A/B test of education navigation. It will affect many pages across the site, so it's important to make sure that the mirror contains a self-consistent version of all the affected pages.

Trello: https://trello.com/c/0v9u9TOs/353-ensure-that-the-gov-uk-mirror-only-mirrors-the-a-version-of-all-tests

The user-agent string comes from govuk_crawler_worker: https://github.com/alphagov/govuk_crawler_worker/blob/master/http_crawler/crawler.go#L71