### PR TITLE
Remove Education nav AB test config

### DIFF
--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -213,29 +213,6 @@ sub vcl_recv {
     return(pass);
   }
 
-  if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
-    set req.http.GOVUK-ABTest-EducationNavigation = "A";
-  # Some users, such as remote testers, will be given a URL with a query string
-  # to place them into a specific bucket.
-  } else if (req.url ~ "[\?\&]ABTest-EducationNavigation=A(&|$)") {
-    set req.http.GOVUK-ABTest-EducationNavigation = "A";
-  } else if (req.url ~ "[\?\&]ABTest-EducationNavigation=B(&|$)") {
-    set req.http.GOVUK-ABTest-EducationNavigation = "B";
-  } else if (req.url ~ "^/education(\/|\?|$)" || req.url ~ "^/childcare-parenting(\/|\?|$)") {
-    # If a user goes to a new navigation page, add them automatically to the B
-    # group, so they can see a consistent navigation throughout.
-    set req.http.GOVUK-ABTest-EducationNavigation = "B";
-  } else if (req.http.Cookie ~ "ABTest-EducationNavigation") {
-    # Set the value of the header to whatever decision was previously made
-    set req.http.GOVUK-ABTest-EducationNavigation = req.http.Cookie:ABTest-EducationNavigation;
-  } else {
-    if (randombool(5,10)) {
-      set req.http.GOVUK-ABTest-EducationNavigation = "B";
-    } else {
-      set req.http.GOVUK-ABTest-EducationNavigation = "A";
-    }
-  }
-
   <% template_path = File.join(File.dirname(__FILE__), "vcl_templates/_multivariate_tests.vcl.erb") -%>
   <%= ERB.new(File.new(template_path).read, nil, "-", "_erbout2").result(binding) %>
 
@@ -338,12 +315,6 @@ sub vcl_deliver {
     && req.http.Cookie !~ "ABTest-Example") {
     # Set a fairly short cookie expiry because this is just an A/B test demo.
     add resp.http.Set-Cookie = "ABTest-Example=" req.http.GOVUK-ABTest-Example "; expires=" now + 1d;
-  }
-  if (req.http.Cookie !~ "ABTest-EducationNavigation"
-    || req.url ~ "[\?\&]ABTest-EducationNavigation="
-    || req.url ~ "^/education(\/|\?|$)"
-    || req.url ~ "^/childcare-parenting(\/|\?|$)") {
-    add resp.http.Set-Cookie = "ABTest-EducationNavigation=" req.http.GOVUK-ABTest-EducationNavigation "; expires=" now + 365d "; path=/";
   }
 
   # Begin dynamic section


### PR DESCRIPTION
https://trello.com/c/WT9haiUu/59-remove-all-remaining-parts-of-education-navigation-ab-test-logic

The education navigation AB test is being removed.
This PR reverts https://github.com/alphagov/govuk-cdn-config/pull/29

DNM because we need to deploy this and other PRs in a specific order