### PR TITLE
Revert "Add TLS header for Licensify requests"

### DIFF
--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -207,12 +207,6 @@ sub vcl_recv {
   # Unspoofable original client address.
   set req.http.True-Client-IP = req.http.Fastly-Client-IP;
 
-  # Set a TLSversion request header for requests going to the Licensify application
-  # This is used to block unsecure requests at the application level for payment security reasons and an absence of caching in Licensify
-  if (req.url ~ "^/apply-for-a-licence/.*") {
-    set req.http.TLSversion = tls.client.protocol;
-  }
-
 #FASTLY recv
 
   if (req.request != "HEAD" && req.request != "GET" && req.request != "FASTLYPURGE") {


### PR DESCRIPTION
Reverts alphagov/govuk-cdn-config#65. This was tested on staging but doesn't seem to work. More investigation is required.

cc @PeteLeaman 