### PR TITLE
Fix syntax error in www config

### DIFF
--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -199,7 +199,7 @@ sub vcl_recv {
   }
 
   # Make sure the original 'A' version is stored in the GOV.UK Mirror
-  if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker" {
+  if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
     set req.http.GOVUK-ABTest-Example = "A";
   } else if (req.http.Cookie ~ "ABTest-Example") {
     # Set the value of the header to whatever decision was previously made


### PR DESCRIPTION
Add missing bracket to fix the deployment of the www config. 😞 

The deployment step failed because the syntax error, but Jenkins reported the fastly-configure job as a success. Could we also make the job fail when this happens? (There's always the [text-finder plugin](https://wiki.jenkins-ci.org/display/JENKINS/Text-finder+Plugin) if we can't identify the failure any other way.)

Trello: https://trello.com/c/0v9u9TOs/353-ensure-that-the-gov-uk-mirror-only-mirrors-the-a-version-of-all-tests