### PR TITLE
Add the backend name to response header for assets service

### DIFF
--- a/vcl_templates/assets.vcl.erb
+++ b/vcl_templates/assets.vcl.erb
@@ -214,6 +214,8 @@ sub vcl_recv {
 sub vcl_fetch {
 #FASTLY fetch
 
+  set beresp.http.Fastly-Backend-Name = req.http.Fastly-Backend-Name;
+
   if ((beresp.status >= 500 && beresp.status <= 599) && req.restarts < 3 && (req.request == "GET" || req.request == "HEAD") && !beresp.http.No-Fallback) {
     set beresp.saintmode = 5s;
     return (restart);


### PR DESCRIPTION
This mimics the behaviour of the www service and might assist in
debugging the issue where Word documents are delivered to the browser
as plaintext.

Copied from https://github.com/alphagov/govuk-cdn-config/blob/master/vcl_templates/www.vcl.erb#L234