### PR TITLE
Add users to B group when going to a nav page

### DIFF
--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -220,6 +220,10 @@ sub vcl_recv {
     set req.http.GOVUK-ABTest-EducationNavigation = "A";
   } else if (req.url ~ "[\?\&]ABTest-EducationNavigation=B(&|$)") {
     set req.http.GOVUK-ABTest-EducationNavigation = "B";
+  } else if (req.url ~ "^/education(/|$)") {
+    # If a user goes to a new navigation page, add them automatically to the B
+    # group, so they can see a consistent navigation throughout.
+    set req.http.GOVUK-ABTest-EducationNavigation = "B";
   } else if (req.http.Cookie ~ "ABTest-EducationNavigation") {
     # Set the value of the header to whatever decision was previously made
     set req.http.GOVUK-ABTest-EducationNavigation = req.http.Cookie:ABTest-EducationNavigation;
@@ -313,7 +317,7 @@ sub vcl_deliver {
     # Set a fairly short cookie expiry because this is just an A/B test demo.
     add resp.http.Set-Cookie = "ABTest-Example=" req.http.GOVUK-ABTest-Example "; expires=" now + 1d;
   }
-  if (req.http.Cookie !~ "ABTest-EducationNavigation" || req.url ~ "[\?\&]ABTest-EducationNavigation=") {
+  if (req.http.Cookie !~ "ABTest-EducationNavigation" || req.url ~ "[\?\&]ABTest-EducationNavigation=" || req.url ~ "^/education(/|$)") {
     add resp.http.Set-Cookie = "ABTest-EducationNavigation=" req.http.GOVUK-ABTest-EducationNavigation "; expires=" now + 365d "; path=/";
   }
 


### PR DESCRIPTION
We are enabling the new navigation pages for everyone that goes directly
to them. The reason for this is to avoid people seeing 404s, and search
indexers index pages that might point people to 404s.

This is a complementary change where we assign users to the B group when
they go directly to a new navigation page, so they see a consistent
navigation throughout the site.

All new navigation pages start with `/education`.

cc/ @suzannehamilton @tijmenb 