### PR TITLE
Fix null TLS protocol detection

### DIFF
--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -318,9 +318,9 @@ sub vcl_deliver {
   }
 
   # Set the TLS version session cookie with the raw protocol version from
-  # Fastly only if it isn't already set. We also check for a value of (null)
-  # which occurs during http>https upgrading.
-  if (tls.client.protocol != "(null)" && req.http.Cookie !~ "TLSversion") {
+  # Fastly only if it isn't already set. We also check for a null TLS value,
+  # which can occur when trying to access over HTTP (http>https upgrading).
+  if (tls.client.protocol && req.http.Cookie !~ "TLSversion") {
     add resp.http.Set-Cookie = "TLSversion=" tls.client.protocol "; secure";
   }
 #FASTLY deliver


### PR DESCRIPTION
Previously we were checking the `tls.client.protocol` value against a literal string of `(null)`, which is what the cookie value ended up as if the request was via HTTP.  But the actual value is not the same as the string representation, so the check was always passing (i.e. it never matched `(null)`)."