### PR TITLE
Add cookie on childcare and parenting pages

### DIFF
--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -236,7 +236,7 @@ sub vcl_recv {
     set req.http.GOVUK-ABTest-EducationNavigation = "A";
   } else if (req.url ~ "[\?\&]ABTest-EducationNavigation=B(&|$)") {
     set req.http.GOVUK-ABTest-EducationNavigation = "B";
-  } else if (req.url ~ "^/education(\/|\?|$)") {
+  } else if (req.url ~ "^/education(\/|\?|$)" || req.url ~ "^/childcare-parenting(\/|\?|$)") {
     # If a user goes to a new navigation page, add them automatically to the B
     # group, so they can see a consistent navigation throughout.
     set req.http.GOVUK-ABTest-EducationNavigation = "B";
@@ -384,7 +384,10 @@ sub vcl_deliver {
     # Set a fairly short cookie expiry because this is just an A/B test demo.
     add resp.http.Set-Cookie = "ABTest-Example=" req.http.GOVUK-ABTest-Example "; expires=" now + 1d;
   }
-  if (req.http.Cookie !~ "ABTest-EducationNavigation" || req.url ~ "[\?\&]ABTest-EducationNavigation=" || req.url ~ "^/education(\/|\?|$)") {
+  if (req.http.Cookie !~ "ABTest-EducationNavigation"
+    || req.url ~ "[\?\&]ABTest-EducationNavigation="
+    || req.url ~ "^/education(\/|\?|$)"
+    || req.url ~ "^/childcare-parenting(\/|\?|$)") {
     add resp.http.Set-Cookie = "ABTest-EducationNavigation=" req.http.GOVUK-ABTest-EducationNavigation "; expires=" now + 365d "; path=/";
   }
 


### PR DESCRIPTION
This commit allows us to rollout the EducationNavigation A/B test to Childcare and Parenting navigation pages. By visiting those pages, users will be automatically assigned to the B variant of that A/B test, which means they will be able to see the new navigation across both navigation pages and content pages.

Note: the taxonomy isn't live yet, but once it's published this will start working. It's safe to deploy this change because it doesn't affect any other branch.

Trello: https://trello.com/c/Sa4FrnW2/66-update-cdn-configs-to-include-parenting-childcare-root-taxon

### Test

This has been tested in staging:
- deploy link: https://deploy.staging.publishing.service.gov.uk/job/Deploy_CDN/162/console
- branch in fastly-configure: https://github.com/alphagov/fastly-configure/compare/test-cdn-config-branch-rollout-parenting-childcare?expand=1

#### First visit, Set-Cookie and Vary header set appropriately

<img width="1440" alt="screen shot 2017-07-24 at 11 24 18" src="https://user-images.githubusercontent.com/416701/28519523-d8e70f50-7063-11e7-9b87-cc76266bcc10.png">

#### Cookie set for subsequent page views

<img width="1440" alt="screen shot 2017-07-24 at 11 22 42" src="https://user-images.githubusercontent.com/416701/28519532-e2b14c30-7063-11e7-98a7-1d6c895a47f1.png">
