### PR TITLE
Bump TLD redirect HSTS max-age to 1 hour

### DIFF
--- a/vcl_templates/tldredirect.vcl.erb
+++ b/vcl_templates/tldredirect.vcl.erb
@@ -44,7 +44,7 @@ sub vcl_error {
     set obj.status = 301;
     set obj.response = "Moved Permanently";
     set obj.http.Location = "https://www.gov.uk" req.url;
-    set obj.http.Strict-Transport-Security = "max-age=10";
+    set obj.http.Strict-Transport-Security = "max-age=3600";
   }
 
   synthetic {""};


### PR DESCRIPTION
The 10 second max-age introduced in #20 seems to be fine. This
commit increases that to 1 hour (3600 seconds), as a further step
outlined in #14.