### PR TITLE
Add blue box ab test

### DIFF
--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -244,7 +244,7 @@ sub vcl_recv {
     # Set the value of the header to whatever decision was previously made
     set req.http.GOVUK-ABTest-EducationNavigation = req.http.Cookie:ABTest-EducationNavigation;
   } else {
-    if (randombool(3,10)) {
+    if (randombool(5,10)) {
       set req.http.GOVUK-ABTest-EducationNavigation = "B";
     } else {
       set req.http.GOVUK-ABTest-EducationNavigation = "A";

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -246,6 +246,16 @@ sub vcl_recv {
   } else {
     if (randombool(5,10)) {
       set req.http.GOVUK-ABTest-EducationNavigation = "B";
+
+      # On only new sessions assigned to the new navigation, we should split the
+      # traffic so 50% see the new blue box and the other 50% don't.
+      if (randombool(5,10)) {
+        # This is equivalent to the A group, or control group
+        set req.http.GOVUK-ABTest-NavigationTest = "NoBlueBox";
+      } else {
+        # This is equivalent to the B group, with modifications
+        set req.http.GOVUK-ABTest-NavigationTest = "ShowBlueBox";
+      }
     } else {
       set req.http.GOVUK-ABTest-EducationNavigation = "A";
     }
@@ -384,6 +394,10 @@ sub vcl_deliver {
   }
   if (req.http.Cookie !~ "ABTest-EducationNavigation" || req.url ~ "[\?\&]ABTest-EducationNavigation=" || req.url ~ "^/education(\/|\?|$)") {
     add resp.http.Set-Cookie = "ABTest-EducationNavigation=" req.http.GOVUK-ABTest-EducationNavigation "; expires=" now + 365d "; path=/";
+  }
+
+  if (req.http.Cookie !~ "ABTest-NavigationTest" || req.url ~ "[\?\&]ABTest-NavigationTest=" || req.url ~ "^/education(\/|\?|$)") {
+    add resp.http.Set-Cookie = "ABTest-NavigationTest=" req.http.GOVUK-ABTest-NavigationTest "; expires=" now + 30d "; path=/";
   }
 
   # Begin dynamic section


### PR DESCRIPTION
In this PR:

- increase the number of users that see the new navigation on Education content to 50%, so we can increase the pool of users that will try the new A/B test below;
- add the header and cookie to all users that will be seeing the existing EducationNavigation A/B test. We split those users into 2 groups: 50% will see things unchanged (control) and the other 50% will see the new pattern, a blue box. The cookie is set to expire after 45 days, which means that by then we would have either removed the blue box or add it to everyone.

Trello: https://trello.com/c/S5jp2jih/179-setup-technical-implementation-for-a-b-testing-the-blue-box

When both dependencies are merged, we can then go ahead and deploy this. The changes to the A/B testing gem will allow for verbose variant names.
