### PR TITLE
Increase sessions in B variant to 30%

### DIFF
--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -228,7 +228,7 @@ sub vcl_recv {
     # Set the value of the header to whatever decision was previously made
     set req.http.GOVUK-ABTest-EducationNavigation = req.http.Cookie:ABTest-EducationNavigation;
   } else {
-    if (randombool(1,10)) {
+    if (randombool(3,10)) {
       set req.http.GOVUK-ABTest-EducationNavigation = "B";
     } else {
       set req.http.GOVUK-ABTest-EducationNavigation = "A";


### PR DESCRIPTION
This commit makes sure 30% of new sessions will see the new Education
Navigation in GOV.UK.

This was a product decision so we can ramp up our numbers.