### PR TITLE
Use query string to switch between navigation A/B test variants

### DIFF
--- a/vcl_templates/tldredirect.vcl.erb
+++ b/vcl_templates/tldredirect.vcl.erb
@@ -9,6 +9,14 @@ backend dummy {
 }
 
 sub vcl_recv {
+
+  # Force SSL.
+  if (!req.http.Fastly-SSL) {
+    error 801 "Force SSL";
+  } else {
+    error 802 "Redirect GOV.UK";
+  }
+
   return(error);
 }
 
@@ -25,9 +33,20 @@ sub vcl_deliver {
 }
 
 sub vcl_error {
-  set obj.status = 301;
-  set obj.response = "Moved Permanently";
-  set obj.http.Location = "https://www.gov.uk" req.url;
+  if (obj.status == 801) {
+    set obj.status = 301;
+    set obj.response = "Moved Permanently";
+    set obj.http.Location = "https://" req.http.host req.url;
+    set obj.http.Fastly-Backend-Name = "force_ssl";
+  }
+
+  if (obj.status == 802) {
+    set obj.status = 301;
+    set obj.response = "Moved Permanently";
+    set obj.http.Location = "https://www.gov.uk" req.url;
+    set obj.http.Strict-Transport-Security = "max-age=10";
+  }
+
   synthetic {""};
   return (deliver);
 }

--- a/vcl_templates/tldredirect.vcl.erb
+++ b/vcl_templates/tldredirect.vcl.erb
@@ -44,7 +44,7 @@ sub vcl_error {
     set obj.status = 301;
     set obj.response = "Moved Permanently";
     set obj.http.Location = "https://www.gov.uk" req.url;
-    set obj.http.Strict-Transport-Security = "max-age=10";
+    set obj.http.Strict-Transport-Security = "max-age=3600";
   }
 
   synthetic {""};

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -200,9 +200,9 @@ sub vcl_recv {
 
   if (req.http.Cookie !~ "ABTest-Example") {
     if (randombool(5,10)) {
-       set req.http.GOVUK-ABTest-Example = "A";
+      set req.http.GOVUK-ABTest-Example = "B";
     } else {
-       set req.http.GOVUK-ABTest-Example = "B";
+      set req.http.GOVUK-ABTest-Example = "A";
     }
   } else {
     # Set the value of the header to whatever decision was previously made

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -198,15 +198,18 @@ sub vcl_recv {
     return(pass);
   }
 
-  if (req.http.Cookie !~ "ABTest-Example") {
+  # Make sure the original 'A' version is stored in the GOV.UK Mirror
+  if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker" {
+    set req.http.GOVUK-ABTest-Example = "A";
+  } else if (req.http.Cookie ~ "ABTest-Example") {
+    # Set the value of the header to whatever decision was previously made
+    set req.http.GOVUK-ABTest-Example = req.http.Cookie:ABTest-Example;
+  } else {
     if (randombool(5,10)) {
       set req.http.GOVUK-ABTest-Example = "B";
     } else {
       set req.http.GOVUK-ABTest-Example = "A";
     }
-  } else {
-    # Set the value of the header to whatever decision was previously made
-    set req.http.GOVUK-ABTest-Example = req.http.Cookie:ABTest-Example;
   }
 
   return(lookup);
@@ -285,7 +288,9 @@ sub vcl_deliver {
   # Only set the A/B example cookie if the request is to the A/B test page. This
   # ensures that most visitors to the site aren't assigned an irrelevant test
   # cookie.
-  if (req.url ~ "^/help/ab-testing" && req.http.Cookie !~ "ABTest-Example") {
+  if (req.url ~ "^/help/ab-testing"
+    && req.http.User-Agent !~ "^GOV\.UK Crawler Worker"
+    && req.http.Cookie !~ "ABTest-Example") {
     # Set a fairly short cookie expiry because this is just an A/B test demo.
     # We should choose a longer expiry for a real A/B test.
     add resp.http.Set-Cookie = "ABTest-Example=" req.http.GOVUK-ABTest-Example "; expires=" now + 1d;

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -199,7 +199,7 @@ sub vcl_recv {
   }
 
   # Make sure the original 'A' version is stored in the GOV.UK Mirror
-  if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker" {
+  if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
     set req.http.GOVUK-ABTest-Example = "A";
   } else if (req.http.Cookie ~ "ABTest-Example") {
     # Set the value of the header to whatever decision was previously made

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -282,7 +282,10 @@ sub vcl_miss {
 
 sub vcl_deliver {
   # Set the A/B cookie
-  if (req.http.Cookie !~ "ABTest-Example") {
+  # Only set the A/B example cookie if the request is to the A/B test page. This
+  # ensures that most visitors to the site aren't assigned an irrelevant test
+  # cookie.
+  if (req.url ~ "^/help/ab-testing" && req.http.Cookie !~ "ABTest-Example") {
     # Set a fairly short cookie expiry because this is just an A/B test demo.
     # We should choose a longer expiry for a real A/B test.
     add resp.http.Set-Cookie = "ABTest-Example=" req.http.GOVUK-ABTest-Example "; expires=" now + 1d;

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -212,6 +212,23 @@ sub vcl_recv {
     }
   }
 
+  if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker" {
+    set req.http.GOVUK-ABTest-EducationNavigation = "A";
+  } else if (req.http.Cookie ~ "ABTest-EducationNavigation") {
+    # Set the value of the header to whatever decision was previously made
+    set req.http.GOVUK-ABTest-EducationNavigation = req.http.Cookie:ABTest-EducationNavigation;
+  } else {
+    # TODO: Once the education navigation A/B test starts, increase the
+    # probability of a user seeing the new 'B' version. When we do this, we MUST
+    # increase the cookie expiry time in vcl_deliver below.
+    # For now, always show users the original 'A' version.
+    if (randombool(0,10)) {
+      set req.http.GOVUK-ABTest-EducationNavigation = "B";
+    } else {
+      set req.http.GOVUK-ABTest-EducationNavigation = "A";
+    }
+  }
+
   return(lookup);
 }
 
@@ -284,7 +301,7 @@ sub vcl_miss {
 }
 
 sub vcl_deliver {
-  # Set the A/B cookie
+  # Set the A/B cookies
   # Only set the A/B example cookie if the request is to the A/B test page. This
   # ensures that most visitors to the site aren't assigned an irrelevant test
   # cookie.
@@ -292,8 +309,14 @@ sub vcl_deliver {
     && req.http.User-Agent !~ "^GOV\.UK Crawler Worker"
     && req.http.Cookie !~ "ABTest-Example") {
     # Set a fairly short cookie expiry because this is just an A/B test demo.
-    # We should choose a longer expiry for a real A/B test.
     add resp.http.Set-Cookie = "ABTest-Example=" req.http.GOVUK-ABTest-Example "; expires=" now + 1d;
+  }
+  if (req.http.Cookie !~ "ABTest-EducationNavigation") {
+    # TODO: Increase expiry time to 'now + 1y' when we start to assign users to
+    # the 'B' bucket. It is currently 1 day because users will all receive the
+    # 'A' cookie before the A/B test begins, and we need to make sure that they
+    # don't all get stuck with the 'A' version when the test starts.
+    add resp.http.Set-Cookie = "ABTest-EducationNavigation=" req.http.GOVUK-ABTest-EducationNavigation "; expires=" now + 1d "; path=/";
   }
 
 #FASTLY deliver

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -214,6 +214,12 @@ sub vcl_recv {
 
   if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker" {
     set req.http.GOVUK-ABTest-EducationNavigation = "A";
+  # Some users, such as remote testers, will be given a URL with a query string
+  # to place them into a specific bucket.
+  } else if (req.url ~ "[\?\&]ABTest-EducationNavigation=A(&|$)") {
+    set req.http.GOVUK-ABTest-EducationNavigation = "A";
+  } else if (req.url ~ "[\?\&]ABTest-EducationNavigation=B(&|$)") {
+    set req.http.GOVUK-ABTest-EducationNavigation = "B";
   } else if (req.http.Cookie ~ "ABTest-EducationNavigation") {
     # Set the value of the header to whatever decision was previously made
     set req.http.GOVUK-ABTest-EducationNavigation = req.http.Cookie:ABTest-EducationNavigation;


### PR DESCRIPTION
The changes to education navigation will be tested by remote testers. Unlike regular users, who should be assigned the A or B variant at random, remote testers need to see a specific version of the A/B test.

Remote testers make their first visit to the site through a link that we email to them. So a convenient way to place them in the A or B buckets is to append a query string in that link that we send them, and identify it when assigning buckets.

The query string will be `?ABTest-EducationNavigation=A`, i.e. one that matches the A/B testing cookie. This isn't essential for this test, but it will make it easier for us to commonise this config for future tests.

https://trello.com/c/F2L41y9R/321-roll-out-the-new-navigation-via-a-b-testing-to-remote-testers-before-the-general-public

Dependencies:
- [ ] #17 (once merged, rebase this PR on master)