### PR TITLE
Remove basic auth realm for integration

### DIFF
--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -400,7 +400,7 @@ sub vcl_error {
 
   <% if config['basic_authentication'] %>
   if (obj.status == 401) {
-    set obj.http.WWW-Authenticate = "Basic realm=Enter the GOV.UK username/password (not your personal username/password)";
+    set obj.http.WWW-Authenticate = "Basic";
     synthetic {""};
     return (deliver);
   }


### PR DESCRIPTION
Safari doesn’t like the realm name with spaces in it, and it’s not necessary.