### PR TITLE
Change VCL templating

### DIFF
--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -253,28 +253,30 @@ sub vcl_recv {
 
   # Begin dynamic section
   <% ab_tests.each do |test| %>
-  if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
-    set req.http.GOVUK-ABTest-<%= test['name'] %> = "A";
+  if (table.lookup(active_ab_tests, "<%= test %>") == "true") {
+    if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
+      set req.http.GOVUK-ABTest-<%= test %> = "A";
 
-  } else if (req.url ~ "[\?\&]ABTest-<%= test['name'] %>=A(&|$)") {
-    # Some users, such as remote testers, will be given a URL with a query string
-    # to place them into a specific bucket.
-    set req.http.GOVUK-ABTest-<%= test['name'] %> = "A";
+    } else if (req.url ~ "[\?\&]ABTest-<%= test %>=A(&|$)") {
+      # Some users, such as remote testers, will be given a URL with a query string
+      # to place them into a specific bucket.
+      set req.http.GOVUK-ABTest-<%= test %> = "A";
 
-  } else if (req.url ~ "[\?\&]ABTest-<%= test['name'] %>=B(&|$)") {
-    # Some users, such as remote testers, will be given a URL with a query string
-    # to place them into a specific bucket.
-    set req.http.GOVUK-ABTest-<%= test['name'] %> = "B";
+    } else if (req.url ~ "[\?\&]ABTest-<%= test %>=B(&|$)") {
+      # Some users, such as remote testers, will be given a URL with a query string
+      # to place them into a specific bucket.
+      set req.http.GOVUK-ABTest-<%= test %> = "B";
 
-  } else if (req.http.Cookie ~ "ABTest-<%= test['name'] %>") {
-    # Set the value of the header to whatever decision was previously made
-    set req.http.GOVUK-ABTest-<%= test['name'] %> = req.http.Cookie:ABTest-<%= test['name'] %>;
+    } else if (req.http.Cookie ~ "ABTest-<%= test %>") {
+      # Set the value of the header to whatever decision was previously made
+      set req.http.GOVUK-ABTest-<%= test %> = req.http.Cookie:ABTest-<%= test %>;
 
-  } else {
-    if (randombool(<%= test['b_percentage'] %>, 100)) {
-      set req.http.GOVUK-ABTest-<%= test['name'] %> = "B";
     } else {
-      set req.http.GOVUK-ABTest-<%= test['name'] %> = "A";
+      if (randombool(std.atoi(table.lookup(ab_test_b_percentages, "<%= test %>")), 100)) {
+        set req.http.GOVUK-ABTest-<%= test %> = "B";
+      } else {
+        set req.http.GOVUK-ABTest-<%= test %> = "A";
+      }
     }
   }
   <% end %>
@@ -385,9 +387,13 @@ sub vcl_deliver {
   }
 
   # Begin dynamic section
+  declare local var.expiry TIME;
   <% ab_tests.each do |test| %>
-  if (req.http.Cookie !~ "ABTest-<%= test['name'] %>" || req.url ~ "[\?\&]ABTest-<%= test['name'] %>" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
-    add resp.http.Set-Cookie = "ABTest-<%= test['name'] %>=" req.http.GOVUK-ABTest-<%= test['name'] %> "; expires=" now + <%= test['expiry'] %> "; path=/";
+  if (table.lookup(active_ab_tests, "<%= test %>") == "true") {
+    if (req.http.Cookie !~ "ABTest-<%= test %>" || req.url ~ "[\?\&]ABTest-<%= test %>" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
+      set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "<%= test %>"))));
+      add resp.http.Set-Cookie = "ABTest-<%= test %>=" req.http.GOVUK-ABTest-<%= test %> "; expires=" var.expiry "; path=/";
+    }
   }
   <% end %>
   # End dynamic section


### PR DESCRIPTION
We can now use a hybrid system which allows us to enable/disable tests as well as change certain settings without having to deploy Fastly each time.

[Dictionaries PR](https://github.digital.cabinet-office.gov.uk/gds/cdn-configs/pull/124)
[Fastly Config PR](https://github.com/alphagov/fastly-configure/pull/25)

https://trello.com/c/HOV2ChJ9/104-simplify-a-b-test-cdn-configuration