### PR TITLE
Enable www S3 mirror

### DIFF
--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -68,12 +68,12 @@ backend F_mirror0 {
         .interval = 10s;
     }
 }
-# Mirror backend for provider 1
-backend F_mirror1 {
+# Mirror backend for S3
+backend F_mirrorS3 {
     .connect_timeout = 1s;
     .dynamic = true;
-    .port = "<%= config.fetch('provider1_mirror_port', 443) %>";
-    .host = "<%= config.fetch('provider1_mirror_hostname') %>";
+    .port = "<%= config.fetch('s3_mirror_port', 443) %>";
+    .host = "<%= config.fetch('s3_mirror_hostname') %>";
     .first_byte_timeout = 15s;
     .max_connections = 200;
     .between_bytes_timeout = 10s;
@@ -85,13 +85,13 @@ backend F_mirror1 {
     <%- if config['ssl_ciphers'] -%>
     .ssl_ciphers = "<%= config['ssl_ciphers'] -%>";
     <%- end -%>
-    .ssl_cert_hostname = "<%= config.fetch('ssl_cert_hostname', config.fetch('provider1_mirror_hostname')) %>";
-    .ssl_sni_hostname = "<%= config.fetch('ssl_sni_hostname', config.fetch('provider1_mirror_hostname')) %>";
+    .ssl_cert_hostname = "<%= config.fetch('ssl_cert_hostname', config.fetch('s3_mirror_hostname')) %>";
+    .ssl_sni_hostname = "<%= config.fetch('ssl_sni_hostname', config.fetch('s3_mirror_hostname')) %>";
 
     .probe = {
         .request =
-            "HEAD / HTTP/1.1"
-            "Host: <%= config.fetch('provider1_mirror_hostname') %>"
+            "HEAD <%= config.fetch('s3_mirror_probe_request', '/') %> HTTP/1.1"
+            "Host: <%= config.fetch('s3_mirror_hostname') %>"
             "User-Agent: Fastly healthcheck (git version: <%= config['git_version'] %>)"
             "Connection: close";
         .threshold = 1;
@@ -184,9 +184,24 @@ sub vcl_recv {
 
   # FIXME: Prefer a fallback director if we move to Varnish 3
   if (req.restarts > 2) {
-    set req.backend = F_mirror1;
-    set req.http.host = "<%= config.fetch('provider1_mirror_hostname') %>";
-    set req.http.Fastly-Backend-Name = "mirror1";
+    set req.backend = F_mirrorS3;
+    set req.http.host = "<%= config.fetch('s3_mirror_hostname') %>";
+    set req.http.Fastly-Backend-Name = "mirrorS3";
+
+    # Requests to home page, rewrite to index.html
+    if (req.url ~ "^/?([\?#].*)?$") {
+      set req.url = regsub(req.url, "^/?([\?#].*)?$", "/index.html\1");
+    }
+
+    # Replace multiple /
+    set req.url = regsuball(req.url, "([^:])//+", "\1/");
+
+    # Requests without document extension, rewrite adding .html
+    if (req.url !~ "^([^#\?\s]+)\.(atom|chm|css|csv|diff|doc|docx|dot|dxf|eps|gif|gml|html|ico|ics|jpeg|jpg|JPG|js|json|kml|odp|ods|odt|pdf|PDF|png|ppt|pptx|ps|rdf|rtf|sch|txt|wsdl|xls|xlsm|xlsx|xlt|xml|xsd|xslt|zip)([\?#]+.*)?$") {
+      set req.url = regsub(req.url, "^([^#\?\s]+)([\?#]+.*)?$", "\1.html\2");
+    }
+    # Add bucket directory prefix to all the requests
+    set req.url = "/<%= config.fetch('s3_mirror_prefix') %>" req.url;
   }
 
   # Unspoofable original client address.
@@ -282,6 +297,9 @@ sub vcl_fetch {
     set req.http.Fastly-Cachetype = "ERROR";
     set beresp.ttl = 1s;
     set beresp.grace = 5s;
+    if (beresp.http.Fastly-Backend-Name ~ "mirrorS3") {
+      error 503 "Error page";
+    }
     return (deliver);
   }
 
@@ -290,6 +308,12 @@ sub vcl_fetch {
   } else {
     # apply the default ttl
     set beresp.ttl = <%= config.fetch('default_ttl') %>s;
+
+    # S3 does not set cache headers by default. Override TTL and add cache-control with 15 minutes
+    if (beresp.http.Fastly-Backend-Name ~ "mirrorS3") {
+      set beresp.ttl = 900s;
+      set beresp.http.Cache-Control = "max-age=900";
+    }
   }
 
   # Override default.vcl behaviour of return(pass).


### PR DESCRIPTION
Update www template to use new S3 mirror instead of mirror1.
There are a few changes specific for S3:
- Depending on how the bucket is configured, the backend probe request
needs to point to the directory where the content is located
- S3 does not set cache headers by default, we need to override the default TTL and add
header based on previous Nginx mirror configuration
- Requests need to be rewritten to match location in the bucket and add file extension
if it does not exist in the request, similar to try_files configuration in Nginx
- S3 errors need to serve static error page
