### PR TITLE
Revert "Add TLS header for Licensify requests"

### DIFF
--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -231,12 +231,6 @@ sub vcl_recv {
 
   }
 
-  # Set a TLSversion request header for requests going to the Licensify application
-  # This is used to block unsecure requests at the application level for payment security reasons and an absence of caching in Licensify
-  if (req.url ~ "^/apply-for-a-licence/.*") {
-    set req.http.TLSversion = tls.client.protocol;
-  }
-
   return(lookup);
 }
 


### PR DESCRIPTION
Reverts alphagov/govuk-cdn-config#71. The previous change in alphagov/govuk-cdn-config#68 (which was never reverted) did work after all.