### PR TITLE
Add tls cookie

### DIFF
--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -296,16 +296,11 @@ sub vcl_deliver {
     add resp.http.Set-Cookie = "ABTest-Example=" req.http.GOVUK-ABTest-Example "; expires=" now + 1d;
   }
 
-  if (tls.client.protocol == "TLSv1.2") {
-    add resp.http.Set-Cookie = "TLSversion=TLSv1.2; max-age=0; secure";
-  } else if (tls.client.protocol == "TLSv1.1") {
-    add resp.http.Set-Cookie = "TLSversion=TLSv1.1; max-age=0; secure";
-  } else if (tls.client.protocol == "TLSv1") {
-    add resp.http.Set-Cookie = "TLSversion=TLSv1.0; max-age=0; secure";
-  } else {
-    add resp.http.Set-Cookie = "TLSversion=unknown; max-age=0; secure";
+  # Set the tls version session cookie with the raw protocol version from
+  # fastly only if it isn't already set
+  if (req.http.Cookie !~ "TLSversion") {
+    add resp.http.Set-Cookie = "TLSversion=" tls.client.protocol "; secure";
   }
-
 #FASTLY deliver
 }
 

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -296,6 +296,16 @@ sub vcl_deliver {
     add resp.http.Set-Cookie = "ABTest-Example=" req.http.GOVUK-ABTest-Example "; expires=" now + 1d;
   }
 
+  if (tls.client.protocol == "TLSv1.2") {
+    add resp.http.Set-Cookie = "TLSversion=TLSv1.2; max-age=0; secure";
+  } else if (tls.client.protocol == "TLSv1.1") {
+    add resp.http.Set-Cookie = "TLSversion=TLSv1.1; max-age=0; secure";
+  } else if (tls.client.protocol == "TLSv1") {
+    add resp.http.Set-Cookie = "TLSversion=TLSv1.0; max-age=0; secure";
+  } else {
+    add resp.http.Set-Cookie = "TLSversion=unknown; max-age=0; secure";
+  }
+
 #FASTLY deliver
 }
 


### PR DESCRIPTION
For: https://trello.com/c/JX541tka/113-add-tls-version-information-to-google-analytics

Also see https://github.com/alphagov/static/pull/900 which consumes this cookie.  Our goal here is to set a cookie with the tls protocol version as understood by fastly and then read the cookie in the frontend so we can send the protocol version to GA and let us work out how many visitors use each version of the protocol.  This will ultimately inform our decisions about when/if to drop support older versions of the protocol (see: [Fastly's plan to deprecate 1.0 and 1.1](https://www.fastly.com/blog/phase-two-our-tls-10-and-11-deprecation-plan).