### PR TITLE
serve a 404 page if the request url has autodiscover in it

### DIFF
--- a/vcl_templates/bouncer.vcl.erb
+++ b/vcl_templates/bouncer.vcl.erb
@@ -107,6 +107,12 @@ sub vcl_recv {
     return(pass);
   }
 
+  # Serve a 404 Not Found response if request URL matches "/autodiscover/autodiscover.xml"
+  # This is to avoid a Denial of Service "attack" from certain government machines.
+  if (req.url ~ "(?i)^/autodiscover/autodiscover.xml") {
+    error 404 "Not Found";
+  }
+
   return(lookup);
 }
 

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -262,6 +262,10 @@ sub vcl_recv {
 
   }
 
+  if (req.url ~ "(?i)^/autodiscover/autodiscover.xml") {
+    error 404 "Not Found";
+  }
+
   return(lookup);
 }
 


### PR DESCRIPTION
# Context

This morning 24 January 2019, there has been a large number of POST request to the URL: https://www.gov.uk/AutoDiscover/autodiscover.xml which put a large amount of strain on the cache machines. The originators of the requests seems to be from government machines.

Further details on the analysis is from Kibana dashboard [here](https://kibana.logit.io/s/0ea55710-075b-4eab-bfc3-475f28cdd0c3/app/kibana#/discover?_g=(refreshInterval:(display:Off,pause:!f,value:0),time:(from:now-4h,mode:quick,to:now))&_a=(columns:!(request,status),filters:!(),index:%27*-*%27,interval:auto,query:(query_string:(analyze_wildcard:!t,query:%27429%27)),sort:!(%27@timestamp%27,desc)))

# Decisions
1. After discussion with 2nd line and platform health, it was decided to block `AutoDiscover/autodiscover.xml` urls to gov.uk by modify the fastly config.