### PR TITLE
Add TLS header for Licensify requests

### DIFF
--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -207,6 +207,11 @@ sub vcl_recv {
   # Unspoofable original client address.
   set req.http.True-Client-IP = req.http.Fastly-Client-IP;
 
+  # Set TLS version request header for requests to the Licensify application
+  if (req.url ~ "^/apply-for-a-licence/.*") {
+    set req.http.TLSversion = tls.client.protocol;
+  }
+
 #FASTLY recv
 
   if (req.request != "HEAD" && req.request != "GET" && req.request != "FASTLYPURGE") {

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -207,7 +207,8 @@ sub vcl_recv {
   # Unspoofable original client address.
   set req.http.True-Client-IP = req.http.Fastly-Client-IP;
 
-  # Set TLS version request header for requests to the Licensify application
+  # Set a TLSversion request header for requests going to the Licensify application
+  # This is used to block unsecure requests at the application level for payment security reasons and an absence of caching in Licensify
   if (req.url ~ "^/apply-for-a-licence/.*") {
     set req.http.TLSversion = tls.client.protocol;
   }


### PR DESCRIPTION
Added a request header containing the TLS version number for requests to the Licensify app
(This is so we can block requests with TLS versions below 1.2 for payment security reasons)