### PR TITLE
Revert "Add blue box A/B test for users in new NavigationTest"

### DIFF
--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -227,6 +227,7 @@ sub vcl_recv {
     }
   }
 
+
   if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
     set req.http.GOVUK-ABTest-EducationNavigation = "A";
   # Some users, such as remote testers, will be given a URL with a query string
@@ -247,20 +248,6 @@ sub vcl_recv {
       set req.http.GOVUK-ABTest-EducationNavigation = "B";
     } else {
       set req.http.GOVUK-ABTest-EducationNavigation = "A";
-    }
-  }
-
-  if (req.url ~ "[\?\&]ABTest-NavigationTest=NoBlueBox(&|$)") {
-    set req.http.GOVUK-ABTest-NavigationTest = "NoBlueBox";
-  } else if (req.url ~ "[\?\&]ABTest-NavigationTest=ShowBlueBox(&|$)") {
-    set req.http.GOVUK-ABTest-NavigationTest = "ShowBlueBox";
-  } else if (req.http.Cookie ~ "ABTest-NavigationTest") {
-    set req.http.GOVUK-ABTest-NavigationTest = req.http.Cookie:ABTest-NavigationTest;
-  } else if (req.http.GOVUK-ABTest-EducationNavigation ~ "B") {
-    if (randombool(5,10)) {
-      set req.http.GOVUK-ABTest-NavigationTest = "ShowBlueBox";
-    } else {
-      set req.http.GOVUK-ABTest-NavigationTest = "NoBlueBox";
     }
   }
 
@@ -399,14 +386,6 @@ sub vcl_deliver {
   }
   if (req.http.Cookie !~ "ABTest-EducationNavigation" || req.url ~ "[\?\&]ABTest-EducationNavigation=" || req.url ~ "^/education(\/|\?|$)") {
     add resp.http.Set-Cookie = "ABTest-EducationNavigation=" req.http.GOVUK-ABTest-EducationNavigation "; expires=" now + 365d "; path=/";
-  }
-
-  # Only set the Blue Box cookie if we are on the B group of EducationNavigation
-  # test.
-  if (req.http.GOVUK-ABTest-EducationNavigation ~ "B") {
-    if (req.http.Cookie !~ "ABTest-NavigationTest" || req.url ~ "[\?\&]ABTest-NavigationTest=" || req.url ~ "^/education(\/|\?|$)") {
-      add resp.http.Set-Cookie = "ABTest-NavigationTest=" req.http.GOVUK-ABTest-NavigationTest "; expires=" now + 30d "; path=/";
-    }
   }
 
   # Begin dynamic section


### PR DESCRIPTION
This reverts commit 5cc21d7db46b305f89301af1a5fe67a0572cce68.

The A/B test is now complete and we are rolling out blue boxes to all
accordion pages to users in the new navigation.

More details here: https://github.com/alphagov/collections/pull/360

Trello: https://trello.com/c/U50vnFY8/36-navbeta-going-100-with-the-blue-box