### PR TITLE
Avoid writing null TLS cookies on http>https upgrade

### DIFF
--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -325,9 +325,10 @@ sub vcl_deliver {
     add resp.http.Set-Cookie = "ABTest-EducationNavigation=" req.http.GOVUK-ABTest-EducationNavigation "; expires=" now + 1d "; path=/";
   }
 
-  # Set the tls version session cookie with the raw protocol version from
-  # fastly only if it isn't already set
-  if (req.http.Cookie !~ "TLSversion") {
+  # Set the TLS version session cookie with the raw protocol version from
+  # Fastly only if it isn't already set. We also check for a value of (null)
+  # which occurs during http>https upgrading.
+  if (tls.client.protocol != "(null)" && req.http.Cookie !~ "TLSversion") {
     add resp.http.Set-Cookie = "TLSversion=" tls.client.protocol "; secure";
   }
 #FASTLY deliver


### PR DESCRIPTION
The `vcl_deliver` block still fires during an HTTP → HTTPS upgrade, so we [write the TLS version cookie with a `(null)` value](https://gist.github.com/davidillsley/8dc427420704d21e8f5a3f3d27bdbb26), and don't update it when a valid value actually exists.  This change avoids writing the cookie in the first place if we have a null value.

Note: this doesn't take in to account anyone who already has a null value set in a cookie, but as they're session cookies and will be expired on browser close, this is acceptable.