### PR TITLE
Js detection cookie

### DIFF
--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -238,8 +238,8 @@ sub vcl_recv {
   if (req.http.Cookie ~ "JS-Detection") {
     set req.http.GOVUK-JS-Detection = req.http.Cookie:JS-Detection;
   } else {
-  # If the identifier cookie isn't present, set the header to a unique value),
-  # dervived as per the suggestion in https://community.fastly.com/t/unique-request-identifier/468/2
+  # If the identifier cookie isn't present, set the header to a unique value,
+  # derived as per the suggestion in https://community.fastly.com/t/unique-request-identifier/468/2
     set req.http.GOVUK-JS-Detection = digest.hash_sha1(now randomstr(64) req.http.host req.url req.http.Fastly-Client-IP server.identity);
 
   }

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -340,7 +340,7 @@ sub vcl_deliver {
 
   # Set the Javascript detection cookie
   if (req.http.User-Agent !~ "^GOV\.UK Crawler Worker" && req.http.Cookie !~ "JS-Detection") {
-    add resp.http.Set-Cookie = "JS-Detection=" req.http.GOVUK-JS-Detection "; expires=" now + 5w;
+    add resp.http.Set-Cookie = "JS-Detection=" req.http.GOVUK-JS-Detection "; expires=" now + 5w "; path=/";
   }
 
 

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -212,6 +212,7 @@ sub vcl_recv {
     }
   }
 
+
   if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
     set req.http.GOVUK-ABTest-EducationNavigation = "A";
   # Some users, such as remote testers, will be given a URL with a query string
@@ -233,6 +234,14 @@ sub vcl_recv {
     } else {
       set req.http.GOVUK-ABTest-EducationNavigation = "A";
     }
+
+  if (req.http.Cookie ~ "JS-Detection") {
+    set req.http.GOVUK-JS-Detection = req.http.Cookie:JS-Detection;
+  } else {
+  # If the identifier cookie isn't present, set the header to a unique value),
+  # dervived as per the suggestion in https://community.fastly.com/t/unique-request-identifier/468/2
+    set req.http.GOVUK-JS-Detection = digest.hash_sha1(now randomstr(64) req.http.host req.url req.http.Fastly-Client-IP server.identity);
+
   }
 
   return(lookup);
@@ -321,12 +330,20 @@ sub vcl_deliver {
     add resp.http.Set-Cookie = "ABTest-EducationNavigation=" req.http.GOVUK-ABTest-EducationNavigation "; expires=" now + 365d "; path=/";
   }
 
+
   # Set the TLS version session cookie with the raw protocol version from
   # Fastly only if it isn't already set. We also check for a null TLS value,
   # which can occur when trying to access over HTTP (http>https upgrading).
   if (tls.client.protocol && req.http.Cookie !~ "TLSversion") {
     add resp.http.Set-Cookie = "TLSversion=" tls.client.protocol "; secure";
   }
+
+  # Set the Javascript detection cookie
+  if (req.http.User-Agent !~ "^GOV\.UK Crawler Worker" && req.http.Cookie !~ "JS-Detection") {
+    add resp.http.Set-Cookie = "JS-Detection=" req.http.GOVUK-JS-Detection "; expires=" now + 5w;
+  }
+
+
 #FASTLY deliver
 }
 


### PR DESCRIPTION
Opening #22 again. This is a re-run of the experiment described in https://gds.blog.gov.uk/2013/10/21/how-many-people-are-missing-out-on-javascript-enhancement/

The original experiment didn't use cookies, but we're using cookies as an enhancement to track unique users and possibly filter out any pre-scanning behaviour by browsers which could possibly skew the number of users appearing to use javascript.

https://www.gov.uk/help/cookies now has a description of this cookie.