### PR TITLE
Fix ABTest-EducationNavigation cookie setting for remote testers

### DIFF
--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -317,7 +317,7 @@ sub vcl_deliver {
     # Set a fairly short cookie expiry because this is just an A/B test demo.
     add resp.http.Set-Cookie = "ABTest-Example=" req.http.GOVUK-ABTest-Example "; expires=" now + 1d;
   }
-  if (req.http.Cookie !~ "ABTest-EducationNavigation") {
+  if (req.http.Cookie !~ "ABTest-EducationNavigation" || req.url ~ "[\?\&]ABTest-EducationNavigation=") {
     # TODO: Increase expiry time to 'now + 1y' when we start to assign users to
     # the 'B' bucket. It is currently 1 day because users will all receive the
     # 'A' cookie before the A/B test begins, and we need to make sure that they


### PR DESCRIPTION
Remote testers will be sent a URL like https://www.gov.uk?ABTest-EducationNavigation=B to ensure that they see a specific version of the A/B test. This was broken if they already had
an A/B testing cookie, because Fastly would not overwrite the existing cookie.

This commit makes ensures the correct cookie is set if the URL contains the A/B test query string, regardless of whether the user had an existing cookie.

Trello: https://trello.com/c/F2L41y9R/321-pre-release-of-beta-roll-out-the-new-navigation-via-a-b-testing-to-remote-testers-before-the-general-public