### PR TITLE
Send a CORS header with the analytics response

### DIFF
--- a/vcl_templates/assets.vcl.erb
+++ b/vcl_templates/assets.vcl.erb
@@ -274,6 +274,7 @@ sub vcl_error {
 
   if (obj.status == 802) {
     set obj.http.Content-Type = "text/plain";
+    set obj.http.Access-Control-Allow-Origin = "*";
     set obj.status = 200;
     synthetic {""};
     return(deliver);


### PR DESCRIPTION
Without this change, browsers warn that they’re not allowed to use the
response. Our code isn’t using the response anyway, but we shouldn’t be
throwing Javascript errors. Returning this header stops those errors
being raised.