### PR TITLE
 Add TLS header for Licensify requests

### DIFF
--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -236,6 +236,12 @@ sub vcl_recv {
 
   }
 
+  # Set a TLSversion request header for requests going to the Licensify application
+  # This is used to block unsecure requests at the application level for payment security reasons and an absence of caching in Licensify
+  if (req.url ~ "^/apply-for-a-licence/.*") {
+    set req.http.TLSversion = tls.client.protocol;
+  }
+
   return(lookup);
 }
 


### PR DESCRIPTION
Added a request header containing the TLS version number for requests to the Licensify app
- Previous [attempt  ](https://github.com/alphagov/govuk-cdn-config/pull/68) failed and the request header & value wasn't showing on /apply-for-a-licence/ pages
- Trying again with the code below the '#FASTLY recv' comment as this may affect it as shown [here](https://community.fastly.com/t/troubleshooting-tips-for-your-custom-vcl-upload/462)