### PR TITLE
Show the B version of the Education Navigation A/B test to 10% of users

### DIFF
--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -224,11 +224,7 @@ sub vcl_recv {
     # Set the value of the header to whatever decision was previously made
     set req.http.GOVUK-ABTest-EducationNavigation = req.http.Cookie:ABTest-EducationNavigation;
   } else {
-    # TODO: Once the education navigation A/B test starts, increase the
-    # probability of a user seeing the new 'B' version. When we do this, we MUST
-    # increase the cookie expiry time in vcl_deliver below.
-    # For now, always show users the original 'A' version.
-    if (randombool(0,10)) {
+    if (randombool(1,10)) {
       set req.http.GOVUK-ABTest-EducationNavigation = "B";
     } else {
       set req.http.GOVUK-ABTest-EducationNavigation = "A";
@@ -318,11 +314,7 @@ sub vcl_deliver {
     add resp.http.Set-Cookie = "ABTest-Example=" req.http.GOVUK-ABTest-Example "; expires=" now + 1d;
   }
   if (req.http.Cookie !~ "ABTest-EducationNavigation" || req.url ~ "[\?\&]ABTest-EducationNavigation=") {
-    # TODO: Increase expiry time to 'now + 1y' when we start to assign users to
-    # the 'B' bucket. It is currently 1 day because users will all receive the
-    # 'A' cookie before the A/B test begins, and we need to make sure that they
-    # don't all get stuck with the 'A' version when the test starts.
-    add resp.http.Set-Cookie = "ABTest-EducationNavigation=" req.http.GOVUK-ABTest-EducationNavigation "; expires=" now + 1d "; path=/";
+    add resp.http.Set-Cookie = "ABTest-EducationNavigation=" req.http.GOVUK-ABTest-EducationNavigation "; expires=" now + 1y "; path=/";
   }
 
   # Set the tls version session cookie with the raw protocol version from


### PR DESCRIPTION
Increase the B fraction from 0/10 to 1/10 to start the Education Navigation A/B test.

Also increase the A/B test cookie expiry from 1 day to 1 year, so that users see the same variant throughout the test.

Marked as DO NOT MERGE because we want to control when we deploy this.

Trello: https://trello.com/c/pCvpvtds/356-roll-out-the-navigation-a-b-test-to-the-general-public