### PR TITLE
Experiment with preloading the font

### DIFF
--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -335,6 +335,10 @@ sub vcl_deliver {
 <% end # if -%>
   # End dynamic section
 
+  # Experiment with preloading the font. Tijmen will remove this after the 28th
+  # of February (if it's still there after that time, please remind him).
+  add resp.http.Link = "<//assets.publishing.service.gov.uk/static/fonts-5ff8c53913434afd0072a480d7cfca67cace4c8d03f6ef96b78a4455728ce745.css>; rel=preload; as=style; nopush";
+
   # Set the TLS version session cookie with the raw protocol version from
   # Fastly only if it isn't already set. We also check for a null TLS value,
   # which can occur when trying to access over HTTP (http>https upgrading).


### PR DESCRIPTION
This extra header is [used by supporting browsers to preload the font](https://www.w3.org/TR/preload/#early-fetch-of-critical-resources) (our biggest asset). This means that the browser can load the file in parallel with the other work to load the page, it doesn't have to wait before the DOM is loaded. This is an experiment to see if it makes a difference in the performance of GOV.UK.

Initial tests on staging are inconclusive, but it's hard to test this because staging doesn't have an SSL certificate so our speed test software can't look at it. I intend to run this on GOV.UK for a few
weeks and use Speedcurve to monitor differences.

If we were going to use this, we'd obviously have to figure out a way to make sure this URL doesn't go out of date. It hasn't changed in 4 years, but might soon.

## Header format

The header format is `<URL> as=style; rel=preload; nopush`.

- `as=style` tells the browser that this is CSS (https://www.w3.org/TR/preload/#as-attribute)
- `rel=preload` tells the browser to preload (there's also prefetch https://www.w3.org/TR/resource-hints/#dfn-prefetch)
- `nopush` is used to tell the browser to not do a HTTP2 server push. I think this is to prevent a HTTP capable server from sending the asset that is likely to be cached by the user already https://www.w3.org/TR/preload/#server-push-http-2. I'm not a 100% certain about this, but it's what the Financial Times uses:

```
 @tijmenb ~ $ curl -sI https://www.ft.com | grep preload
Link: <//www.ft.com/__assets/hashed/front-page/68e84d8a/main.css>; as="style"; rel="preload"; nopush, <//www.ft.com/__assets/hashed/front-page/ac64daf4/teaser-promoted.css>; as="style"; rel="preload"; nopush, <//www.ft.com/__assets/hashed/front-page/ce181dd7/teaser-syndicated.css>; as="style"; rel="preload"; nopush, <//www.ft.com/__assets/hashed/front-page/13f4040a/teaser-small.css>; as="style"; rel="preload"; nopush, <//www.ft.com/__assets/hashed/front-page/1c307cd3/teaser-video.css>; as="style"; rel="preload"; nopush, <//www.ft.com/__assets/hashed/front-page/803601a7/teaser-live.css>; as="style"; rel="preload"; nopush, <https://www.ft.com/__origami/service/polyfill/v2/polyfill.min.js?features=default,requestAnimationFrame,Promise,matchMedia,HTMLPictureElement,fetch,Array.prototype.find,Array.prototype.findIndex,Array.prototype.includes,IntersectionObserver,Map,Array.from,NodeList.prototype.@@iterator,Array.prototype.@@iterator,EventSource&flags=gated&source=next&unknown=polyfill>; as="script"; rel="preload"; nopush, <//www.ft.com/__assets/hashed/n-ui/43aaa5d7/font-loader.js>; as="script"; rel="preload"; nopush, <//www.ft.com/__assets/hashed/n-ui/681ad877/o-errors.js>; as="script"; rel="preload"; nopush, <//www.ft.com/__assets/hashed/n-ui/2dbd7036/es5.js>; as="script"; rel="preload"; nopush, <//www.ft.com/__assets/hashed/front-page/2a0b6942/main.js>; as="script"; rel="preload"; nopush, <https://www.ft.com/__origami/service/image/v2/images/raw/ftlogo:brand-ft-masthead?source=o-header&tint=%2333302E,%2333302E&format=svg>; as="image"; rel="preload"; nopush, <https://www.ft.com/__graphics/german-election-2017/widget.html>; as="document"; rel="preload"; nopush
```

## Proof that this works (on staging)

Before:

![screen shot 2018-02-01 at 17 00 25](https://user-images.githubusercontent.com/233676/35691802-6b3e9324-0771-11e8-8796-2940127aef28.png)

After, you'll see the "Other" under "initiator":

![screen shot 2018-02-01 at 17 00 19](https://user-images.githubusercontent.com/233676/35691801-6b1aea46-0771-11e8-899b-ad99bddb3425.png)


https://trello.com/c/G1iddwUO/42-preload-assets-for-speed