### PR TITLE
Allow query params on /education URLs

### DIFF
--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -220,7 +220,7 @@ sub vcl_recv {
     set req.http.GOVUK-ABTest-EducationNavigation = "A";
   } else if (req.url ~ "[\?\&]ABTest-EducationNavigation=B(&|$)") {
     set req.http.GOVUK-ABTest-EducationNavigation = "B";
-  } else if (req.url ~ "^/education(/|$)") {
+  } else if (req.url ~ "^/education(\/|\?|$)") {
     # If a user goes to a new navigation page, add them automatically to the B
     # group, so they can see a consistent navigation throughout.
     set req.http.GOVUK-ABTest-EducationNavigation = "B";
@@ -317,7 +317,7 @@ sub vcl_deliver {
     # Set a fairly short cookie expiry because this is just an A/B test demo.
     add resp.http.Set-Cookie = "ABTest-Example=" req.http.GOVUK-ABTest-Example "; expires=" now + 1d;
   }
-  if (req.http.Cookie !~ "ABTest-EducationNavigation" || req.url ~ "[\?\&]ABTest-EducationNavigation=" || req.url ~ "^/education(/|$)") {
+  if (req.http.Cookie !~ "ABTest-EducationNavigation" || req.url ~ "[\?\&]ABTest-EducationNavigation=" || req.url ~ "^/education(\/|\?|$)") {
     add resp.http.Set-Cookie = "ABTest-EducationNavigation=" req.http.GOVUK-ABTest-EducationNavigation "; expires=" now + 365d "; path=/";
   }
 


### PR DESCRIPTION
When adding smokey tests to verify we were assigning users to the
expected bucket, we realised we used a cache busting param to the
request. In doing so, the request wasn't recognised as being a request
to /education, meaning we weren't being assigned to the correct bucket.

This change makes sure we also allow for `?` after /education.

