### PR TITLE
Add basic auth header to healthcheck when present

### DIFF
--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -25,6 +25,9 @@ backend F_origin {
 <% if config['rate_limit_token'] %>
             "Rate-Limit-Token: <%= config['rate_limit_token'] %>"
 <% end %>
+<% if config['basic_authentication'] %>
+            "Authorization: Basic <%= config['base_authentication'] %>"
+<% end %>
             "Connection: close";
         .threshold = 1;
         .window = 2;


### PR DESCRIPTION
https://trello.com/c/vX7ZC4fb/673-work-out-why-some-paths-return-an-error-message-when-using-the-integration-cdn

Integration www backend healthchecks from Fastly have been failing with 401
so I'm assuming a basic auth header will allow the check to be made successfully.

Depends on https://github.com/alphagov/cdn-configs/pull/75