### PR TITLE
Remove font preloading

### DIFF
--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -341,10 +341,6 @@ sub vcl_deliver {
 <% end # if -%>
   # End dynamic section
 
-  # Experiment with preloading the font. Tijmen will remove this after the 28th
-  # of February (if it's still there after that time, please remind him).
-  add resp.http.Link = "<//assets.publishing.service.gov.uk/static/fonts-5ff8c53913434afd0072a480d7cfca67cace4c8d03f6ef96b78a4455728ce745.css>; rel=preload; as=style; nopush";
-
   # Set the TLS version session cookie with the raw protocol version from
   # Fastly only if it isn't already set. We also check for a null TLS value,
   # which can occur when trying to access over HTTP (http>https upgrading).


### PR DESCRIPTION
This preloading of the font has been in place since Feb 1st (https://github.com/alphagov/govuk-cdn-config/pull/64). This commit rolls it back because:

- We are likely to be start implementing a different font loading strategy, which makes use of WOFF and WOFF2 compression. At this point we can't preload the font because this would likely result in extra downloads (all users would get the WOFF2, even if they won't use it).
- Chrome seems to be loading the font twice. This could be caused by the absence of the `crossorigin` in the preload header, but we don't know for sure.