### PR TITLE
Serve an empty response direct from Fastly

### DIFF
--- a/vcl_templates/assets.vcl.erb
+++ b/vcl_templates/assets.vcl.erb
@@ -153,6 +153,11 @@ sub vcl_recv {
      error 801 "Force SSL";
   }
 
+  # Serve and log an empty response for analytics purposes
+  if (req.url ~ "^/static/a\?") {
+     error 802 "Empty for analytics logging";
+  }
+
   # Serve from stale for 24 hours if origin is sick
   set req.grace = 24h;
 
@@ -265,6 +270,13 @@ sub vcl_error {
     set obj.http.Location = "https://" req.http.host req.url;
     synthetic {""};
     return (deliver);
+  }
+
+  if (obj.status == 802) {
+    set obj.http.Content-Type = "text/plain";
+    set obj.status = 200;
+    synthetic {""};
+    return(deliver);
   }
 
   # Assume we've hit vcl_error() because the backend is unavailable


### PR DESCRIPTION
This will be used to store logs of the requests from the tracking
Javascript.