### PR TITLE
Forward basic auth header to origin when present

### DIFF
--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -22,12 +22,12 @@ backend F_origin {
             "HEAD / HTTP/1.1"
             "Host: <%= config.fetch('origin_hostname') %>"
             "User-Agent: Fastly healthcheck (git version: <%= config['git_version'] %>)"
-<% if config['rate_limit_token'] %>
+<% if config['rate_limit_token'] -%>
             "Rate-Limit-Token: <%= config['rate_limit_token'] %>"
-<% end %>
-<% if config['basic_authentication'] %>
+<% end -%>
+<% if config['basic_authentication'] -%>
             "Authorization: Basic <%= config['basic_authentication'] %>"
-<% end %>
+<% end -%>
             "Connection: close";
         .threshold = 1;
         .window = 2;
@@ -230,6 +230,12 @@ sub vcl_recv {
   if (req.url ~ "^/apply-for-a-licence/.*") {
     set req.http.TLSversion = tls.client.protocol;
   }
+
+<% if config['basic_authentication'] -%>
+  if (req.backend == F_origin) {
+    set req.http.Authorization = "Basic <%= config['basic_authentication'] %>";
+  }
+<% end -%>
 
 #FASTLY recv
 


### PR DESCRIPTION
https://trello.com/c/vX7ZC4fb/673-work-out-why-some-paths-return-an-error-message-when-using-the-integration-cdn

After some advice from Fastly we think this might solve the failing (401) requests to origin.
Also tidy up whitespace in healthcheck headers.

Relevant also to a typo fix here https://github.com/alphagov/cdn-configs/pull/76