### PR TITLE
Experiment with CSP

### DIFF
--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -379,6 +379,8 @@ sub vcl_deliver {
     add resp.http.Set-Cookie = "TLSversion=" tls.client.protocol "; secure";
   }
 
+  add resp.http.Content-Security-Policy-Report-Only = "default-src https 'self' *.publishing.service.gov.uk; img-src 'self' www.google-analytics.com *.publishing.service.gov.uk; script-src 'self' www.google-analytics.com *.publishing.service.gov.uk 'sha256-G29/qSW/JHHANtFhlrZVDZW1HOkCDRc78ggbqwwIJ2g=' 'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU='; style-src 'self' *.publishing.service.gov.uk 'unsafe-inline'; report-uri https://sentry.io/api/1377947/security/?sentry_key=f7898bf4858d436aa3568ae042371b94;"
+
   # Set the Javascript detection cookie
   if (req.http.User-Agent !~ "^GOV\.UK Crawler Worker" && req.http.Cookie !~ "JS-Detection") {
     add resp.http.Set-Cookie = "JS-Detection=" req.http.GOVUK-JS-Detection "; expires=" now + 5w "; path=/";


### PR DESCRIPTION
This introduces a report-only Content Security Policy (CSP) for GOV.UK.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy

> The HTTP Content-Security-Policy response header allows web site administrators to control resources the user agent is allowed to load for a given page. With a few exceptions, policies mostly involve specifying server origins and script endpoints. This helps guard against cross-site scripting attacks (XSS).

I designed the policy in government-frontend, this being the commented source:

```
# By default, only allow HTTPS connections, and allow usage of
*.publishing.service.gov.uk
"default-src https 'self' *.publishing.service.gov.uk;",

# Allow images from the current domain, Google Analytics (the tracking
pixel), and publishing domains.
"img-src 'self' www.google-analytics.com *.publishing.service.gov.uk;",

# Allow scripts from the current domain, Google Analytics, publishing
domains, and 2 scripts:
"script-src 'self' www.google-analytics.com *.publishing.service.gov.uk
" +

# Allow
https://github.com/alphagov/govuk_template/blob/79340eb91ad8c4279d16da30
2765d0946d89b1ca/source/views/layouts/govuk_template.html.erb#L40
"'sha256-G29/qSW/JHHANtFhlrZVDZW1HOkCDRc78ggbqwwIJ2g=' " +

# Allow
https://github.com/alphagov/govuk_template/blob/79340eb91ad8c4279d16da30
2765d0946d89b1ca/source/views/layouts/govuk_template.html.erb#L112-L113
"'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU=';",

# Allow styles from own domain and publishing domains. Also allow
"unsafe-inline" styles,
# because we use the `style` attribute on some HTML elements.
"style-src 'self' *.publishing.service.gov.uk 'unsafe-inline';",

# Report any violations to Sentry
(https://sentry.io/govuk/govuk-frontend-csp)
"report-uri
https://sentry.io/api/1377947/security/?sentry_key=f7898bf4858d436aa3568
ae042371b94;"
```

I intend to run this on GOV.UK for a bit and then revert it, so that we can analyse the results. The violations will be sent to https://sentry.io/govuk/govuk-frontend-csp.

https://trello.com/c/ml5fQQxS