### PR TITLE
Add cookie for GOVUK-ABTest-Benchmarking

### DIFF
--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -235,7 +235,7 @@ sub vcl_recv {
       set req.http.GOVUK-ABTest-EducationNavigation = "A";
     }
   }
-  
+
   if (req.http.Cookie ~ "JS-Detection") {
     set req.http.GOVUK-JS-Detection = req.http.Cookie:JS-Detection;
   } else {
@@ -243,6 +243,21 @@ sub vcl_recv {
   # derived as per the suggestion in https://community.fastly.com/t/unique-request-identifier/468/2
     set req.http.GOVUK-JS-Detection = digest.hash_sha1(now randomstr(64) req.http.host req.url req.http.Fastly-Client-IP server.identity);
 
+  }
+
+  # Rules for GOVUK-ABTest-Benchmarking
+  if (req.url ~ "[\?\&]ABTest-Benchmarking=A(&|$)") {
+    set req.http.GOVUK-ABTest-Benchmarking = "A";
+  } else if (req.url ~ "[\?\&]ABTest-Benchmarking=B(&|$)") {
+    set req.http.GOVUK-ABTest-Benchmarking = "B";
+  } else if (req.http.Cookie ~ "ABTest-Benchmarking") {
+    # Set the value of the header to whatever decision was previously made
+    set req.http.GOVUK-ABTest-Benchmarking = req.http.Cookie:ABTest-Benchmarking;
+  } else {
+    # We default everyone to A, because remote testers will have a param in the
+    # URL to add them to the B group. In this test, we don't want anyone else
+    # having the B variant.
+    set req.http.GOVUK-ABTest-Benchmarking = "A";
   }
 
   return(lookup);
@@ -327,10 +342,16 @@ sub vcl_deliver {
     # Set a fairly short cookie expiry because this is just an A/B test demo.
     add resp.http.Set-Cookie = "ABTest-Example=" req.http.GOVUK-ABTest-Example "; expires=" now + 1d;
   }
+
+  # Set A/B cookie for ABTest-EducationNavigation valid for 1 year
   if (req.http.Cookie !~ "ABTest-EducationNavigation" || req.url ~ "[\?\&]ABTest-EducationNavigation=" || req.url ~ "^/education(\/|\?|$)") {
     add resp.http.Set-Cookie = "ABTest-EducationNavigation=" req.http.GOVUK-ABTest-EducationNavigation "; expires=" now + 365d "; path=/";
   }
 
+  # Set A/B cookie for ABTest-Benchmarking valid for 7 days only
+  if (req.http.Cookie !~ "ABTest-Benchmarking" || req.url ~ "[\?\&]ABTest-Benchmarking=") {
+    add resp.http.Set-Cookie = "ABTest-Benchmarking=" req.http.GOVUK-ABTest-Benchmarking"; expires=" now + 7d "; path=/";
+  }
 
   # Set the TLS version session cookie with the raw protocol version from
   # Fastly only if it isn't already set. We also check for a null TLS value,


### PR DESCRIPTION
### Background

We are going to be running a new A/B test for the GOV.UK benchmarking
task. In this A/B test, which should last less than 1 week, we will be
adding a tracking library so we understand how users interact with the
new navigation pages we have exposed for Education content.

### Changes

In this commit we add rules to set the ABTest-Benchmarking cookie based
on a few things.

On `vcl_recv`:

- If the user visits GOV.UK with a parameter like
  `?ABTest-Benchmarking=B`, we will use that value to set the header
  accordingly, so the application knows what variant to render (and set
  the `Vary` header appropriately);
- If the user already has a cookie set, we use that value in the
  header, so the application knows what variant to render (and set
  the `Vary` header appropriately);
- Finally, for anyone else, we always put them in the `A` bucket,
  because we only want to track users in the benchmarking test and no
  one else.

On `vcl_deliver`, on the first visit, we set the cookie and make sure
it expires after 7 days.

Trello: https://trello.com/c/NJ6O76BR/281-heatmap-tracking