### PR TITLE
Test VCL against previously generated files

### DIFF
--- a/spec/test-outputs/apt-integration.out.vcl
+++ b/spec/test-outputs/apt-integration.out.vcl
@@ -1,0 +1,123 @@
+# Backends
+backend F_apt {
+    .connect_timeout = 1s;
+    .dynamic = true;
+    .port = "80";
+    .host = "foo";
+    .first_byte_timeout = 15s;
+    .max_connections = 200;
+    .between_bytes_timeout = 10s;
+    .share_key = "123";
+
+    .probe = {
+        .request =
+          "HEAD / HTTP/1.1"
+          "Host: foo"
+          "Connection: close";
+        .window = 5;
+        .threshold = 1;
+        .timeout = 2s;
+        .initial = 5;
+        .dummy = true;
+      }
+}
+
+sub vcl_recv {
+#FASTLY recv
+
+    # Prevent third parties from flushing CDN caches with FASTLYPURGE
+    if (req.request == "FASTLYPURGE") {
+      error 403 "Forbiddden";
+    }
+
+    # Unspoofable original client address
+    set req.http.True-Client-IP = req.http.Fastly-Client-IP;
+
+    if (req.request != "HEAD" && req.request != "GET" && req.request != "FASTLYPURGE") {
+      return(pass);
+    }
+
+    return(lookup);
+}
+
+sub vcl_fetch {
+#FASTLY fetch
+
+  if ((beresp.status == 500 || beresp.status == 503) && req.restarts < 1 && (req.request == "GET" || req.request == "HEAD")) {
+    restart;
+  }
+
+  if(req.restarts > 0 ) {
+    set beresp.http.Fastly-Restarts = req.restarts;
+  }
+
+  if (beresp.http.Set-Cookie) {
+    set req.http.Fastly-Cachetype = "SETCOOKIE";
+    return (pass);
+  }
+
+  if (beresp.http.Cache-Control ~ "private") {
+    set req.http.Fastly-Cachetype = "PRIVATE";
+    return (pass);
+  }
+
+  if (beresp.status == 500 || beresp.status == 503) {
+    set req.http.Fastly-Cachetype = "ERROR";
+    set beresp.ttl = 1s;
+    set beresp.grace = 5s;
+    return (deliver);
+  }
+
+  if (beresp.http.Expires || beresp.http.Surrogate-Control ~ "max-age" || beresp.http.Cache-Control ~"(s-maxage|max-age)") {
+    # keep the ttl here
+  } else {
+    # apply the default ttl
+    set beresp.ttl = 3600s;
+  }
+
+  return(deliver);
+}
+
+sub vcl_hit {
+#FASTLY hit
+
+  if (!obj.cacheable) {
+    return(pass);
+  }
+  return(deliver);
+}
+
+sub vcl_miss {
+#FASTLY miss
+  return(fetch);
+}
+
+sub vcl_deliver {
+#FASTLY deliver
+  return(deliver);
+}
+
+sub vcl_error {
+#FASTLY error
+}
+
+sub vcl_pass {
+#FASTLY pass
+}
+
+sub vcl_hash {
+
+  #-FASTLY HASH CODE WITH GENERATION FOR PURGE ALL
+  #
+
+  #if unspecified fall back to normal
+  {
+
+    set req.hash += req.url;
+    set req.hash += req.http.host;
+    set req.hash += "#####GENERATION#####";
+    return (hash);
+  }
+  #--FASTLY END HASH CODE
+
+}

--- a/spec/test-outputs/apt-production.out.vcl
+++ b/spec/test-outputs/apt-production.out.vcl
@@ -1,0 +1,123 @@
+# Backends
+backend F_apt {
+    .connect_timeout = 1s;
+    .dynamic = true;
+    .port = "80";
+    .host = "foo";
+    .first_byte_timeout = 15s;
+    .max_connections = 200;
+    .between_bytes_timeout = 10s;
+    .share_key = "123";
+
+    .probe = {
+        .request =
+          "HEAD / HTTP/1.1"
+          "Host: foo"
+          "Connection: close";
+        .window = 5;
+        .threshold = 1;
+        .timeout = 2s;
+        .initial = 5;
+        .dummy = true;
+      }
+}
+
+sub vcl_recv {
+#FASTLY recv
+
+    # Prevent third parties from flushing CDN caches with FASTLYPURGE
+    if (req.request == "FASTLYPURGE") {
+      error 403 "Forbiddden";
+    }
+
+    # Unspoofable original client address
+    set req.http.True-Client-IP = req.http.Fastly-Client-IP;
+
+    if (req.request != "HEAD" && req.request != "GET" && req.request != "FASTLYPURGE") {
+      return(pass);
+    }
+
+    return(lookup);
+}
+
+sub vcl_fetch {
+#FASTLY fetch
+
+  if ((beresp.status == 500 || beresp.status == 503) && req.restarts < 1 && (req.request == "GET" || req.request == "HEAD")) {
+    restart;
+  }
+
+  if(req.restarts > 0 ) {
+    set beresp.http.Fastly-Restarts = req.restarts;
+  }
+
+  if (beresp.http.Set-Cookie) {
+    set req.http.Fastly-Cachetype = "SETCOOKIE";
+    return (pass);
+  }
+
+  if (beresp.http.Cache-Control ~ "private") {
+    set req.http.Fastly-Cachetype = "PRIVATE";
+    return (pass);
+  }
+
+  if (beresp.status == 500 || beresp.status == 503) {
+    set req.http.Fastly-Cachetype = "ERROR";
+    set beresp.ttl = 1s;
+    set beresp.grace = 5s;
+    return (deliver);
+  }
+
+  if (beresp.http.Expires || beresp.http.Surrogate-Control ~ "max-age" || beresp.http.Cache-Control ~"(s-maxage|max-age)") {
+    # keep the ttl here
+  } else {
+    # apply the default ttl
+    set beresp.ttl = 3600s;
+  }
+
+  return(deliver);
+}
+
+sub vcl_hit {
+#FASTLY hit
+
+  if (!obj.cacheable) {
+    return(pass);
+  }
+  return(deliver);
+}
+
+sub vcl_miss {
+#FASTLY miss
+  return(fetch);
+}
+
+sub vcl_deliver {
+#FASTLY deliver
+  return(deliver);
+}
+
+sub vcl_error {
+#FASTLY error
+}
+
+sub vcl_pass {
+#FASTLY pass
+}
+
+sub vcl_hash {
+
+  #-FASTLY HASH CODE WITH GENERATION FOR PURGE ALL
+  #
+
+  #if unspecified fall back to normal
+  {
+
+    set req.hash += req.url;
+    set req.hash += req.http.host;
+    set req.hash += "#####GENERATION#####";
+    return (hash);
+  }
+  #--FASTLY END HASH CODE
+
+}

--- a/spec/test-outputs/apt-staging.out.vcl
+++ b/spec/test-outputs/apt-staging.out.vcl
@@ -1,0 +1,123 @@
+# Backends
+backend F_apt {
+    .connect_timeout = 1s;
+    .dynamic = true;
+    .port = "80";
+    .host = "foo";
+    .first_byte_timeout = 15s;
+    .max_connections = 200;
+    .between_bytes_timeout = 10s;
+    .share_key = "123";
+
+    .probe = {
+        .request =
+          "HEAD / HTTP/1.1"
+          "Host: foo"
+          "Connection: close";
+        .window = 5;
+        .threshold = 1;
+        .timeout = 2s;
+        .initial = 5;
+        .dummy = true;
+      }
+}
+
+sub vcl_recv {
+#FASTLY recv
+
+    # Prevent third parties from flushing CDN caches with FASTLYPURGE
+    if (req.request == "FASTLYPURGE") {
+      error 403 "Forbiddden";
+    }
+
+    # Unspoofable original client address
+    set req.http.True-Client-IP = req.http.Fastly-Client-IP;
+
+    if (req.request != "HEAD" && req.request != "GET" && req.request != "FASTLYPURGE") {
+      return(pass);
+    }
+
+    return(lookup);
+}
+
+sub vcl_fetch {
+#FASTLY fetch
+
+  if ((beresp.status == 500 || beresp.status == 503) && req.restarts < 1 && (req.request == "GET" || req.request == "HEAD")) {
+    restart;
+  }
+
+  if(req.restarts > 0 ) {
+    set beresp.http.Fastly-Restarts = req.restarts;
+  }
+
+  if (beresp.http.Set-Cookie) {
+    set req.http.Fastly-Cachetype = "SETCOOKIE";
+    return (pass);
+  }
+
+  if (beresp.http.Cache-Control ~ "private") {
+    set req.http.Fastly-Cachetype = "PRIVATE";
+    return (pass);
+  }
+
+  if (beresp.status == 500 || beresp.status == 503) {
+    set req.http.Fastly-Cachetype = "ERROR";
+    set beresp.ttl = 1s;
+    set beresp.grace = 5s;
+    return (deliver);
+  }
+
+  if (beresp.http.Expires || beresp.http.Surrogate-Control ~ "max-age" || beresp.http.Cache-Control ~"(s-maxage|max-age)") {
+    # keep the ttl here
+  } else {
+    # apply the default ttl
+    set beresp.ttl = 3600s;
+  }
+
+  return(deliver);
+}
+
+sub vcl_hit {
+#FASTLY hit
+
+  if (!obj.cacheable) {
+    return(pass);
+  }
+  return(deliver);
+}
+
+sub vcl_miss {
+#FASTLY miss
+  return(fetch);
+}
+
+sub vcl_deliver {
+#FASTLY deliver
+  return(deliver);
+}
+
+sub vcl_error {
+#FASTLY error
+}
+
+sub vcl_pass {
+#FASTLY pass
+}
+
+sub vcl_hash {
+
+  #-FASTLY HASH CODE WITH GENERATION FOR PURGE ALL
+  #
+
+  #if unspecified fall back to normal
+  {
+
+    set req.hash += req.url;
+    set req.hash += req.http.host;
+    set req.hash += "#####GENERATION#####";
+    return (hash);
+  }
+  #--FASTLY END HASH CODE
+
+}

--- a/spec/test-outputs/assets-integration.out.vcl
+++ b/spec/test-outputs/assets-integration.out.vcl
@@ -1,0 +1,309 @@
+backend F_origin {
+    .connect_timeout = 5s;
+    .dynamic = true;
+    .port = "443";
+    .host = "foo";
+    .first_byte_timeout = 15s;
+    .max_connections = 200;
+    .between_bytes_timeout = 10s;
+    .share_key = "123";
+
+    .ssl = true;
+    .ssl_check_cert = always;
+    .min_tls_version = "1.2";
+    .ssl_cert_hostname = "foo";
+    .ssl_sni_hostname = "foo";
+
+    .probe = {
+        .request =
+            "HEAD /__canary__ HTTP/1.1"
+            "Host: assets.publishing.service.gov.uk"
+            "User-Agent: Fastly healthcheck (git version: )"
+
+            "Connection: close";
+        .threshold = 1;
+        .window = 2;
+        .timeout = 5s;
+        .initial = 1;
+        .expected_response = 200;
+        .interval = 10s;
+      }
+}
+# Mirror backend for provider 0
+backend F_mirror1 {
+    .connect_timeout = 1s;
+    .dynamic = true;
+    .port = "443";
+    .host = "foo";
+    .first_byte_timeout = 15s;
+    .max_connections = 200;
+    .between_bytes_timeout = 10s;
+    .share_key = "123";
+
+    .ssl = true;
+    .ssl_check_cert = always;
+    .min_tls_version = "1.2";
+    .ssl_cert_hostname = "foo";
+    .ssl_sni_hostname = "foo";
+
+    .probe = {
+        .request =
+            "HEAD /__canary__ HTTP/1.1"
+            "Host: foo"
+            "User-Agent: Fastly healthcheck (git version: )"
+            "Connection: close";
+        .threshold = 1;
+        .window = 2;
+        .timeout = 5s;
+        .initial = 1;
+        .expected_response = 200;
+        .interval = 10s;
+    }
+}
+# Mirror backend for S3
+backend F_mirrorS3 {
+    .connect_timeout = 1s;
+    .dynamic = true;
+    .port = "443";
+    .host = "bar";
+    .first_byte_timeout = 15s;
+    .max_connections = 200;
+    .between_bytes_timeout = 10s;
+    .share_key = "123";
+
+    .ssl = true;
+    .ssl_check_cert = always;
+    .min_tls_version = "1.2";
+    .ssl_cert_hostname = "bar";
+    .ssl_sni_hostname = "bar";
+
+    .probe = {
+        .request =
+            "HEAD / HTTP/1.1"
+            "Host: bar"
+            "User-Agent: Fastly healthcheck (git version: )"
+            "Connection: close";
+        .threshold = 1;
+        .window = 2;
+        .timeout = 5s;
+        .initial = 1;
+        .expected_response = 200;
+        .interval = 10s;
+    }
+}
+
+backend sick_force_grace {
+  .host = "127.0.0.1";
+  .port = "1";
+  .probe = {
+    .request = "invalid";
+    .interval = 365d;
+    .initial = 0;
+  }
+}
+
+
+acl purge_ip_whitelist {
+  "37.26.93.252";     # Skyscape mirrors
+  "31.210.241.100";   # Carrenza mirrors
+
+  "23.235.32.0"/20;   # Fastly cache node
+  "43.249.72.0"/22;   # Fastly cache node
+  "103.244.50.0"/24;  # Fastly cache node
+  "103.245.222.0"/23; # Fastly cache node
+  "103.245.224.0"/24; # Fastly cache node
+  "104.156.80.0"/20;  # Fastly cache node
+  "151.101.0.0"/16;   # Fastly cache node
+  "157.52.64.0"/18;   # Fastly cache node
+  "172.111.64.0"/18;  # Fastly cache node
+  "185.31.16.0"/22;   # Fastly cache node
+  "199.27.72.0"/21;   # Fastly cache node
+  "199.232.0.0"/16;   # Fastly cache node
+  "202.21.128.0"/24;  # Fastly cache node
+  "203.57.145.0"/24;  # Fastly cache node
+}
+
+sub vcl_recv {
+
+  # Allow FASTLYPURGE from IPs defined in the ACL only, else return a HTTP 403
+  if (req.request == "FASTLYPURGE") {
+    if (client.ip ~ purge_ip_whitelist) {
+      return (lookup);
+    }
+    error 403 "Forbidden";
+  }
+
+  # Force SSL.
+  if (!req.http.Fastly-SSL) {
+     error 801 "Force SSL";
+  }
+
+  # Serve and log an empty response for analytics purposes
+  if (req.url ~ "^/static/a\?") {
+     error 802 "OK";
+  }
+
+  # Serve from stale for 24 hours if origin is sick
+  set req.grace = 24h;
+
+  # Default backend.
+  set req.backend = F_origin;
+  set req.http.Fastly-Backend-Name = "origin";
+
+  # Force host header for staging and integration.
+  set req.http.host = "assets.publishing.service.gov.uk";
+
+
+  # Serve stale if it exists.
+  if (req.restarts > 0) {
+    set req.backend = sick_force_grace;
+    set req.http.Fastly-Backend-Name = "stale";
+  }
+
+  # Failover to mirror.
+  if (req.restarts > 1) {
+    # Don't serve from stale for mirrors
+    set req.grace = 0s;
+    set req.http.Fastly-Failover = "1";
+
+    set req.backend = F_mirror1;
+    set req.http.Fastly-Backend-Name = "mirror1";
+    set req.http.host = "foo";
+  }
+
+  # FIXME: Prefer a fallback director if we move to Varnish 3
+  if (req.restarts > 2) {
+    set req.backend = F_mirrorS3;
+    set req.http.host = "bar";
+    set req.http.Fastly-Backend-Name = "mirrorS3";
+
+    # Replace multiple /
+    set req.url = regsuball(req.url, "([^:])//+", "\1/");
+
+    # Rewrite adding bucket directory prefix
+    set req.url = "/foo_" req.url;
+  }
+
+  # Unspoofable original client address.
+  set req.http.True-Client-IP = req.http.Fastly-Client-IP;
+
+#FASTLY recv
+
+  if (req.request != "HEAD" && req.request != "GET" && req.request != "FASTLYPURGE") {
+    return(pass);
+  }
+
+  return(lookup);
+}
+
+sub vcl_fetch {
+#FASTLY fetch
+
+  set beresp.http.Fastly-Backend-Name = req.http.Fastly-Backend-Name;
+
+  if ((beresp.status >= 500 && beresp.status <= 599) && req.restarts < 3 && (req.request == "GET" || req.request == "HEAD") && !beresp.http.No-Fallback) {
+    set beresp.saintmode = 5s;
+    return (restart);
+  }
+
+  if (req.restarts == 0) {
+    # Keep stale for origin
+    set beresp.grace = 24h;
+  }
+
+  if(req.restarts > 0 ) {
+    set beresp.http.Fastly-Restarts = req.restarts;
+  }
+
+  if (beresp.http.Cache-Control ~ "private") {
+    set req.http.Fastly-Cachetype = "PRIVATE";
+    return (pass);
+  }
+
+  if (beresp.http.Cache-Control ~ "max-age=0") {
+    return (pass);
+  }
+
+  if (beresp.http.Cache-Control ~ "no-(store|cache)") {
+    return (pass);
+  }
+
+  if (beresp.status >= 500 && beresp.status <= 599) {
+    set req.http.Fastly-Cachetype = "ERROR";
+    set beresp.ttl = 1s;
+    set beresp.grace = 5s;
+    if (beresp.http.Fastly-Backend-Name ~ "mirrorS3") {
+      error 503 "Error page";
+    }
+    return (deliver);
+  }
+
+  if (beresp.http.Expires || beresp.http.Surrogate-Control ~ "max-age" || beresp.http.Cache-Control ~"(s-maxage|max-age)") {
+    # keep the ttl here
+  } else {
+    # apply the default ttl
+    set beresp.ttl = 5000s;
+    # S3 does not set cache headers by default. Override TTL and add cache-control with 15 minutes
+    if (beresp.http.Fastly-Backend-Name ~ "mirrorS3") {
+      set beresp.ttl = 900s;
+      set beresp.http.Cache-Control = "max-age=900";
+    }
+  }
+
+  # Override default.vcl behaviour of return(pass).
+  if (beresp.http.Set-Cookie) {
+    return (deliver);
+  }
+}
+
+sub vcl_hit {
+#FASTLY hit
+}
+
+sub vcl_miss {
+#FASTLY miss
+}
+
+sub vcl_deliver {
+#FASTLY deliver
+}
+
+sub vcl_error {
+  if (obj.status == 801) {
+    set obj.status = 301;
+    set obj.response = "Moved Permanently";
+    set obj.http.Location = "https://" req.http.host req.url;
+    synthetic {""};
+    return (deliver);
+  }
+
+  if (obj.status == 802) {
+    set obj.http.Content-Type = "text/plain";
+    set obj.http.Access-Control-Allow-Origin = "*";
+    set obj.status = 200;
+    synthetic {""};
+    return(deliver);
+  }
+
+  # Assume we've hit vcl_error() because the backend is unavailable
+  # for the first two retries. By restarting, vcl_recv() will try
+  # serving from stale before failing over to the mirrors.
+  if (req.restarts < 3) {
+    return (restart);
+  }
+
+  synthetic {"
+    GOV.UK is experiencing technical difficulties now. Please try again later."};
+
+  return (deliver);
+
+#FASTLY error
+}
+
+sub vcl_pass {
+#FASTLY pass
+}
+
+sub vcl_hash {
+#FASTLY hash
+}

--- a/spec/test-outputs/assets-production.out.vcl
+++ b/spec/test-outputs/assets-production.out.vcl
@@ -1,0 +1,308 @@
+backend F_origin {
+    .connect_timeout = 5s;
+    .dynamic = true;
+    .port = "443";
+    .host = "foo";
+    .first_byte_timeout = 15s;
+    .max_connections = 200;
+    .between_bytes_timeout = 10s;
+    .share_key = "123";
+
+    .ssl = true;
+    .ssl_check_cert = always;
+    .min_tls_version = "1.2";
+    .ssl_cert_hostname = "foo";
+    .ssl_sni_hostname = "foo";
+
+    .probe = {
+        .request =
+            "HEAD /__canary__ HTTP/1.1"
+            "Host: foo"
+            "User-Agent: Fastly healthcheck (git version: )"
+
+            "Connection: close";
+        .threshold = 1;
+        .window = 2;
+        .timeout = 5s;
+        .initial = 1;
+        .expected_response = 200;
+        .interval = 10s;
+      }
+}
+# Mirror backend for provider 0
+backend F_mirror1 {
+    .connect_timeout = 1s;
+    .dynamic = true;
+    .port = "443";
+    .host = "foo";
+    .first_byte_timeout = 15s;
+    .max_connections = 200;
+    .between_bytes_timeout = 10s;
+    .share_key = "123";
+
+    .ssl = true;
+    .ssl_check_cert = always;
+    .min_tls_version = "1.2";
+    .ssl_cert_hostname = "foo";
+    .ssl_sni_hostname = "foo";
+
+    .probe = {
+        .request =
+            "HEAD /__canary__ HTTP/1.1"
+            "Host: foo"
+            "User-Agent: Fastly healthcheck (git version: )"
+            "Connection: close";
+        .threshold = 1;
+        .window = 2;
+        .timeout = 5s;
+        .initial = 1;
+        .expected_response = 200;
+        .interval = 10s;
+    }
+}
+# Mirror backend for S3
+backend F_mirrorS3 {
+    .connect_timeout = 1s;
+    .dynamic = true;
+    .port = "443";
+    .host = "bar";
+    .first_byte_timeout = 15s;
+    .max_connections = 200;
+    .between_bytes_timeout = 10s;
+    .share_key = "123";
+
+    .ssl = true;
+    .ssl_check_cert = always;
+    .min_tls_version = "1.2";
+    .ssl_cert_hostname = "bar";
+    .ssl_sni_hostname = "bar";
+
+    .probe = {
+        .request =
+            "HEAD / HTTP/1.1"
+            "Host: bar"
+            "User-Agent: Fastly healthcheck (git version: )"
+            "Connection: close";
+        .threshold = 1;
+        .window = 2;
+        .timeout = 5s;
+        .initial = 1;
+        .expected_response = 200;
+        .interval = 10s;
+    }
+}
+
+backend sick_force_grace {
+  .host = "127.0.0.1";
+  .port = "1";
+  .probe = {
+    .request = "invalid";
+    .interval = 365d;
+    .initial = 0;
+  }
+}
+
+
+acl purge_ip_whitelist {
+  "37.26.93.252";     # Skyscape mirrors
+  "31.210.241.100";   # Carrenza mirrors
+
+  "31.210.245.86";    # Carrenza Production
+
+  "23.235.32.0"/20;   # Fastly cache node
+  "43.249.72.0"/22;   # Fastly cache node
+  "103.244.50.0"/24;  # Fastly cache node
+  "103.245.222.0"/23; # Fastly cache node
+  "103.245.224.0"/24; # Fastly cache node
+  "104.156.80.0"/20;  # Fastly cache node
+  "151.101.0.0"/16;   # Fastly cache node
+  "157.52.64.0"/18;   # Fastly cache node
+  "172.111.64.0"/18;  # Fastly cache node
+  "185.31.16.0"/22;   # Fastly cache node
+  "199.27.72.0"/21;   # Fastly cache node
+  "199.232.0.0"/16;   # Fastly cache node
+  "202.21.128.0"/24;  # Fastly cache node
+  "203.57.145.0"/24;  # Fastly cache node
+}
+
+sub vcl_recv {
+
+  # Allow FASTLYPURGE from IPs defined in the ACL only, else return a HTTP 403
+  if (req.request == "FASTLYPURGE") {
+    if (client.ip ~ purge_ip_whitelist) {
+      return (lookup);
+    }
+    error 403 "Forbidden";
+  }
+
+  # Force SSL.
+  if (!req.http.Fastly-SSL) {
+     error 801 "Force SSL";
+  }
+
+  # Serve and log an empty response for analytics purposes
+  if (req.url ~ "^/static/a\?") {
+     error 802 "OK";
+  }
+
+  # Serve from stale for 24 hours if origin is sick
+  set req.grace = 24h;
+
+  # Default backend.
+  set req.backend = F_origin;
+  set req.http.Fastly-Backend-Name = "origin";
+
+
+  # Serve stale if it exists.
+  if (req.restarts > 0) {
+    set req.backend = sick_force_grace;
+    set req.http.Fastly-Backend-Name = "stale";
+  }
+
+  # Failover to mirror.
+  if (req.restarts > 1) {
+    # Don't serve from stale for mirrors
+    set req.grace = 0s;
+    set req.http.Fastly-Failover = "1";
+
+    set req.backend = F_mirror1;
+    set req.http.Fastly-Backend-Name = "mirror1";
+    set req.http.host = "foo";
+  }
+
+  # FIXME: Prefer a fallback director if we move to Varnish 3
+  if (req.restarts > 2) {
+    set req.backend = F_mirrorS3;
+    set req.http.host = "bar";
+    set req.http.Fastly-Backend-Name = "mirrorS3";
+
+    # Replace multiple /
+    set req.url = regsuball(req.url, "([^:])//+", "\1/");
+
+    # Rewrite adding bucket directory prefix
+    set req.url = "/foo_" req.url;
+  }
+
+  # Unspoofable original client address.
+  set req.http.True-Client-IP = req.http.Fastly-Client-IP;
+
+#FASTLY recv
+
+  if (req.request != "HEAD" && req.request != "GET" && req.request != "FASTLYPURGE") {
+    return(pass);
+  }
+
+  return(lookup);
+}
+
+sub vcl_fetch {
+#FASTLY fetch
+
+  set beresp.http.Fastly-Backend-Name = req.http.Fastly-Backend-Name;
+
+  if ((beresp.status >= 500 && beresp.status <= 599) && req.restarts < 3 && (req.request == "GET" || req.request == "HEAD") && !beresp.http.No-Fallback) {
+    set beresp.saintmode = 5s;
+    return (restart);
+  }
+
+  if (req.restarts == 0) {
+    # Keep stale for origin
+    set beresp.grace = 24h;
+  }
+
+  if(req.restarts > 0 ) {
+    set beresp.http.Fastly-Restarts = req.restarts;
+  }
+
+  if (beresp.http.Cache-Control ~ "private") {
+    set req.http.Fastly-Cachetype = "PRIVATE";
+    return (pass);
+  }
+
+  if (beresp.http.Cache-Control ~ "max-age=0") {
+    return (pass);
+  }
+
+  if (beresp.http.Cache-Control ~ "no-(store|cache)") {
+    return (pass);
+  }
+
+  if (beresp.status >= 500 && beresp.status <= 599) {
+    set req.http.Fastly-Cachetype = "ERROR";
+    set beresp.ttl = 1s;
+    set beresp.grace = 5s;
+    if (beresp.http.Fastly-Backend-Name ~ "mirrorS3") {
+      error 503 "Error page";
+    }
+    return (deliver);
+  }
+
+  if (beresp.http.Expires || beresp.http.Surrogate-Control ~ "max-age" || beresp.http.Cache-Control ~"(s-maxage|max-age)") {
+    # keep the ttl here
+  } else {
+    # apply the default ttl
+    set beresp.ttl = 5000s;
+    # S3 does not set cache headers by default. Override TTL and add cache-control with 15 minutes
+    if (beresp.http.Fastly-Backend-Name ~ "mirrorS3") {
+      set beresp.ttl = 900s;
+      set beresp.http.Cache-Control = "max-age=900";
+    }
+  }
+
+  # Override default.vcl behaviour of return(pass).
+  if (beresp.http.Set-Cookie) {
+    return (deliver);
+  }
+}
+
+sub vcl_hit {
+#FASTLY hit
+}
+
+sub vcl_miss {
+#FASTLY miss
+}
+
+sub vcl_deliver {
+#FASTLY deliver
+}
+
+sub vcl_error {
+  if (obj.status == 801) {
+    set obj.status = 301;
+    set obj.response = "Moved Permanently";
+    set obj.http.Location = "https://" req.http.host req.url;
+    synthetic {""};
+    return (deliver);
+  }
+
+  if (obj.status == 802) {
+    set obj.http.Content-Type = "text/plain";
+    set obj.http.Access-Control-Allow-Origin = "*";
+    set obj.status = 200;
+    synthetic {""};
+    return(deliver);
+  }
+
+  # Assume we've hit vcl_error() because the backend is unavailable
+  # for the first two retries. By restarting, vcl_recv() will try
+  # serving from stale before failing over to the mirrors.
+  if (req.restarts < 3) {
+    return (restart);
+  }
+
+  synthetic {"
+    GOV.UK is experiencing technical difficulties now. Please try again later."};
+
+  return (deliver);
+
+#FASTLY error
+}
+
+sub vcl_pass {
+#FASTLY pass
+}
+
+sub vcl_hash {
+#FASTLY hash
+}

--- a/spec/test-outputs/assets-staging.out.vcl
+++ b/spec/test-outputs/assets-staging.out.vcl
@@ -1,0 +1,311 @@
+backend F_origin {
+    .connect_timeout = 5s;
+    .dynamic = true;
+    .port = "443";
+    .host = "foo";
+    .first_byte_timeout = 15s;
+    .max_connections = 200;
+    .between_bytes_timeout = 10s;
+    .share_key = "123";
+
+    .ssl = true;
+    .ssl_check_cert = always;
+    .min_tls_version = "1.2";
+    .ssl_cert_hostname = "foo";
+    .ssl_sni_hostname = "foo";
+
+    .probe = {
+        .request =
+            "HEAD /__canary__ HTTP/1.1"
+            "Host: assets.publishing.service.gov.uk"
+            "User-Agent: Fastly healthcheck (git version: )"
+
+            "Connection: close";
+        .threshold = 1;
+        .window = 2;
+        .timeout = 5s;
+        .initial = 1;
+        .expected_response = 200;
+        .interval = 10s;
+      }
+}
+# Mirror backend for provider 0
+backend F_mirror1 {
+    .connect_timeout = 1s;
+    .dynamic = true;
+    .port = "443";
+    .host = "foo";
+    .first_byte_timeout = 15s;
+    .max_connections = 200;
+    .between_bytes_timeout = 10s;
+    .share_key = "123";
+
+    .ssl = true;
+    .ssl_check_cert = always;
+    .min_tls_version = "1.2";
+    .ssl_cert_hostname = "foo";
+    .ssl_sni_hostname = "foo";
+
+    .probe = {
+        .request =
+            "HEAD /__canary__ HTTP/1.1"
+            "Host: foo"
+            "User-Agent: Fastly healthcheck (git version: )"
+            "Connection: close";
+        .threshold = 1;
+        .window = 2;
+        .timeout = 5s;
+        .initial = 1;
+        .expected_response = 200;
+        .interval = 10s;
+    }
+}
+# Mirror backend for S3
+backend F_mirrorS3 {
+    .connect_timeout = 1s;
+    .dynamic = true;
+    .port = "443";
+    .host = "bar";
+    .first_byte_timeout = 15s;
+    .max_connections = 200;
+    .between_bytes_timeout = 10s;
+    .share_key = "123";
+
+    .ssl = true;
+    .ssl_check_cert = always;
+    .min_tls_version = "1.2";
+    .ssl_cert_hostname = "bar";
+    .ssl_sni_hostname = "bar";
+
+    .probe = {
+        .request =
+            "HEAD / HTTP/1.1"
+            "Host: bar"
+            "User-Agent: Fastly healthcheck (git version: )"
+            "Connection: close";
+        .threshold = 1;
+        .window = 2;
+        .timeout = 5s;
+        .initial = 1;
+        .expected_response = 200;
+        .interval = 10s;
+    }
+}
+
+backend sick_force_grace {
+  .host = "127.0.0.1";
+  .port = "1";
+  .probe = {
+    .request = "invalid";
+    .interval = 365d;
+    .initial = 0;
+  }
+}
+
+
+acl purge_ip_whitelist {
+  "37.26.93.252";     # Skyscape mirrors
+  "31.210.241.100";   # Carrenza mirrors
+
+  "31.210.245.70";    # Carrenza Staging
+
+  "23.235.32.0"/20;   # Fastly cache node
+  "43.249.72.0"/22;   # Fastly cache node
+  "103.244.50.0"/24;  # Fastly cache node
+  "103.245.222.0"/23; # Fastly cache node
+  "103.245.224.0"/24; # Fastly cache node
+  "104.156.80.0"/20;  # Fastly cache node
+  "151.101.0.0"/16;   # Fastly cache node
+  "157.52.64.0"/18;   # Fastly cache node
+  "172.111.64.0"/18;  # Fastly cache node
+  "185.31.16.0"/22;   # Fastly cache node
+  "199.27.72.0"/21;   # Fastly cache node
+  "199.232.0.0"/16;   # Fastly cache node
+  "202.21.128.0"/24;  # Fastly cache node
+  "203.57.145.0"/24;  # Fastly cache node
+}
+
+sub vcl_recv {
+
+  # Allow FASTLYPURGE from IPs defined in the ACL only, else return a HTTP 403
+  if (req.request == "FASTLYPURGE") {
+    if (client.ip ~ purge_ip_whitelist) {
+      return (lookup);
+    }
+    error 403 "Forbidden";
+  }
+
+  # Force SSL.
+  if (!req.http.Fastly-SSL) {
+     error 801 "Force SSL";
+  }
+
+  # Serve and log an empty response for analytics purposes
+  if (req.url ~ "^/static/a\?") {
+     error 802 "OK";
+  }
+
+  # Serve from stale for 24 hours if origin is sick
+  set req.grace = 24h;
+
+  # Default backend.
+  set req.backend = F_origin;
+  set req.http.Fastly-Backend-Name = "origin";
+
+  # Force host header for staging and integration.
+  set req.http.host = "assets.publishing.service.gov.uk";
+
+
+  # Serve stale if it exists.
+  if (req.restarts > 0) {
+    set req.backend = sick_force_grace;
+    set req.http.Fastly-Backend-Name = "stale";
+  }
+
+  # Failover to mirror.
+  if (req.restarts > 1) {
+    # Don't serve from stale for mirrors
+    set req.grace = 0s;
+    set req.http.Fastly-Failover = "1";
+
+    set req.backend = F_mirror1;
+    set req.http.Fastly-Backend-Name = "mirror1";
+    set req.http.host = "foo";
+  }
+
+  # FIXME: Prefer a fallback director if we move to Varnish 3
+  if (req.restarts > 2) {
+    set req.backend = F_mirrorS3;
+    set req.http.host = "bar";
+    set req.http.Fastly-Backend-Name = "mirrorS3";
+
+    # Replace multiple /
+    set req.url = regsuball(req.url, "([^:])//+", "\1/");
+
+    # Rewrite adding bucket directory prefix
+    set req.url = "/foo_" req.url;
+  }
+
+  # Unspoofable original client address.
+  set req.http.True-Client-IP = req.http.Fastly-Client-IP;
+
+#FASTLY recv
+
+  if (req.request != "HEAD" && req.request != "GET" && req.request != "FASTLYPURGE") {
+    return(pass);
+  }
+
+  return(lookup);
+}
+
+sub vcl_fetch {
+#FASTLY fetch
+
+  set beresp.http.Fastly-Backend-Name = req.http.Fastly-Backend-Name;
+
+  if ((beresp.status >= 500 && beresp.status <= 599) && req.restarts < 3 && (req.request == "GET" || req.request == "HEAD") && !beresp.http.No-Fallback) {
+    set beresp.saintmode = 5s;
+    return (restart);
+  }
+
+  if (req.restarts == 0) {
+    # Keep stale for origin
+    set beresp.grace = 24h;
+  }
+
+  if(req.restarts > 0 ) {
+    set beresp.http.Fastly-Restarts = req.restarts;
+  }
+
+  if (beresp.http.Cache-Control ~ "private") {
+    set req.http.Fastly-Cachetype = "PRIVATE";
+    return (pass);
+  }
+
+  if (beresp.http.Cache-Control ~ "max-age=0") {
+    return (pass);
+  }
+
+  if (beresp.http.Cache-Control ~ "no-(store|cache)") {
+    return (pass);
+  }
+
+  if (beresp.status >= 500 && beresp.status <= 599) {
+    set req.http.Fastly-Cachetype = "ERROR";
+    set beresp.ttl = 1s;
+    set beresp.grace = 5s;
+    if (beresp.http.Fastly-Backend-Name ~ "mirrorS3") {
+      error 503 "Error page";
+    }
+    return (deliver);
+  }
+
+  if (beresp.http.Expires || beresp.http.Surrogate-Control ~ "max-age" || beresp.http.Cache-Control ~"(s-maxage|max-age)") {
+    # keep the ttl here
+  } else {
+    # apply the default ttl
+    set beresp.ttl = 5000s;
+    # S3 does not set cache headers by default. Override TTL and add cache-control with 15 minutes
+    if (beresp.http.Fastly-Backend-Name ~ "mirrorS3") {
+      set beresp.ttl = 900s;
+      set beresp.http.Cache-Control = "max-age=900";
+    }
+  }
+
+  # Override default.vcl behaviour of return(pass).
+  if (beresp.http.Set-Cookie) {
+    return (deliver);
+  }
+}
+
+sub vcl_hit {
+#FASTLY hit
+}
+
+sub vcl_miss {
+#FASTLY miss
+}
+
+sub vcl_deliver {
+#FASTLY deliver
+}
+
+sub vcl_error {
+  if (obj.status == 801) {
+    set obj.status = 301;
+    set obj.response = "Moved Permanently";
+    set obj.http.Location = "https://" req.http.host req.url;
+    synthetic {""};
+    return (deliver);
+  }
+
+  if (obj.status == 802) {
+    set obj.http.Content-Type = "text/plain";
+    set obj.http.Access-Control-Allow-Origin = "*";
+    set obj.status = 200;
+    synthetic {""};
+    return(deliver);
+  }
+
+  # Assume we've hit vcl_error() because the backend is unavailable
+  # for the first two retries. By restarting, vcl_recv() will try
+  # serving from stale before failing over to the mirrors.
+  if (req.restarts < 3) {
+    return (restart);
+  }
+
+  synthetic {"
+    GOV.UK is experiencing technical difficulties now. Please try again later."};
+
+  return (deliver);
+
+#FASTLY error
+}
+
+sub vcl_pass {
+#FASTLY pass
+}
+
+sub vcl_hash {
+#FASTLY hash
+}

--- a/spec/test-outputs/performanceplatform-integration.out.vcl
+++ b/spec/test-outputs/performanceplatform-integration.out.vcl
@@ -1,0 +1,225 @@
+backend F_origin {
+    .connect_timeout = 5s;
+    .dynamic = true;
+    .port = "443";
+    .host = "foo";
+    .first_byte_timeout = 15s;
+    .max_connections = 200;
+    .between_bytes_timeout = 10s;
+    .share_key = "123";
+
+    .ssl = true;
+    .ssl_check_cert = always;
+    .min_tls_version = "1.2";
+    .ssl_cert_hostname = "foo";
+    .ssl_sni_hostname = "foo";
+
+    .probe = {
+        .request =
+            "HEAD / HTTP/1.1"
+            "Host: foo"
+            "User-Agent: Fastly healthcheck (git version: )"
+
+            "Connection: close";
+        .threshold = 1;
+        .window = 2;
+        .timeout = 5s;
+        .initial = 1;
+        .expected_response = 200;
+        .interval = 10s;
+    }
+}
+backend sick_force_grace {
+  .host = "127.0.0.1";
+  .port = "1";
+  .probe = {
+    .request = "invalid";
+    .interval = 365d;
+    .initial = 0;
+  }
+}
+
+
+acl purge_ip_whitelist {
+  "37.26.93.252";     # Skyscape mirrors
+  "31.210.241.100";   # Carrenza mirrors
+  "23.235.32.0"/20;   # Fastly cache node
+  "43.249.72.0"/22;   # Fastly cache node
+  "103.244.50.0"/24;  # Fastly cache node
+  "103.245.222.0"/23; # Fastly cache node
+  "103.245.224.0"/24; # Fastly cache node
+  "104.156.80.0"/20;  # Fastly cache node
+  "151.101.0.0"/16;   # Fastly cache node
+  "157.52.64.0"/18;   # Fastly cache node
+  "172.111.64.0"/18;  # Fastly cache node
+  "185.31.16.0"/22;   # Fastly cache node
+  "199.27.72.0"/21;   # Fastly cache node
+  "199.232.0.0"/16;   # Fastly cache node
+  "202.21.128.0"/24;  # Fastly cache node
+  "203.57.145.0"/24;  # Fastly cache node
+}
+
+sub vcl_recv {
+
+  # Allow FASTLYPURGE from IPs defined in the ACL only, else return a HTTP 403
+  if (req.request == "FASTLYPURGE") {
+    if (client.ip ~ purge_ip_whitelist) {
+      return (lookup);
+    }
+    error 403 "Forbidden";
+  }
+
+  # Force SSL.
+  if (!req.http.Fastly-SSL) {
+     error 801 "Force SSL";
+  }
+
+  # Serve from stale for 24 hours if origin is sick
+  set req.grace = 24h;
+
+  # Default backend.
+  set req.backend = F_origin;
+
+  # Serve stale if it exists.
+  if (req.restarts > 0) {
+    set req.backend = sick_force_grace;
+  }
+
+  # Serve from stale for 24 hours if origin is sick
+  set req.grace = 24h;
+
+  # Unspoofable original client address
+  set req.http.True-Client-IP = req.http.Fastly-Client-IP;
+
+  # Route request to application depending on HTTP method used
+  if (req.request ~ "^(PATCH|PUT|POST|DELETE)$") {
+    set req.http.Host = "backdrop-write.boo";
+  } else if (req.request ~ "^(GET|HEAD|OPTIONS)$") {
+    set req.http.Host = "backdrop-read.boo";
+  } else {
+    error 405 "Method not allowed";
+  }
+
+  if (req.url ~ "^/big-screen.*$") {
+    set req.http.x-redir = "https://www.gov.uk/performance" req.url;
+    error 750 "Moved Permanently";
+  }
+
+  # Unspoofable client IP address
+  set req.http.True-Client-IP = req.http.Fastly-Client-IP;
+
+  # govuk request id. Allow setting this so we can trace a full request
+  if (!req.http.GOVUK-Request-Id) {
+    set req.http.GOVUK-Request-Id = server.identity "-" req.xid;
+  }
+
+#FASTLY recv
+
+  if (req.request != "HEAD" && req.request != "GET" && req.request != "FASTLYPURGE") {
+    return(pass);
+  }
+
+  return(lookup);
+}
+
+sub vcl_fetch {
+#FASTLY fetch
+
+  if ((beresp.status >= 500 && beresp.status <= 599) && req.restarts < 3 && (req.request == "GET" || req.request == "HEAD") && !beresp.http.No-Fallback) {
+    set beresp.saintmode = 5s;
+    return (restart);
+  }
+
+  if (req.restarts == 0) {
+    # Keep stale for origin
+    set beresp.grace = 24h;
+  }
+
+  if(req.restarts > 0 ) {
+    set beresp.http.Fastly-Restarts = req.restarts;
+  }
+
+  if (beresp.http.Cache-Control ~ "private") {
+    set req.http.Fastly-Cachetype = "PRIVATE";
+    return (pass);
+  }
+
+  if (beresp.http.Cache-Control ~ "max-age=0") {
+    return (pass);
+  }
+
+  if (beresp.http.Cache-Control ~ "no-(store|cache)") {
+    return (pass);
+  }
+
+  if (beresp.status >= 500 && beresp.status <= 599) {
+    set req.http.Fastly-Cachetype = "ERROR";
+    set beresp.ttl = 1s;
+    set beresp.grace = 5s;
+    return (deliver);
+  }
+
+  if (beresp.http.Expires || beresp.http.Surrogate-Control ~ "max-age" || beresp.http.Cache-Control ~"(s-maxage|max-age)") {
+    # keep the ttl here
+  } else {
+    # apply the default ttl
+    set beresp.ttl = 5000s;
+  }
+
+  # Override default.vcl behaviour of return(pass).
+  if (beresp.http.Set-Cookie) {
+    return (deliver);
+  }
+}
+
+sub vcl_hit {
+#FASTLY hit
+}
+
+sub vcl_miss {
+#FASTLY miss
+}
+
+sub vcl_deliver {
+#FASTLY deliver
+}
+
+sub vcl_error {
+  if (obj.status == 801) {
+    set obj.status = 301;
+    set obj.response = "Moved Permanently";
+    set obj.http.Location = "https://" req.http.host req.url;
+    synthetic {""};
+    return (deliver);
+  } else if (obj.status == 750) {
+    set obj.status = 301;
+    set obj.response = "Moved Permanently";
+    set obj.http.Location = req.http.x-redir;
+    synthetic {""};
+    return (deliver);
+  }
+
+  # Assume we've hit vcl_error() because the backend is unavailable
+  # for the first two retries. By restarting, vcl_recv() will try
+  # serving from stale before failing over to the mirrors.
+  if (req.restarts < 3) {
+    return (restart);
+  }
+
+  synthetic {"
+    GOV.UK is experiencing technical difficulties now. Please try again later."};
+
+  return (deliver);
+
+#FASTLY error
+}
+
+# pipe cannot be included.
+
+sub vcl_pass {
+#FASTLY pass
+}
+
+sub vcl_hash {
+#FASTLY hash
+}

--- a/spec/test-outputs/performanceplatform-production.out.vcl
+++ b/spec/test-outputs/performanceplatform-production.out.vcl
@@ -1,0 +1,225 @@
+backend F_origin {
+    .connect_timeout = 5s;
+    .dynamic = true;
+    .port = "443";
+    .host = "foo";
+    .first_byte_timeout = 15s;
+    .max_connections = 200;
+    .between_bytes_timeout = 10s;
+    .share_key = "123";
+
+    .ssl = true;
+    .ssl_check_cert = always;
+    .min_tls_version = "1.2";
+    .ssl_cert_hostname = "foo";
+    .ssl_sni_hostname = "foo";
+
+    .probe = {
+        .request =
+            "HEAD / HTTP/1.1"
+            "Host: foo"
+            "User-Agent: Fastly healthcheck (git version: )"
+
+            "Connection: close";
+        .threshold = 1;
+        .window = 2;
+        .timeout = 5s;
+        .initial = 1;
+        .expected_response = 200;
+        .interval = 10s;
+    }
+}
+backend sick_force_grace {
+  .host = "127.0.0.1";
+  .port = "1";
+  .probe = {
+    .request = "invalid";
+    .interval = 365d;
+    .initial = 0;
+  }
+}
+
+
+acl purge_ip_whitelist {
+  "37.26.93.252";     # Skyscape mirrors
+  "31.210.241.100";   # Carrenza mirrors
+  "23.235.32.0"/20;   # Fastly cache node
+  "43.249.72.0"/22;   # Fastly cache node
+  "103.244.50.0"/24;  # Fastly cache node
+  "103.245.222.0"/23; # Fastly cache node
+  "103.245.224.0"/24; # Fastly cache node
+  "104.156.80.0"/20;  # Fastly cache node
+  "151.101.0.0"/16;   # Fastly cache node
+  "157.52.64.0"/18;   # Fastly cache node
+  "172.111.64.0"/18;  # Fastly cache node
+  "185.31.16.0"/22;   # Fastly cache node
+  "199.27.72.0"/21;   # Fastly cache node
+  "199.232.0.0"/16;   # Fastly cache node
+  "202.21.128.0"/24;  # Fastly cache node
+  "203.57.145.0"/24;  # Fastly cache node
+}
+
+sub vcl_recv {
+
+  # Allow FASTLYPURGE from IPs defined in the ACL only, else return a HTTP 403
+  if (req.request == "FASTLYPURGE") {
+    if (client.ip ~ purge_ip_whitelist) {
+      return (lookup);
+    }
+    error 403 "Forbidden";
+  }
+
+  # Force SSL.
+  if (!req.http.Fastly-SSL) {
+     error 801 "Force SSL";
+  }
+
+  # Serve from stale for 24 hours if origin is sick
+  set req.grace = 24h;
+
+  # Default backend.
+  set req.backend = F_origin;
+
+  # Serve stale if it exists.
+  if (req.restarts > 0) {
+    set req.backend = sick_force_grace;
+  }
+
+  # Serve from stale for 24 hours if origin is sick
+  set req.grace = 24h;
+
+  # Unspoofable original client address
+  set req.http.True-Client-IP = req.http.Fastly-Client-IP;
+
+  # Route request to application depending on HTTP method used
+  if (req.request ~ "^(PATCH|PUT|POST|DELETE)$") {
+    set req.http.Host = "backdrop-write.boo";
+  } else if (req.request ~ "^(GET|HEAD|OPTIONS)$") {
+    set req.http.Host = "backdrop-read.boo";
+  } else {
+    error 405 "Method not allowed";
+  }
+
+  if (req.url ~ "^/big-screen.*$") {
+    set req.http.x-redir = "https://www.gov.uk/performance" req.url;
+    error 750 "Moved Permanently";
+  }
+
+  # Unspoofable client IP address
+  set req.http.True-Client-IP = req.http.Fastly-Client-IP;
+
+  # govuk request id. Allow setting this so we can trace a full request
+  if (!req.http.GOVUK-Request-Id) {
+    set req.http.GOVUK-Request-Id = server.identity "-" req.xid;
+  }
+
+#FASTLY recv
+
+  if (req.request != "HEAD" && req.request != "GET" && req.request != "FASTLYPURGE") {
+    return(pass);
+  }
+
+  return(lookup);
+}
+
+sub vcl_fetch {
+#FASTLY fetch
+
+  if ((beresp.status >= 500 && beresp.status <= 599) && req.restarts < 3 && (req.request == "GET" || req.request == "HEAD") && !beresp.http.No-Fallback) {
+    set beresp.saintmode = 5s;
+    return (restart);
+  }
+
+  if (req.restarts == 0) {
+    # Keep stale for origin
+    set beresp.grace = 24h;
+  }
+
+  if(req.restarts > 0 ) {
+    set beresp.http.Fastly-Restarts = req.restarts;
+  }
+
+  if (beresp.http.Cache-Control ~ "private") {
+    set req.http.Fastly-Cachetype = "PRIVATE";
+    return (pass);
+  }
+
+  if (beresp.http.Cache-Control ~ "max-age=0") {
+    return (pass);
+  }
+
+  if (beresp.http.Cache-Control ~ "no-(store|cache)") {
+    return (pass);
+  }
+
+  if (beresp.status >= 500 && beresp.status <= 599) {
+    set req.http.Fastly-Cachetype = "ERROR";
+    set beresp.ttl = 1s;
+    set beresp.grace = 5s;
+    return (deliver);
+  }
+
+  if (beresp.http.Expires || beresp.http.Surrogate-Control ~ "max-age" || beresp.http.Cache-Control ~"(s-maxage|max-age)") {
+    # keep the ttl here
+  } else {
+    # apply the default ttl
+    set beresp.ttl = 5000s;
+  }
+
+  # Override default.vcl behaviour of return(pass).
+  if (beresp.http.Set-Cookie) {
+    return (deliver);
+  }
+}
+
+sub vcl_hit {
+#FASTLY hit
+}
+
+sub vcl_miss {
+#FASTLY miss
+}
+
+sub vcl_deliver {
+#FASTLY deliver
+}
+
+sub vcl_error {
+  if (obj.status == 801) {
+    set obj.status = 301;
+    set obj.response = "Moved Permanently";
+    set obj.http.Location = "https://" req.http.host req.url;
+    synthetic {""};
+    return (deliver);
+  } else if (obj.status == 750) {
+    set obj.status = 301;
+    set obj.response = "Moved Permanently";
+    set obj.http.Location = req.http.x-redir;
+    synthetic {""};
+    return (deliver);
+  }
+
+  # Assume we've hit vcl_error() because the backend is unavailable
+  # for the first two retries. By restarting, vcl_recv() will try
+  # serving from stale before failing over to the mirrors.
+  if (req.restarts < 3) {
+    return (restart);
+  }
+
+  synthetic {"
+    GOV.UK is experiencing technical difficulties now. Please try again later."};
+
+  return (deliver);
+
+#FASTLY error
+}
+
+# pipe cannot be included.
+
+sub vcl_pass {
+#FASTLY pass
+}
+
+sub vcl_hash {
+#FASTLY hash
+}

--- a/spec/test-outputs/performanceplatform-staging.out.vcl
+++ b/spec/test-outputs/performanceplatform-staging.out.vcl
@@ -1,0 +1,225 @@
+backend F_origin {
+    .connect_timeout = 5s;
+    .dynamic = true;
+    .port = "443";
+    .host = "foo";
+    .first_byte_timeout = 15s;
+    .max_connections = 200;
+    .between_bytes_timeout = 10s;
+    .share_key = "123";
+
+    .ssl = true;
+    .ssl_check_cert = always;
+    .min_tls_version = "1.2";
+    .ssl_cert_hostname = "foo";
+    .ssl_sni_hostname = "foo";
+
+    .probe = {
+        .request =
+            "HEAD / HTTP/1.1"
+            "Host: foo"
+            "User-Agent: Fastly healthcheck (git version: )"
+
+            "Connection: close";
+        .threshold = 1;
+        .window = 2;
+        .timeout = 5s;
+        .initial = 1;
+        .expected_response = 200;
+        .interval = 10s;
+    }
+}
+backend sick_force_grace {
+  .host = "127.0.0.1";
+  .port = "1";
+  .probe = {
+    .request = "invalid";
+    .interval = 365d;
+    .initial = 0;
+  }
+}
+
+
+acl purge_ip_whitelist {
+  "37.26.93.252";     # Skyscape mirrors
+  "31.210.241.100";   # Carrenza mirrors
+  "23.235.32.0"/20;   # Fastly cache node
+  "43.249.72.0"/22;   # Fastly cache node
+  "103.244.50.0"/24;  # Fastly cache node
+  "103.245.222.0"/23; # Fastly cache node
+  "103.245.224.0"/24; # Fastly cache node
+  "104.156.80.0"/20;  # Fastly cache node
+  "151.101.0.0"/16;   # Fastly cache node
+  "157.52.64.0"/18;   # Fastly cache node
+  "172.111.64.0"/18;  # Fastly cache node
+  "185.31.16.0"/22;   # Fastly cache node
+  "199.27.72.0"/21;   # Fastly cache node
+  "199.232.0.0"/16;   # Fastly cache node
+  "202.21.128.0"/24;  # Fastly cache node
+  "203.57.145.0"/24;  # Fastly cache node
+}
+
+sub vcl_recv {
+
+  # Allow FASTLYPURGE from IPs defined in the ACL only, else return a HTTP 403
+  if (req.request == "FASTLYPURGE") {
+    if (client.ip ~ purge_ip_whitelist) {
+      return (lookup);
+    }
+    error 403 "Forbidden";
+  }
+
+  # Force SSL.
+  if (!req.http.Fastly-SSL) {
+     error 801 "Force SSL";
+  }
+
+  # Serve from stale for 24 hours if origin is sick
+  set req.grace = 24h;
+
+  # Default backend.
+  set req.backend = F_origin;
+
+  # Serve stale if it exists.
+  if (req.restarts > 0) {
+    set req.backend = sick_force_grace;
+  }
+
+  # Serve from stale for 24 hours if origin is sick
+  set req.grace = 24h;
+
+  # Unspoofable original client address
+  set req.http.True-Client-IP = req.http.Fastly-Client-IP;
+
+  # Route request to application depending on HTTP method used
+  if (req.request ~ "^(PATCH|PUT|POST|DELETE)$") {
+    set req.http.Host = "backdrop-write.boo";
+  } else if (req.request ~ "^(GET|HEAD|OPTIONS)$") {
+    set req.http.Host = "backdrop-read.boo";
+  } else {
+    error 405 "Method not allowed";
+  }
+
+  if (req.url ~ "^/big-screen.*$") {
+    set req.http.x-redir = "https://www.gov.uk/performance" req.url;
+    error 750 "Moved Permanently";
+  }
+
+  # Unspoofable client IP address
+  set req.http.True-Client-IP = req.http.Fastly-Client-IP;
+
+  # govuk request id. Allow setting this so we can trace a full request
+  if (!req.http.GOVUK-Request-Id) {
+    set req.http.GOVUK-Request-Id = server.identity "-" req.xid;
+  }
+
+#FASTLY recv
+
+  if (req.request != "HEAD" && req.request != "GET" && req.request != "FASTLYPURGE") {
+    return(pass);
+  }
+
+  return(lookup);
+}
+
+sub vcl_fetch {
+#FASTLY fetch
+
+  if ((beresp.status >= 500 && beresp.status <= 599) && req.restarts < 3 && (req.request == "GET" || req.request == "HEAD") && !beresp.http.No-Fallback) {
+    set beresp.saintmode = 5s;
+    return (restart);
+  }
+
+  if (req.restarts == 0) {
+    # Keep stale for origin
+    set beresp.grace = 24h;
+  }
+
+  if(req.restarts > 0 ) {
+    set beresp.http.Fastly-Restarts = req.restarts;
+  }
+
+  if (beresp.http.Cache-Control ~ "private") {
+    set req.http.Fastly-Cachetype = "PRIVATE";
+    return (pass);
+  }
+
+  if (beresp.http.Cache-Control ~ "max-age=0") {
+    return (pass);
+  }
+
+  if (beresp.http.Cache-Control ~ "no-(store|cache)") {
+    return (pass);
+  }
+
+  if (beresp.status >= 500 && beresp.status <= 599) {
+    set req.http.Fastly-Cachetype = "ERROR";
+    set beresp.ttl = 1s;
+    set beresp.grace = 5s;
+    return (deliver);
+  }
+
+  if (beresp.http.Expires || beresp.http.Surrogate-Control ~ "max-age" || beresp.http.Cache-Control ~"(s-maxage|max-age)") {
+    # keep the ttl here
+  } else {
+    # apply the default ttl
+    set beresp.ttl = 5000s;
+  }
+
+  # Override default.vcl behaviour of return(pass).
+  if (beresp.http.Set-Cookie) {
+    return (deliver);
+  }
+}
+
+sub vcl_hit {
+#FASTLY hit
+}
+
+sub vcl_miss {
+#FASTLY miss
+}
+
+sub vcl_deliver {
+#FASTLY deliver
+}
+
+sub vcl_error {
+  if (obj.status == 801) {
+    set obj.status = 301;
+    set obj.response = "Moved Permanently";
+    set obj.http.Location = "https://" req.http.host req.url;
+    synthetic {""};
+    return (deliver);
+  } else if (obj.status == 750) {
+    set obj.status = 301;
+    set obj.response = "Moved Permanently";
+    set obj.http.Location = req.http.x-redir;
+    synthetic {""};
+    return (deliver);
+  }
+
+  # Assume we've hit vcl_error() because the backend is unavailable
+  # for the first two retries. By restarting, vcl_recv() will try
+  # serving from stale before failing over to the mirrors.
+  if (req.restarts < 3) {
+    return (restart);
+  }
+
+  synthetic {"
+    GOV.UK is experiencing technical difficulties now. Please try again later."};
+
+  return (deliver);
+
+#FASTLY error
+}
+
+# pipe cannot be included.
+
+sub vcl_pass {
+#FASTLY pass
+}
+
+sub vcl_hash {
+#FASTLY hash
+}

--- a/spec/test-outputs/performanceplatform_admin-integration.out.vcl
+++ b/spec/test-outputs/performanceplatform_admin-integration.out.vcl
@@ -1,0 +1,215 @@
+backend F_backend_origin {
+    .connect_timeout = 5s;
+    .dynamic = true;
+    .port = "443";
+    .host = "backend.boo";
+    .first_byte_timeout = 15s;
+    .max_connections = 200;
+    .between_bytes_timeout = 10s;
+    .share_key = "123";
+
+    .ssl = true;
+    .ssl_check_cert = always;
+    .min_tls_version = "1.2";
+    .ssl_cert_hostname = "backend.boo";
+    .ssl_sni_hostname = "backend.boo";
+
+    .probe = {
+        .request =
+            "HEAD /_status HTTP/1.1"
+            "Host: performanceplatform-admin.boo"
+            "User-Agent: Fastly healthcheck (git version: )"
+
+            "Connection: close";
+        .threshold = 1;
+        .window = 2;
+        .timeout = 5s;
+        .initial = 1;
+        .expected_response = 200;
+        .interval = 10s;
+    }
+}
+
+backend sick_force_grace {
+  .host = "127.0.0.1";
+  .port = "1";
+  .probe = {
+    .request = "invalid";
+    .interval = 365d;
+    .initial = 0;
+  }
+}
+
+
+acl purge_ip_whitelist {
+  "37.26.93.252";     # Skyscape mirrors
+  "31.210.241.100";   # Carrenza mirrors
+  "23.235.32.0"/20;   # Fastly cache node
+  "43.249.72.0"/22;   # Fastly cache node
+  "103.244.50.0"/24;  # Fastly cache node
+  "103.245.222.0"/23; # Fastly cache node
+  "103.245.224.0"/24; # Fastly cache node
+  "104.156.80.0"/20;  # Fastly cache node
+  "151.101.0.0"/16;   # Fastly cache node
+  "157.52.64.0"/18;   # Fastly cache node
+  "172.111.64.0"/18;  # Fastly cache node
+  "185.31.16.0"/22;   # Fastly cache node
+  "199.27.72.0"/21;   # Fastly cache node
+  "199.232.0.0"/16;   # Fastly cache node
+  "202.21.128.0"/24;  # Fastly cache node
+  "203.57.145.0"/24;  # Fastly cache node
+}
+
+sub vcl_recv {
+
+  # Allow FASTLYPURGE from IPs defined in the ACL only, else return a HTTP 403
+  if (req.request == "FASTLYPURGE") {
+    if (client.ip ~ purge_ip_whitelist) {
+      return (lookup);
+    }
+    error 403 "Forbidden";
+  }
+
+  # Force SSL.
+  if (!req.http.Fastly-SSL) {
+     error 801 "Force SSL";
+  }
+
+  # Serve from stale for 24 hours if origin is sick
+  set req.grace = 24h;
+
+  set req.backend = F_backend_origin;
+  set req.http.host = "performanceplatform-admin.boo";
+
+  # Serve stale if it exists.
+  if (req.restarts > 0) {
+    set req.backend = sick_force_grace;
+  }
+
+  # Unspoofable original client address.
+  set req.http.True-Client-IP = req.http.Fastly-Client-IP;
+
+  # govuk request id. Allow setting this so we can trace a full request
+  if (!req.http.GOVUK-Request-Id) {
+    set req.http.GOVUK-Request-Id = server.identity "-" req.xid;
+  }
+
+#FASTLY recv
+
+  if (req.request != "HEAD" && req.request != "GET" && req.request != "FASTLYPURGE") {
+    return(pass);
+  }
+
+  return(lookup);
+}
+
+sub vcl_fetch {
+#FASTLY fetch
+
+  if ((beresp.status >= 500 && beresp.status <= 599) && req.restarts < 3 && (req.request == "GET" || req.request == "HEAD") && !beresp.http.No-Fallback) {
+    set beresp.saintmode = 5s;
+    return (restart);
+  }
+
+  if (req.restarts == 0) {
+    # Keep stale for origin
+    set beresp.grace = 24h;
+  }
+
+  if(req.restarts > 0 ) {
+    set beresp.http.Fastly-Restarts = req.restarts;
+  }
+
+  if (beresp.http.Cache-Control ~ "private") {
+    set req.http.Fastly-Cachetype = "PRIVATE";
+    return (pass);
+  }
+
+  if (beresp.http.Cache-Control ~ "max-age=0") {
+    return (pass);
+  }
+
+  if (beresp.http.Cache-Control ~ "no-(store|cache)") {
+    return (pass);
+  }
+
+  if (beresp.status >= 500 && beresp.status <= 599) {
+    set req.http.Fastly-Cachetype = "ERROR";
+    set beresp.ttl = 1s;
+    set beresp.grace = 5s;
+    return (deliver);
+  }
+
+  if (beresp.http.Expires || beresp.http.Surrogate-Control ~ "max-age" || beresp.http.Cache-Control ~"(s-maxage|max-age)") {
+    # keep the ttl here
+  } else {
+    # apply the default ttl
+    set beresp.ttl = 5000s;
+  }
+
+  # Override default.vcl behaviour of return(pass).
+  if (beresp.http.Set-Cookie) {
+    return (deliver);
+  }
+}
+
+sub vcl_hit {
+#FASTLY hit
+}
+
+sub vcl_miss {
+#FASTLY miss
+}
+
+sub vcl_deliver {
+#FASTLY deliver
+}
+
+sub vcl_error {
+  if (obj.status == 801) {
+    set obj.status = 301;
+    set obj.response = "Moved Permanently";
+    set obj.http.Location = "https://" req.http.host req.url;
+    synthetic {""};
+    return (deliver);
+  }
+
+  # Assume we've hit vcl_error() because the backend is unavailable
+  # for the first two retries. By restarting, vcl_recv() will try
+  # serving from stale before failing over to the mirrors.
+  if (req.restarts < 3) {
+    return (restart);
+  }
+
+  synthetic {"
+    <!DOCTYPE html>
+    <html>
+      <head>
+        <title>Welcome to GOV.UK</title>
+        <style>
+          body { font-family: Arial, sans-serif; margin: 0; }
+          header { background: black; }
+          h1 { color: white; font-size: 29px; margin: 0 auto; padding: 10px; max-width: 990px; }
+          p { color: black; margin: 30px auto; max-width: 990px; }
+        </style>
+      </head>
+      <body>
+        <header><h1>GOV.UK</h1></header>
+        <p>We're experiencing technical difficulties. Please try again later.</p>
+      </body>
+    </html>"};
+
+  return (deliver);
+
+#FASTLY error
+}
+
+# pipe cannot be included.
+
+sub vcl_pass {
+#FASTLY pass
+}
+
+sub vcl_hash {
+#FASTLY hash
+}

--- a/spec/test-outputs/performanceplatform_admin-production.out.vcl
+++ b/spec/test-outputs/performanceplatform_admin-production.out.vcl
@@ -1,0 +1,215 @@
+backend F_backend_origin {
+    .connect_timeout = 5s;
+    .dynamic = true;
+    .port = "443";
+    .host = "backend.boo";
+    .first_byte_timeout = 15s;
+    .max_connections = 200;
+    .between_bytes_timeout = 10s;
+    .share_key = "123";
+
+    .ssl = true;
+    .ssl_check_cert = always;
+    .min_tls_version = "1.2";
+    .ssl_cert_hostname = "backend.boo";
+    .ssl_sni_hostname = "backend.boo";
+
+    .probe = {
+        .request =
+            "HEAD /_status HTTP/1.1"
+            "Host: performanceplatform-admin.boo"
+            "User-Agent: Fastly healthcheck (git version: )"
+
+            "Connection: close";
+        .threshold = 1;
+        .window = 2;
+        .timeout = 5s;
+        .initial = 1;
+        .expected_response = 200;
+        .interval = 10s;
+    }
+}
+
+backend sick_force_grace {
+  .host = "127.0.0.1";
+  .port = "1";
+  .probe = {
+    .request = "invalid";
+    .interval = 365d;
+    .initial = 0;
+  }
+}
+
+
+acl purge_ip_whitelist {
+  "37.26.93.252";     # Skyscape mirrors
+  "31.210.241.100";   # Carrenza mirrors
+  "23.235.32.0"/20;   # Fastly cache node
+  "43.249.72.0"/22;   # Fastly cache node
+  "103.244.50.0"/24;  # Fastly cache node
+  "103.245.222.0"/23; # Fastly cache node
+  "103.245.224.0"/24; # Fastly cache node
+  "104.156.80.0"/20;  # Fastly cache node
+  "151.101.0.0"/16;   # Fastly cache node
+  "157.52.64.0"/18;   # Fastly cache node
+  "172.111.64.0"/18;  # Fastly cache node
+  "185.31.16.0"/22;   # Fastly cache node
+  "199.27.72.0"/21;   # Fastly cache node
+  "199.232.0.0"/16;   # Fastly cache node
+  "202.21.128.0"/24;  # Fastly cache node
+  "203.57.145.0"/24;  # Fastly cache node
+}
+
+sub vcl_recv {
+
+  # Allow FASTLYPURGE from IPs defined in the ACL only, else return a HTTP 403
+  if (req.request == "FASTLYPURGE") {
+    if (client.ip ~ purge_ip_whitelist) {
+      return (lookup);
+    }
+    error 403 "Forbidden";
+  }
+
+  # Force SSL.
+  if (!req.http.Fastly-SSL) {
+     error 801 "Force SSL";
+  }
+
+  # Serve from stale for 24 hours if origin is sick
+  set req.grace = 24h;
+
+  set req.backend = F_backend_origin;
+  set req.http.host = "performanceplatform-admin.boo";
+
+  # Serve stale if it exists.
+  if (req.restarts > 0) {
+    set req.backend = sick_force_grace;
+  }
+
+  # Unspoofable original client address.
+  set req.http.True-Client-IP = req.http.Fastly-Client-IP;
+
+  # govuk request id. Allow setting this so we can trace a full request
+  if (!req.http.GOVUK-Request-Id) {
+    set req.http.GOVUK-Request-Id = server.identity "-" req.xid;
+  }
+
+#FASTLY recv
+
+  if (req.request != "HEAD" && req.request != "GET" && req.request != "FASTLYPURGE") {
+    return(pass);
+  }
+
+  return(lookup);
+}
+
+sub vcl_fetch {
+#FASTLY fetch
+
+  if ((beresp.status >= 500 && beresp.status <= 599) && req.restarts < 3 && (req.request == "GET" || req.request == "HEAD") && !beresp.http.No-Fallback) {
+    set beresp.saintmode = 5s;
+    return (restart);
+  }
+
+  if (req.restarts == 0) {
+    # Keep stale for origin
+    set beresp.grace = 24h;
+  }
+
+  if(req.restarts > 0 ) {
+    set beresp.http.Fastly-Restarts = req.restarts;
+  }
+
+  if (beresp.http.Cache-Control ~ "private") {
+    set req.http.Fastly-Cachetype = "PRIVATE";
+    return (pass);
+  }
+
+  if (beresp.http.Cache-Control ~ "max-age=0") {
+    return (pass);
+  }
+
+  if (beresp.http.Cache-Control ~ "no-(store|cache)") {
+    return (pass);
+  }
+
+  if (beresp.status >= 500 && beresp.status <= 599) {
+    set req.http.Fastly-Cachetype = "ERROR";
+    set beresp.ttl = 1s;
+    set beresp.grace = 5s;
+    return (deliver);
+  }
+
+  if (beresp.http.Expires || beresp.http.Surrogate-Control ~ "max-age" || beresp.http.Cache-Control ~"(s-maxage|max-age)") {
+    # keep the ttl here
+  } else {
+    # apply the default ttl
+    set beresp.ttl = 5000s;
+  }
+
+  # Override default.vcl behaviour of return(pass).
+  if (beresp.http.Set-Cookie) {
+    return (deliver);
+  }
+}
+
+sub vcl_hit {
+#FASTLY hit
+}
+
+sub vcl_miss {
+#FASTLY miss
+}
+
+sub vcl_deliver {
+#FASTLY deliver
+}
+
+sub vcl_error {
+  if (obj.status == 801) {
+    set obj.status = 301;
+    set obj.response = "Moved Permanently";
+    set obj.http.Location = "https://" req.http.host req.url;
+    synthetic {""};
+    return (deliver);
+  }
+
+  # Assume we've hit vcl_error() because the backend is unavailable
+  # for the first two retries. By restarting, vcl_recv() will try
+  # serving from stale before failing over to the mirrors.
+  if (req.restarts < 3) {
+    return (restart);
+  }
+
+  synthetic {"
+    <!DOCTYPE html>
+    <html>
+      <head>
+        <title>Welcome to GOV.UK</title>
+        <style>
+          body { font-family: Arial, sans-serif; margin: 0; }
+          header { background: black; }
+          h1 { color: white; font-size: 29px; margin: 0 auto; padding: 10px; max-width: 990px; }
+          p { color: black; margin: 30px auto; max-width: 990px; }
+        </style>
+      </head>
+      <body>
+        <header><h1>GOV.UK</h1></header>
+        <p>We're experiencing technical difficulties. Please try again later.</p>
+      </body>
+    </html>"};
+
+  return (deliver);
+
+#FASTLY error
+}
+
+# pipe cannot be included.
+
+sub vcl_pass {
+#FASTLY pass
+}
+
+sub vcl_hash {
+#FASTLY hash
+}

--- a/spec/test-outputs/performanceplatform_admin-staging.out.vcl
+++ b/spec/test-outputs/performanceplatform_admin-staging.out.vcl
@@ -1,0 +1,215 @@
+backend F_backend_origin {
+    .connect_timeout = 5s;
+    .dynamic = true;
+    .port = "443";
+    .host = "backend.boo";
+    .first_byte_timeout = 15s;
+    .max_connections = 200;
+    .between_bytes_timeout = 10s;
+    .share_key = "123";
+
+    .ssl = true;
+    .ssl_check_cert = always;
+    .min_tls_version = "1.2";
+    .ssl_cert_hostname = "backend.boo";
+    .ssl_sni_hostname = "backend.boo";
+
+    .probe = {
+        .request =
+            "HEAD /_status HTTP/1.1"
+            "Host: performanceplatform-admin.boo"
+            "User-Agent: Fastly healthcheck (git version: )"
+
+            "Connection: close";
+        .threshold = 1;
+        .window = 2;
+        .timeout = 5s;
+        .initial = 1;
+        .expected_response = 200;
+        .interval = 10s;
+    }
+}
+
+backend sick_force_grace {
+  .host = "127.0.0.1";
+  .port = "1";
+  .probe = {
+    .request = "invalid";
+    .interval = 365d;
+    .initial = 0;
+  }
+}
+
+
+acl purge_ip_whitelist {
+  "37.26.93.252";     # Skyscape mirrors
+  "31.210.241.100";   # Carrenza mirrors
+  "23.235.32.0"/20;   # Fastly cache node
+  "43.249.72.0"/22;   # Fastly cache node
+  "103.244.50.0"/24;  # Fastly cache node
+  "103.245.222.0"/23; # Fastly cache node
+  "103.245.224.0"/24; # Fastly cache node
+  "104.156.80.0"/20;  # Fastly cache node
+  "151.101.0.0"/16;   # Fastly cache node
+  "157.52.64.0"/18;   # Fastly cache node
+  "172.111.64.0"/18;  # Fastly cache node
+  "185.31.16.0"/22;   # Fastly cache node
+  "199.27.72.0"/21;   # Fastly cache node
+  "199.232.0.0"/16;   # Fastly cache node
+  "202.21.128.0"/24;  # Fastly cache node
+  "203.57.145.0"/24;  # Fastly cache node
+}
+
+sub vcl_recv {
+
+  # Allow FASTLYPURGE from IPs defined in the ACL only, else return a HTTP 403
+  if (req.request == "FASTLYPURGE") {
+    if (client.ip ~ purge_ip_whitelist) {
+      return (lookup);
+    }
+    error 403 "Forbidden";
+  }
+
+  # Force SSL.
+  if (!req.http.Fastly-SSL) {
+     error 801 "Force SSL";
+  }
+
+  # Serve from stale for 24 hours if origin is sick
+  set req.grace = 24h;
+
+  set req.backend = F_backend_origin;
+  set req.http.host = "performanceplatform-admin.boo";
+
+  # Serve stale if it exists.
+  if (req.restarts > 0) {
+    set req.backend = sick_force_grace;
+  }
+
+  # Unspoofable original client address.
+  set req.http.True-Client-IP = req.http.Fastly-Client-IP;
+
+  # govuk request id. Allow setting this so we can trace a full request
+  if (!req.http.GOVUK-Request-Id) {
+    set req.http.GOVUK-Request-Id = server.identity "-" req.xid;
+  }
+
+#FASTLY recv
+
+  if (req.request != "HEAD" && req.request != "GET" && req.request != "FASTLYPURGE") {
+    return(pass);
+  }
+
+  return(lookup);
+}
+
+sub vcl_fetch {
+#FASTLY fetch
+
+  if ((beresp.status >= 500 && beresp.status <= 599) && req.restarts < 3 && (req.request == "GET" || req.request == "HEAD") && !beresp.http.No-Fallback) {
+    set beresp.saintmode = 5s;
+    return (restart);
+  }
+
+  if (req.restarts == 0) {
+    # Keep stale for origin
+    set beresp.grace = 24h;
+  }
+
+  if(req.restarts > 0 ) {
+    set beresp.http.Fastly-Restarts = req.restarts;
+  }
+
+  if (beresp.http.Cache-Control ~ "private") {
+    set req.http.Fastly-Cachetype = "PRIVATE";
+    return (pass);
+  }
+
+  if (beresp.http.Cache-Control ~ "max-age=0") {
+    return (pass);
+  }
+
+  if (beresp.http.Cache-Control ~ "no-(store|cache)") {
+    return (pass);
+  }
+
+  if (beresp.status >= 500 && beresp.status <= 599) {
+    set req.http.Fastly-Cachetype = "ERROR";
+    set beresp.ttl = 1s;
+    set beresp.grace = 5s;
+    return (deliver);
+  }
+
+  if (beresp.http.Expires || beresp.http.Surrogate-Control ~ "max-age" || beresp.http.Cache-Control ~"(s-maxage|max-age)") {
+    # keep the ttl here
+  } else {
+    # apply the default ttl
+    set beresp.ttl = 5000s;
+  }
+
+  # Override default.vcl behaviour of return(pass).
+  if (beresp.http.Set-Cookie) {
+    return (deliver);
+  }
+}
+
+sub vcl_hit {
+#FASTLY hit
+}
+
+sub vcl_miss {
+#FASTLY miss
+}
+
+sub vcl_deliver {
+#FASTLY deliver
+}
+
+sub vcl_error {
+  if (obj.status == 801) {
+    set obj.status = 301;
+    set obj.response = "Moved Permanently";
+    set obj.http.Location = "https://" req.http.host req.url;
+    synthetic {""};
+    return (deliver);
+  }
+
+  # Assume we've hit vcl_error() because the backend is unavailable
+  # for the first two retries. By restarting, vcl_recv() will try
+  # serving from stale before failing over to the mirrors.
+  if (req.restarts < 3) {
+    return (restart);
+  }
+
+  synthetic {"
+    <!DOCTYPE html>
+    <html>
+      <head>
+        <title>Welcome to GOV.UK</title>
+        <style>
+          body { font-family: Arial, sans-serif; margin: 0; }
+          header { background: black; }
+          h1 { color: white; font-size: 29px; margin: 0 auto; padding: 10px; max-width: 990px; }
+          p { color: black; margin: 30px auto; max-width: 990px; }
+        </style>
+      </head>
+      <body>
+        <header><h1>GOV.UK</h1></header>
+        <p>We're experiencing technical difficulties. Please try again later.</p>
+      </body>
+    </html>"};
+
+  return (deliver);
+
+#FASTLY error
+}
+
+# pipe cannot be included.
+
+sub vcl_pass {
+#FASTLY pass
+}
+
+sub vcl_hash {
+#FASTLY hash
+}

--- a/spec/test-outputs/performanceplatform_stagecraft-integration.out.vcl
+++ b/spec/test-outputs/performanceplatform_stagecraft-integration.out.vcl
@@ -1,0 +1,215 @@
+backend F_api_origin {
+    .connect_timeout = 5s;
+    .dynamic = true;
+    .port = "443";
+    .host = "api.boo";
+    .first_byte_timeout = 15s;
+    .max_connections = 200;
+    .between_bytes_timeout = 10s;
+    .share_key = "123";
+
+    .ssl = true;
+    .ssl_check_cert = always;
+    .min_tls_version = "1.2";
+    .ssl_cert_hostname = "api.boo";
+    .ssl_sni_hostname = "api.boo";
+
+    .probe = {
+        .request =
+            "HEAD /_status HTTP/1.1"
+            "Host: stagecraft.boo"
+            "User-Agent: Fastly healthcheck (git version: )"
+
+            "Connection: close";
+        .threshold = 1;
+        .window = 2;
+        .timeout = 5s;
+        .initial = 1;
+        .expected_response = 200;
+        .interval = 10s;
+    }
+}
+
+backend sick_force_grace {
+  .host = "127.0.0.1";
+  .port = "1";
+  .probe = {
+    .request = "invalid";
+    .interval = 365d;
+    .initial = 0;
+  }
+}
+
+
+acl purge_ip_whitelist {
+  "37.26.93.252";     # Skyscape mirrors
+  "31.210.241.100";   # Carrenza mirrors
+  "23.235.32.0"/20;   # Fastly cache node
+  "43.249.72.0"/22;   # Fastly cache node
+  "103.244.50.0"/24;  # Fastly cache node
+  "103.245.222.0"/23; # Fastly cache node
+  "103.245.224.0"/24; # Fastly cache node
+  "104.156.80.0"/20;  # Fastly cache node
+  "151.101.0.0"/16;   # Fastly cache node
+  "157.52.64.0"/18;   # Fastly cache node
+  "172.111.64.0"/18;  # Fastly cache node
+  "185.31.16.0"/22;   # Fastly cache node
+  "199.27.72.0"/21;   # Fastly cache node
+  "199.232.0.0"/16;   # Fastly cache node
+  "202.21.128.0"/24;  # Fastly cache node
+  "203.57.145.0"/24;  # Fastly cache node
+}
+
+sub vcl_recv {
+
+  # Allow FASTLYPURGE from IPs defined in the ACL only, else return a HTTP 403
+  if (req.request == "FASTLYPURGE") {
+    if (client.ip ~ purge_ip_whitelist) {
+      return (lookup);
+    }
+    error 403 "Forbidden";
+  }
+
+  # Force SSL.
+  if (!req.http.Fastly-SSL) {
+     error 801 "Force SSL";
+  }
+
+  # Serve from stale for 24 hours if origin is sick
+  set req.grace = 24h;
+
+	set req.backend = F_api_origin;
+	set req.http.host = "stagecraft.boo";
+
+  # Serve stale if it exists.
+  if (req.restarts > 0) {
+    set req.backend = sick_force_grace;
+  }
+
+  # Unspoofable original client address.
+  set req.http.True-Client-IP = req.http.Fastly-Client-IP;
+
+  # govuk request id. Allow setting this so we can trace a full request
+  if (!req.http.GOVUK-Request-Id) {
+    set req.http.GOVUK-Request-Id = server.identity "-" req.xid;
+  }
+
+#FASTLY recv
+
+  if (req.request != "HEAD" && req.request != "GET" && req.request != "FASTLYPURGE") {
+    return(pass);
+  }
+
+  return(lookup);
+}
+
+sub vcl_fetch {
+#FASTLY fetch
+
+  if ((beresp.status >= 500 && beresp.status <= 599) && req.restarts < 3 && (req.request == "GET" || req.request == "HEAD") && !beresp.http.No-Fallback) {
+    set beresp.saintmode = 5s;
+    return (restart);
+  }
+
+  if (req.restarts == 0) {
+    # Keep stale for origin
+    set beresp.grace = 24h;
+  }
+
+  if(req.restarts > 0 ) {
+    set beresp.http.Fastly-Restarts = req.restarts;
+  }
+
+  if (beresp.http.Cache-Control ~ "private") {
+    set req.http.Fastly-Cachetype = "PRIVATE";
+    return (pass);
+  }
+
+  if (beresp.http.Cache-Control ~ "max-age=0") {
+    return (pass);
+  }
+
+  if (beresp.http.Cache-Control ~ "no-(store|cache)") {
+    return (pass);
+  }
+
+  if (beresp.status >= 500 && beresp.status <= 599) {
+    set req.http.Fastly-Cachetype = "ERROR";
+    set beresp.ttl = 1s;
+    set beresp.grace = 5s;
+    return (deliver);
+  }
+
+  if (beresp.http.Expires || beresp.http.Surrogate-Control ~ "max-age" || beresp.http.Cache-Control ~"(s-maxage|max-age)") {
+    # keep the ttl here
+  } else {
+    # apply the default ttl
+    set beresp.ttl = 5000s;
+  }
+
+  # Override default.vcl behaviour of return(pass).
+  if (beresp.http.Set-Cookie) {
+    return (deliver);
+  }
+}
+
+sub vcl_hit {
+#FASTLY hit
+}
+
+sub vcl_miss {
+#FASTLY miss
+}
+
+sub vcl_deliver {
+#FASTLY deliver
+}
+
+sub vcl_error {
+  if (obj.status == 801) {
+    set obj.status = 301;
+    set obj.response = "Moved Permanently";
+    set obj.http.Location = "https://" req.http.host req.url;
+    synthetic {""};
+    return (deliver);
+  }
+
+  # Assume we've hit vcl_error() because the backend is unavailable
+  # for the first two retries. By restarting, vcl_recv() will try
+  # serving from stale before failing over to the mirrors.
+  if (req.restarts < 3) {
+    return (restart);
+  }
+
+  synthetic {"
+    <!DOCTYPE html>
+    <html>
+      <head>
+        <title>Welcome to GOV.UK</title>
+        <style>
+          body { font-family: Arial, sans-serif; margin: 0; }
+          header { background: black; }
+          h1 { color: white; font-size: 29px; margin: 0 auto; padding: 10px; max-width: 990px; }
+          p { color: black; margin: 30px auto; max-width: 990px; }
+        </style>
+      </head>
+      <body>
+        <header><h1>GOV.UK</h1></header>
+        <p>We're experiencing technical difficulties. Please try again later.</p>
+      </body>
+    </html>"};
+
+  return (deliver);
+
+#FASTLY error
+}
+
+# pipe cannot be included.
+
+sub vcl_pass {
+#FASTLY pass
+}
+
+sub vcl_hash {
+#FASTLY hash
+}

--- a/spec/test-outputs/performanceplatform_stagecraft-production.out.vcl
+++ b/spec/test-outputs/performanceplatform_stagecraft-production.out.vcl
@@ -1,0 +1,215 @@
+backend F_api_origin {
+    .connect_timeout = 5s;
+    .dynamic = true;
+    .port = "443";
+    .host = "api.boo";
+    .first_byte_timeout = 15s;
+    .max_connections = 200;
+    .between_bytes_timeout = 10s;
+    .share_key = "123";
+
+    .ssl = true;
+    .ssl_check_cert = always;
+    .min_tls_version = "1.2";
+    .ssl_cert_hostname = "api.boo";
+    .ssl_sni_hostname = "api.boo";
+
+    .probe = {
+        .request =
+            "HEAD /_status HTTP/1.1"
+            "Host: stagecraft.boo"
+            "User-Agent: Fastly healthcheck (git version: )"
+
+            "Connection: close";
+        .threshold = 1;
+        .window = 2;
+        .timeout = 5s;
+        .initial = 1;
+        .expected_response = 200;
+        .interval = 10s;
+    }
+}
+
+backend sick_force_grace {
+  .host = "127.0.0.1";
+  .port = "1";
+  .probe = {
+    .request = "invalid";
+    .interval = 365d;
+    .initial = 0;
+  }
+}
+
+
+acl purge_ip_whitelist {
+  "37.26.93.252";     # Skyscape mirrors
+  "31.210.241.100";   # Carrenza mirrors
+  "23.235.32.0"/20;   # Fastly cache node
+  "43.249.72.0"/22;   # Fastly cache node
+  "103.244.50.0"/24;  # Fastly cache node
+  "103.245.222.0"/23; # Fastly cache node
+  "103.245.224.0"/24; # Fastly cache node
+  "104.156.80.0"/20;  # Fastly cache node
+  "151.101.0.0"/16;   # Fastly cache node
+  "157.52.64.0"/18;   # Fastly cache node
+  "172.111.64.0"/18;  # Fastly cache node
+  "185.31.16.0"/22;   # Fastly cache node
+  "199.27.72.0"/21;   # Fastly cache node
+  "199.232.0.0"/16;   # Fastly cache node
+  "202.21.128.0"/24;  # Fastly cache node
+  "203.57.145.0"/24;  # Fastly cache node
+}
+
+sub vcl_recv {
+
+  # Allow FASTLYPURGE from IPs defined in the ACL only, else return a HTTP 403
+  if (req.request == "FASTLYPURGE") {
+    if (client.ip ~ purge_ip_whitelist) {
+      return (lookup);
+    }
+    error 403 "Forbidden";
+  }
+
+  # Force SSL.
+  if (!req.http.Fastly-SSL) {
+     error 801 "Force SSL";
+  }
+
+  # Serve from stale for 24 hours if origin is sick
+  set req.grace = 24h;
+
+	set req.backend = F_api_origin;
+	set req.http.host = "stagecraft.boo";
+
+  # Serve stale if it exists.
+  if (req.restarts > 0) {
+    set req.backend = sick_force_grace;
+  }
+
+  # Unspoofable original client address.
+  set req.http.True-Client-IP = req.http.Fastly-Client-IP;
+
+  # govuk request id. Allow setting this so we can trace a full request
+  if (!req.http.GOVUK-Request-Id) {
+    set req.http.GOVUK-Request-Id = server.identity "-" req.xid;
+  }
+
+#FASTLY recv
+
+  if (req.request != "HEAD" && req.request != "GET" && req.request != "FASTLYPURGE") {
+    return(pass);
+  }
+
+  return(lookup);
+}
+
+sub vcl_fetch {
+#FASTLY fetch
+
+  if ((beresp.status >= 500 && beresp.status <= 599) && req.restarts < 3 && (req.request == "GET" || req.request == "HEAD") && !beresp.http.No-Fallback) {
+    set beresp.saintmode = 5s;
+    return (restart);
+  }
+
+  if (req.restarts == 0) {
+    # Keep stale for origin
+    set beresp.grace = 24h;
+  }
+
+  if(req.restarts > 0 ) {
+    set beresp.http.Fastly-Restarts = req.restarts;
+  }
+
+  if (beresp.http.Cache-Control ~ "private") {
+    set req.http.Fastly-Cachetype = "PRIVATE";
+    return (pass);
+  }
+
+  if (beresp.http.Cache-Control ~ "max-age=0") {
+    return (pass);
+  }
+
+  if (beresp.http.Cache-Control ~ "no-(store|cache)") {
+    return (pass);
+  }
+
+  if (beresp.status >= 500 && beresp.status <= 599) {
+    set req.http.Fastly-Cachetype = "ERROR";
+    set beresp.ttl = 1s;
+    set beresp.grace = 5s;
+    return (deliver);
+  }
+
+  if (beresp.http.Expires || beresp.http.Surrogate-Control ~ "max-age" || beresp.http.Cache-Control ~"(s-maxage|max-age)") {
+    # keep the ttl here
+  } else {
+    # apply the default ttl
+    set beresp.ttl = 5000s;
+  }
+
+  # Override default.vcl behaviour of return(pass).
+  if (beresp.http.Set-Cookie) {
+    return (deliver);
+  }
+}
+
+sub vcl_hit {
+#FASTLY hit
+}
+
+sub vcl_miss {
+#FASTLY miss
+}
+
+sub vcl_deliver {
+#FASTLY deliver
+}
+
+sub vcl_error {
+  if (obj.status == 801) {
+    set obj.status = 301;
+    set obj.response = "Moved Permanently";
+    set obj.http.Location = "https://" req.http.host req.url;
+    synthetic {""};
+    return (deliver);
+  }
+
+  # Assume we've hit vcl_error() because the backend is unavailable
+  # for the first two retries. By restarting, vcl_recv() will try
+  # serving from stale before failing over to the mirrors.
+  if (req.restarts < 3) {
+    return (restart);
+  }
+
+  synthetic {"
+    <!DOCTYPE html>
+    <html>
+      <head>
+        <title>Welcome to GOV.UK</title>
+        <style>
+          body { font-family: Arial, sans-serif; margin: 0; }
+          header { background: black; }
+          h1 { color: white; font-size: 29px; margin: 0 auto; padding: 10px; max-width: 990px; }
+          p { color: black; margin: 30px auto; max-width: 990px; }
+        </style>
+      </head>
+      <body>
+        <header><h1>GOV.UK</h1></header>
+        <p>We're experiencing technical difficulties. Please try again later.</p>
+      </body>
+    </html>"};
+
+  return (deliver);
+
+#FASTLY error
+}
+
+# pipe cannot be included.
+
+sub vcl_pass {
+#FASTLY pass
+}
+
+sub vcl_hash {
+#FASTLY hash
+}

--- a/spec/test-outputs/performanceplatform_stagecraft-staging.out.vcl
+++ b/spec/test-outputs/performanceplatform_stagecraft-staging.out.vcl
@@ -1,0 +1,215 @@
+backend F_api_origin {
+    .connect_timeout = 5s;
+    .dynamic = true;
+    .port = "443";
+    .host = "api.boo";
+    .first_byte_timeout = 15s;
+    .max_connections = 200;
+    .between_bytes_timeout = 10s;
+    .share_key = "123";
+
+    .ssl = true;
+    .ssl_check_cert = always;
+    .min_tls_version = "1.2";
+    .ssl_cert_hostname = "api.boo";
+    .ssl_sni_hostname = "api.boo";
+
+    .probe = {
+        .request =
+            "HEAD /_status HTTP/1.1"
+            "Host: stagecraft.boo"
+            "User-Agent: Fastly healthcheck (git version: )"
+
+            "Connection: close";
+        .threshold = 1;
+        .window = 2;
+        .timeout = 5s;
+        .initial = 1;
+        .expected_response = 200;
+        .interval = 10s;
+    }
+}
+
+backend sick_force_grace {
+  .host = "127.0.0.1";
+  .port = "1";
+  .probe = {
+    .request = "invalid";
+    .interval = 365d;
+    .initial = 0;
+  }
+}
+
+
+acl purge_ip_whitelist {
+  "37.26.93.252";     # Skyscape mirrors
+  "31.210.241.100";   # Carrenza mirrors
+  "23.235.32.0"/20;   # Fastly cache node
+  "43.249.72.0"/22;   # Fastly cache node
+  "103.244.50.0"/24;  # Fastly cache node
+  "103.245.222.0"/23; # Fastly cache node
+  "103.245.224.0"/24; # Fastly cache node
+  "104.156.80.0"/20;  # Fastly cache node
+  "151.101.0.0"/16;   # Fastly cache node
+  "157.52.64.0"/18;   # Fastly cache node
+  "172.111.64.0"/18;  # Fastly cache node
+  "185.31.16.0"/22;   # Fastly cache node
+  "199.27.72.0"/21;   # Fastly cache node
+  "199.232.0.0"/16;   # Fastly cache node
+  "202.21.128.0"/24;  # Fastly cache node
+  "203.57.145.0"/24;  # Fastly cache node
+}
+
+sub vcl_recv {
+
+  # Allow FASTLYPURGE from IPs defined in the ACL only, else return a HTTP 403
+  if (req.request == "FASTLYPURGE") {
+    if (client.ip ~ purge_ip_whitelist) {
+      return (lookup);
+    }
+    error 403 "Forbidden";
+  }
+
+  # Force SSL.
+  if (!req.http.Fastly-SSL) {
+     error 801 "Force SSL";
+  }
+
+  # Serve from stale for 24 hours if origin is sick
+  set req.grace = 24h;
+
+	set req.backend = F_api_origin;
+	set req.http.host = "stagecraft.boo";
+
+  # Serve stale if it exists.
+  if (req.restarts > 0) {
+    set req.backend = sick_force_grace;
+  }
+
+  # Unspoofable original client address.
+  set req.http.True-Client-IP = req.http.Fastly-Client-IP;
+
+  # govuk request id. Allow setting this so we can trace a full request
+  if (!req.http.GOVUK-Request-Id) {
+    set req.http.GOVUK-Request-Id = server.identity "-" req.xid;
+  }
+
+#FASTLY recv
+
+  if (req.request != "HEAD" && req.request != "GET" && req.request != "FASTLYPURGE") {
+    return(pass);
+  }
+
+  return(lookup);
+}
+
+sub vcl_fetch {
+#FASTLY fetch
+
+  if ((beresp.status >= 500 && beresp.status <= 599) && req.restarts < 3 && (req.request == "GET" || req.request == "HEAD") && !beresp.http.No-Fallback) {
+    set beresp.saintmode = 5s;
+    return (restart);
+  }
+
+  if (req.restarts == 0) {
+    # Keep stale for origin
+    set beresp.grace = 24h;
+  }
+
+  if(req.restarts > 0 ) {
+    set beresp.http.Fastly-Restarts = req.restarts;
+  }
+
+  if (beresp.http.Cache-Control ~ "private") {
+    set req.http.Fastly-Cachetype = "PRIVATE";
+    return (pass);
+  }
+
+  if (beresp.http.Cache-Control ~ "max-age=0") {
+    return (pass);
+  }
+
+  if (beresp.http.Cache-Control ~ "no-(store|cache)") {
+    return (pass);
+  }
+
+  if (beresp.status >= 500 && beresp.status <= 599) {
+    set req.http.Fastly-Cachetype = "ERROR";
+    set beresp.ttl = 1s;
+    set beresp.grace = 5s;
+    return (deliver);
+  }
+
+  if (beresp.http.Expires || beresp.http.Surrogate-Control ~ "max-age" || beresp.http.Cache-Control ~"(s-maxage|max-age)") {
+    # keep the ttl here
+  } else {
+    # apply the default ttl
+    set beresp.ttl = 5000s;
+  }
+
+  # Override default.vcl behaviour of return(pass).
+  if (beresp.http.Set-Cookie) {
+    return (deliver);
+  }
+}
+
+sub vcl_hit {
+#FASTLY hit
+}
+
+sub vcl_miss {
+#FASTLY miss
+}
+
+sub vcl_deliver {
+#FASTLY deliver
+}
+
+sub vcl_error {
+  if (obj.status == 801) {
+    set obj.status = 301;
+    set obj.response = "Moved Permanently";
+    set obj.http.Location = "https://" req.http.host req.url;
+    synthetic {""};
+    return (deliver);
+  }
+
+  # Assume we've hit vcl_error() because the backend is unavailable
+  # for the first two retries. By restarting, vcl_recv() will try
+  # serving from stale before failing over to the mirrors.
+  if (req.restarts < 3) {
+    return (restart);
+  }
+
+  synthetic {"
+    <!DOCTYPE html>
+    <html>
+      <head>
+        <title>Welcome to GOV.UK</title>
+        <style>
+          body { font-family: Arial, sans-serif; margin: 0; }
+          header { background: black; }
+          h1 { color: white; font-size: 29px; margin: 0 auto; padding: 10px; max-width: 990px; }
+          p { color: black; margin: 30px auto; max-width: 990px; }
+        </style>
+      </head>
+      <body>
+        <header><h1>GOV.UK</h1></header>
+        <p>We're experiencing technical difficulties. Please try again later.</p>
+      </body>
+    </html>"};
+
+  return (deliver);
+
+#FASTLY error
+}
+
+# pipe cannot be included.
+
+sub vcl_pass {
+#FASTLY pass
+}
+
+sub vcl_hash {
+#FASTLY hash
+}

--- a/spec/test-outputs/servicegovuk-integration.out.vcl
+++ b/spec/test-outputs/servicegovuk-integration.out.vcl
@@ -1,0 +1,58 @@
+backend dummy {
+  .host = "127.0.0.1";
+  .port = "1";
+  .probe = {
+    .request = "invalid";
+    .initial = 0;
+    .interval = 365d;
+  }
+}
+
+sub vcl_recv {
+
+  # Force SSL.
+  if (!req.http.Fastly-SSL) {
+    error 801 "Force SSL";
+  } else {
+    error 802 "Redirect GOV.UK";
+  }
+
+  return(error);
+}
+
+sub vcl_fetch {
+}
+
+sub vcl_hit {
+}
+
+sub vcl_miss {
+}
+
+sub vcl_deliver {
+}
+
+sub vcl_error {
+  if (obj.status == 801) {
+    set obj.status = 301;
+    set obj.response = "Moved Permanently";
+    set obj.http.Location = "https://" req.http.host req.url;
+    set obj.http.Fastly-Backend-Name = "force_ssl";
+  }
+
+  if (obj.status == 802) {
+    set obj.status = 302;
+    set obj.response = "Moved Temporarily";
+    set obj.http.Location = "https://www.gov.uk";
+    set obj.http.Strict-Transport-Security = "max-age=63072000; includeSubDomains; preload";
+  }
+
+  synthetic {""};
+  return (deliver);
+}
+
+sub vcl_pass {
+}
+
+sub vcl_hash {
+}

--- a/spec/test-outputs/servicegovuk-production.out.vcl
+++ b/spec/test-outputs/servicegovuk-production.out.vcl
@@ -1,0 +1,58 @@
+backend dummy {
+  .host = "127.0.0.1";
+  .port = "1";
+  .probe = {
+    .request = "invalid";
+    .initial = 0;
+    .interval = 365d;
+  }
+}
+
+sub vcl_recv {
+
+  # Force SSL.
+  if (!req.http.Fastly-SSL) {
+    error 801 "Force SSL";
+  } else {
+    error 802 "Redirect GOV.UK";
+  }
+
+  return(error);
+}
+
+sub vcl_fetch {
+}
+
+sub vcl_hit {
+}
+
+sub vcl_miss {
+}
+
+sub vcl_deliver {
+}
+
+sub vcl_error {
+  if (obj.status == 801) {
+    set obj.status = 301;
+    set obj.response = "Moved Permanently";
+    set obj.http.Location = "https://" req.http.host req.url;
+    set obj.http.Fastly-Backend-Name = "force_ssl";
+  }
+
+  if (obj.status == 802) {
+    set obj.status = 302;
+    set obj.response = "Moved Temporarily";
+    set obj.http.Location = "https://www.gov.uk";
+    set obj.http.Strict-Transport-Security = "max-age=63072000; includeSubDomains; preload";
+  }
+
+  synthetic {""};
+  return (deliver);
+}
+
+sub vcl_pass {
+}
+
+sub vcl_hash {
+}

--- a/spec/test-outputs/servicegovuk-staging.out.vcl
+++ b/spec/test-outputs/servicegovuk-staging.out.vcl
@@ -1,0 +1,58 @@
+backend dummy {
+  .host = "127.0.0.1";
+  .port = "1";
+  .probe = {
+    .request = "invalid";
+    .initial = 0;
+    .interval = 365d;
+  }
+}
+
+sub vcl_recv {
+
+  # Force SSL.
+  if (!req.http.Fastly-SSL) {
+    error 801 "Force SSL";
+  } else {
+    error 802 "Redirect GOV.UK";
+  }
+
+  return(error);
+}
+
+sub vcl_fetch {
+}
+
+sub vcl_hit {
+}
+
+sub vcl_miss {
+}
+
+sub vcl_deliver {
+}
+
+sub vcl_error {
+  if (obj.status == 801) {
+    set obj.status = 301;
+    set obj.response = "Moved Permanently";
+    set obj.http.Location = "https://" req.http.host req.url;
+    set obj.http.Fastly-Backend-Name = "force_ssl";
+  }
+
+  if (obj.status == 802) {
+    set obj.status = 302;
+    set obj.response = "Moved Temporarily";
+    set obj.http.Location = "https://www.gov.uk";
+    set obj.http.Strict-Transport-Security = "max-age=63072000; includeSubDomains; preload";
+  }
+
+  synthetic {""};
+  return (deliver);
+}
+
+sub vcl_pass {
+}
+
+sub vcl_hash {
+}

--- a/spec/test-outputs/tldredirect-integration.out.vcl
+++ b/spec/test-outputs/tldredirect-integration.out.vcl
@@ -1,0 +1,58 @@
+backend dummy {
+  .host = "127.0.0.1";
+  .port = "1";
+  .probe = {
+    .request = "invalid";
+    .initial = 0;
+    .interval = 365d;
+  }
+}
+
+sub vcl_recv {
+
+  # Force SSL.
+  if (!req.http.Fastly-SSL) {
+    error 801 "Force SSL";
+  } else {
+    error 802 "Redirect GOV.UK";
+  }
+
+  return(error);
+}
+
+sub vcl_fetch {
+}
+
+sub vcl_hit {
+}
+
+sub vcl_miss {
+}
+
+sub vcl_deliver {
+}
+
+sub vcl_error {
+  if (obj.status == 801) {
+    set obj.status = 301;
+    set obj.response = "Moved Permanently";
+    set obj.http.Location = "https://" req.http.host req.url;
+    set obj.http.Fastly-Backend-Name = "force_ssl";
+  }
+
+  if (obj.status == 802) {
+    set obj.status = 301;
+    set obj.response = "Moved Permanently";
+    set obj.http.Location = "https://www.gov.uk" req.url;
+    set obj.http.Strict-Transport-Security = "max-age=63072000";
+  }
+
+  synthetic {""};
+  return (deliver);
+}
+
+sub vcl_pass {
+}
+
+sub vcl_hash {
+}

--- a/spec/test-outputs/tldredirect-production.out.vcl
+++ b/spec/test-outputs/tldredirect-production.out.vcl
@@ -1,0 +1,58 @@
+backend dummy {
+  .host = "127.0.0.1";
+  .port = "1";
+  .probe = {
+    .request = "invalid";
+    .initial = 0;
+    .interval = 365d;
+  }
+}
+
+sub vcl_recv {
+
+  # Force SSL.
+  if (!req.http.Fastly-SSL) {
+    error 801 "Force SSL";
+  } else {
+    error 802 "Redirect GOV.UK";
+  }
+
+  return(error);
+}
+
+sub vcl_fetch {
+}
+
+sub vcl_hit {
+}
+
+sub vcl_miss {
+}
+
+sub vcl_deliver {
+}
+
+sub vcl_error {
+  if (obj.status == 801) {
+    set obj.status = 301;
+    set obj.response = "Moved Permanently";
+    set obj.http.Location = "https://" req.http.host req.url;
+    set obj.http.Fastly-Backend-Name = "force_ssl";
+  }
+
+  if (obj.status == 802) {
+    set obj.status = 301;
+    set obj.response = "Moved Permanently";
+    set obj.http.Location = "https://www.gov.uk" req.url;
+    set obj.http.Strict-Transport-Security = "max-age=63072000";
+  }
+
+  synthetic {""};
+  return (deliver);
+}
+
+sub vcl_pass {
+}
+
+sub vcl_hash {
+}

--- a/spec/test-outputs/tldredirect-staging.out.vcl
+++ b/spec/test-outputs/tldredirect-staging.out.vcl
@@ -1,0 +1,58 @@
+backend dummy {
+  .host = "127.0.0.1";
+  .port = "1";
+  .probe = {
+    .request = "invalid";
+    .initial = 0;
+    .interval = 365d;
+  }
+}
+
+sub vcl_recv {
+
+  # Force SSL.
+  if (!req.http.Fastly-SSL) {
+    error 801 "Force SSL";
+  } else {
+    error 802 "Redirect GOV.UK";
+  }
+
+  return(error);
+}
+
+sub vcl_fetch {
+}
+
+sub vcl_hit {
+}
+
+sub vcl_miss {
+}
+
+sub vcl_deliver {
+}
+
+sub vcl_error {
+  if (obj.status == 801) {
+    set obj.status = 301;
+    set obj.response = "Moved Permanently";
+    set obj.http.Location = "https://" req.http.host req.url;
+    set obj.http.Fastly-Backend-Name = "force_ssl";
+  }
+
+  if (obj.status == 802) {
+    set obj.status = 301;
+    set obj.response = "Moved Permanently";
+    set obj.http.Location = "https://www.gov.uk" req.url;
+    set obj.http.Strict-Transport-Security = "max-age=63072000";
+  }
+
+  synthetic {""};
+  return (deliver);
+}
+
+sub vcl_pass {
+}
+
+sub vcl_hash {
+}

--- a/spec/test-outputs/www-integration.out.vcl
+++ b/spec/test-outputs/www-integration.out.vcl
@@ -1,0 +1,503 @@
+backend F_origin {
+    .connect_timeout = 5s;
+    .dynamic = true;
+    .port = "443";
+    .host = "foo";
+    .first_byte_timeout = 15s;
+    .max_connections = 200;
+    .between_bytes_timeout = 10s;
+    .share_key = "123";
+
+    .ssl = true;
+    .ssl_check_cert = always;
+    .min_tls_version = "1.2";
+    .ssl_cert_hostname = "foo";
+    .ssl_sni_hostname = "foo";
+
+    .probe = {
+        .request =
+            "HEAD / HTTP/1.1"
+            "Host: foo"
+            "User-Agent: Fastly healthcheck (git version: )"
+            "Connection: close";
+        .threshold = 1;
+        .window = 2;
+        .timeout = 5s;
+        .initial = 1;
+        .expected_response = 200;
+        .interval = 10s;
+    }
+}
+# Mirror backend for provider 0
+backend F_mirror1 {
+    .connect_timeout = 1s;
+    .dynamic = true;
+    .port = "443";
+    .host = "foo";
+    .first_byte_timeout = 15s;
+    .max_connections = 200;
+    .between_bytes_timeout = 10s;
+    .share_key = "123";
+
+    .ssl = true;
+    .ssl_check_cert = always;
+    .min_tls_version = "1.2";
+    .ssl_cert_hostname = "foo";
+    .ssl_sni_hostname = "foo";
+
+    .probe = {
+        .request =
+            "HEAD / HTTP/1.1"
+            "Host: foo"
+            "User-Agent: Fastly healthcheck (git version: )"
+            "Connection: close";
+        .threshold = 1;
+        .window = 2;
+        .timeout = 5s;
+        .initial = 1;
+        .expected_response = 200;
+        .interval = 10s;
+    }
+}
+# Mirror backend for S3
+backend F_mirrorS3 {
+    .connect_timeout = 1s;
+    .dynamic = true;
+    .port = "443";
+    .host = "bar";
+    .first_byte_timeout = 15s;
+    .max_connections = 200;
+    .between_bytes_timeout = 10s;
+    .share_key = "123";
+
+    .ssl = true;
+    .ssl_check_cert = always;
+    .min_tls_version = "1.2";
+    .ssl_cert_hostname = "bar";
+    .ssl_sni_hostname = "bar";
+
+    .probe = {
+        .request =
+            "HEAD / HTTP/1.1"
+            "Host: bar"
+            "User-Agent: Fastly healthcheck (git version: )"
+            "Connection: close";
+        .threshold = 1;
+        .window = 2;
+        .timeout = 5s;
+        .initial = 1;
+        .expected_response = 200;
+        .interval = 10s;
+    }
+}
+
+backend sick_force_grace {
+  .host = "127.0.0.1";
+  .port = "1";
+  .probe = {
+    .request = "invalid";
+    .interval = 365d;
+    .initial = 0;
+  }
+}
+
+
+acl purge_ip_whitelist {
+  "37.26.93.252";     # Skyscape mirrors
+  "31.210.241.100";   # Carrenza mirrors
+
+  "23.235.32.0"/20;   # Fastly cache node
+  "43.249.72.0"/22;   # Fastly cache node
+  "103.244.50.0"/24;  # Fastly cache node
+  "103.245.222.0"/23; # Fastly cache node
+  "103.245.224.0"/24; # Fastly cache node
+  "104.156.80.0"/20;  # Fastly cache node
+  "151.101.0.0"/16;   # Fastly cache node
+  "157.52.64.0"/18;   # Fastly cache node
+  "172.111.64.0"/18;  # Fastly cache node
+  "185.31.16.0"/22;   # Fastly cache node
+  "199.27.72.0"/21;   # Fastly cache node
+  "199.232.0.0"/16;   # Fastly cache node
+  "202.21.128.0"/24;  # Fastly cache node
+  "203.57.145.0"/24;  # Fastly cache node
+}
+
+
+
+sub vcl_recv {
+
+  # Allow FASTLYPURGE from IPs defined in the ACL only, else return a HTTP 403
+  if (req.request == "FASTLYPURGE") {
+    if (client.ip ~ purge_ip_whitelist) {
+      return (lookup);
+    }
+    error 403 "Forbidden";
+  }
+
+  
+
+  # Check whether the remote IP address is in the list of blocked IPs
+  if (table.lookup(ip_address_blacklist, client.ip)) {
+    error 403 "Forbidden";
+  }
+
+  
+
+  # Force SSL.
+  if (!req.http.Fastly-SSL) {
+     error 801 "Force SSL";
+  }
+
+  # Serve a 404 Not Found response if request URL matches "/autodiscover/autodiscover.xml"
+  # This is to avoid a Denial of Service "attack" from certain government machines.
+  if (req.url ~ "(?i)^/autodiscover/autodiscover.xml") {
+    error 404 "Not Found";
+  }
+
+  # Serve from stale for 24 hours if origin is sick
+  set req.grace = 24h;
+
+  # Default backend.
+  set req.backend = F_origin;
+  set req.http.Fastly-Backend-Name = "origin";
+
+  # Serve stale if it exists.
+  if (req.restarts > 0) {
+    set req.backend = sick_force_grace;
+    set req.http.Fastly-Backend-Name = "stale";
+  }
+
+  # Failover to mirror.
+  if (req.restarts > 1) {
+    # Don't serve from stale for mirrors
+    set req.grace = 0s;
+    set req.http.Fastly-Failover = "1";
+
+    set req.backend = F_mirror1;
+    set req.http.host = "foo";
+    set req.http.Fastly-Backend-Name = "mirror1";
+  }
+
+  # FIXME: Prefer a fallback director if we move to Varnish 3
+  if (req.restarts > 2) {
+    set req.backend = F_mirrorS3;
+    set req.http.host = "bar";
+    set req.http.Fastly-Backend-Name = "mirrorS3";
+
+    # Requests to home page, rewrite to index.html
+    if (req.url ~ "^/?([\?#].*)?$") {
+      set req.url = regsub(req.url, "^/?([\?#].*)?$", "/index.html\1");
+    }
+
+    # Replace multiple /
+    set req.url = regsuball(req.url, "([^:])//+", "\1/");
+
+    # Requests without document extension, rewrite adding .html
+    if (req.url !~ "^([^#\?\s]+)\.(atom|chm|css|csv|diff|doc|docx|dot|dxf|eps|gif|gml|html|ico|ics|jpeg|jpg|JPG|js|json|kml|odp|ods|odt|pdf|PDF|png|ppt|pptx|ps|rdf|rtf|sch|txt|wsdl|xls|xlsm|xlsx|xlt|xml|xsd|xslt|zip)([\?#]+.*)?$") {
+      set req.url = regsub(req.url, "^([^#\?\s]+)([\?#]+.*)?$", "\1.html\2");
+    }
+    # Add bucket directory prefix to all the requests
+    set req.url = "/foo_" req.url;
+  }
+
+  # Unspoofable original client address.
+  set req.http.True-Client-IP = req.http.Fastly-Client-IP;
+
+  # Set a TLSversion request header for requests going to the Licensify application
+  # This is used to block unsecure requests at the application level for payment security reasons and an absence of caching in Licensify
+  if (req.url ~ "^/apply-for-a-licence/.*") {
+    set req.http.TLSversion = tls.client.protocol;
+  }
+
+
+#FASTLY recv
+
+  if (req.request != "HEAD" && req.request != "GET" && req.request != "FASTLYPURGE") {
+    return(pass);
+  }
+
+    # Begin dynamic section
+if (table.lookup(active_ab_tests, "Example") == "true") {
+  if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
+    set req.http.GOVUK-ABTest-Example = "A";
+  } else if (req.url ~ "[\?\&]ABTest-Example=A(&|$)") {
+    # Some users, such as remote testers, will be given a URL with a query string
+    # to place them into a specific bucket.
+    set req.http.GOVUK-ABTest-Example = "A";
+  } else if (req.url ~ "[\?\&]ABTest-Example=B(&|$)") {
+    # Some users, such as remote testers, will be given a URL with a query string
+    # to place them into a specific bucket.
+    set req.http.GOVUK-ABTest-Example = "B";
+  } else if (req.http.Cookie ~ "ABTest-Example") {
+    # Set the value of the header to whatever decision was previously made
+    set req.http.GOVUK-ABTest-Example = req.http.Cookie:ABTest-Example;
+  } else {
+    declare local var.denominator_Example INTEGER;
+    declare local var.denominator_Example_A INTEGER;
+    declare local var.nominator_Example_A INTEGER;
+    set var.nominator_Example_A = std.atoi(table.lookup(example_percentages, "A"));
+    set var.denominator_Example += var.nominator_Example_A;
+    declare local var.denominator_Example_B INTEGER;
+    declare local var.nominator_Example_B INTEGER;
+    set var.nominator_Example_B = std.atoi(table.lookup(example_percentages, "B"));
+    set var.denominator_Example += var.nominator_Example_B;
+    set var.denominator_Example_A = var.denominator_Example;
+    if (randombool(var.nominator_Example_A, var.denominator_Example_A)) {
+      set req.http.GOVUK-ABTest-Example = "A";
+    } else {
+      set req.http.GOVUK-ABTest-Example = "B";
+    }
+  }
+}
+if (table.lookup(active_ab_tests, "ViewDrivingLicence") == "true") {
+  if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
+    set req.http.GOVUK-ABTest-ViewDrivingLicence = "A";
+  } else if (req.url ~ "[\?\&]ABTest-ViewDrivingLicence=A(&|$)") {
+    # Some users, such as remote testers, will be given a URL with a query string
+    # to place them into a specific bucket.
+    set req.http.GOVUK-ABTest-ViewDrivingLicence = "A";
+  } else if (req.url ~ "[\?\&]ABTest-ViewDrivingLicence=B(&|$)") {
+    # Some users, such as remote testers, will be given a URL with a query string
+    # to place them into a specific bucket.
+    set req.http.GOVUK-ABTest-ViewDrivingLicence = "B";
+  } else if (req.http.Cookie ~ "ABTest-ViewDrivingLicence") {
+    # Set the value of the header to whatever decision was previously made
+    set req.http.GOVUK-ABTest-ViewDrivingLicence = req.http.Cookie:ABTest-ViewDrivingLicence;
+  } else {
+    declare local var.denominator_ViewDrivingLicence INTEGER;
+    declare local var.denominator_ViewDrivingLicence_A INTEGER;
+    declare local var.nominator_ViewDrivingLicence_A INTEGER;
+    set var.nominator_ViewDrivingLicence_A = std.atoi(table.lookup(viewdrivinglicence_percentages, "A"));
+    set var.denominator_ViewDrivingLicence += var.nominator_ViewDrivingLicence_A;
+    declare local var.denominator_ViewDrivingLicence_B INTEGER;
+    declare local var.nominator_ViewDrivingLicence_B INTEGER;
+    set var.nominator_ViewDrivingLicence_B = std.atoi(table.lookup(viewdrivinglicence_percentages, "B"));
+    set var.denominator_ViewDrivingLicence += var.nominator_ViewDrivingLicence_B;
+    set var.denominator_ViewDrivingLicence_A = var.denominator_ViewDrivingLicence;
+    if (randombool(var.nominator_ViewDrivingLicence_A, var.denominator_ViewDrivingLicence_A)) {
+      set req.http.GOVUK-ABTest-ViewDrivingLicence = "A";
+    } else {
+      set req.http.GOVUK-ABTest-ViewDrivingLicence = "B";
+    }
+  }
+}
+if (table.lookup(active_ab_tests, "RelatedLinksAATest") == "true") {
+  if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
+    set req.http.GOVUK-ABTest-RelatedLinksAATest = "A";
+  } else if (req.url ~ "[\?\&]ABTest-RelatedLinksAATest=A(&|$)") {
+    # Some users, such as remote testers, will be given a URL with a query string
+    # to place them into a specific bucket.
+    set req.http.GOVUK-ABTest-RelatedLinksAATest = "A";
+  } else if (req.url ~ "[\?\&]ABTest-RelatedLinksAATest=B(&|$)") {
+    # Some users, such as remote testers, will be given a URL with a query string
+    # to place them into a specific bucket.
+    set req.http.GOVUK-ABTest-RelatedLinksAATest = "B";
+  } else if (req.http.Cookie ~ "ABTest-RelatedLinksAATest") {
+    # Set the value of the header to whatever decision was previously made
+    set req.http.GOVUK-ABTest-RelatedLinksAATest = req.http.Cookie:ABTest-RelatedLinksAATest;
+  } else {
+    declare local var.denominator_RelatedLinksAATest INTEGER;
+    declare local var.denominator_RelatedLinksAATest_A INTEGER;
+    declare local var.nominator_RelatedLinksAATest_A INTEGER;
+    set var.nominator_RelatedLinksAATest_A = std.atoi(table.lookup(relatedlinksaatest_percentages, "A"));
+    set var.denominator_RelatedLinksAATest += var.nominator_RelatedLinksAATest_A;
+    declare local var.denominator_RelatedLinksAATest_B INTEGER;
+    declare local var.nominator_RelatedLinksAATest_B INTEGER;
+    set var.nominator_RelatedLinksAATest_B = std.atoi(table.lookup(relatedlinksaatest_percentages, "B"));
+    set var.denominator_RelatedLinksAATest += var.nominator_RelatedLinksAATest_B;
+    set var.denominator_RelatedLinksAATest_A = var.denominator_RelatedLinksAATest;
+    if (randombool(var.nominator_RelatedLinksAATest_A, var.denominator_RelatedLinksAATest_A)) {
+      set req.http.GOVUK-ABTest-RelatedLinksAATest = "A";
+    } else {
+      set req.http.GOVUK-ABTest-RelatedLinksAATest = "B";
+    }
+  }
+}
+# End dynamic section
+
+
+  if (req.http.Cookie ~ "JS-Detection") {
+    set req.http.GOVUK-JS-Detection = req.http.Cookie:JS-Detection;
+  } else {
+  # If the identifier cookie isn't present, set the header to a unique value,
+  # derived as per the suggestion in https://community.fastly.com/t/unique-request-identifier/468/2
+    set req.http.GOVUK-JS-Detection = digest.hash_sha1(now randomstr(64) req.http.host req.url req.http.Fastly-Client-IP server.identity);
+
+  }
+
+  return(lookup);
+}
+
+sub vcl_fetch {
+#FASTLY fetch
+
+  set beresp.http.Fastly-Backend-Name = req.http.Fastly-Backend-Name;
+
+  if ((beresp.status >= 500 && beresp.status <= 599) && req.restarts < 3 && (req.request == "GET" || req.request == "HEAD") && !beresp.http.No-Fallback) {
+    set beresp.saintmode = 5s;
+    return (restart);
+  }
+
+  if (req.restarts == 0) {
+    # Keep stale for origin
+    set beresp.grace = 24h;
+  }
+
+  if(req.restarts > 0 ) {
+    set beresp.http.Fastly-Restarts = req.restarts;
+  }
+
+  if (beresp.http.Cache-Control ~ "private") {
+    set req.http.Fastly-Cachetype = "PRIVATE";
+    return (pass);
+  }
+
+  if (beresp.http.Cache-Control ~ "max-age=0") {
+    return (pass);
+  }
+
+  if (beresp.http.Cache-Control ~ "no-(store|cache)") {
+    return (pass);
+  }
+
+  # The only valid status from our mirrors is a 200. They cannot return e.g.
+  # a 301 status code. All errors from the mirrors are set to 503 as they
+  # cannot know whether or not a page actually exists (e.g. /search is a valid
+  # URL but the mirror cannot return it).
+  if (beresp.status != 200 && beresp.http.Fastly-Backend-Name ~ "mirror") {
+    set beresp.status = 503;
+  }
+
+  if (beresp.status >= 500 && beresp.status <= 599) {
+    set req.http.Fastly-Cachetype = "ERROR";
+    set beresp.ttl = 1s;
+    set beresp.grace = 5s;
+    if (beresp.http.Fastly-Backend-Name ~ "mirrorS3") {
+      error 503 "Error page";
+    }
+    return (deliver);
+  }
+
+  if (beresp.http.Expires || beresp.http.Surrogate-Control ~ "max-age" || beresp.http.Cache-Control ~"(s-maxage|max-age)") {
+    # keep the ttl here
+  } else {
+    # apply the default ttl
+    set beresp.ttl = 5000s;
+
+    # S3 does not set cache headers by default. Override TTL and add cache-control with 15 minutes
+    if (beresp.http.Fastly-Backend-Name ~ "mirrorS3") {
+      set beresp.ttl = 900s;
+      set beresp.http.Cache-Control = "max-age=900";
+    }
+  }
+
+  # Override default.vcl behaviour of return(pass).
+  if (beresp.http.Set-Cookie) {
+    return (deliver);
+  }
+}
+
+sub vcl_hit {
+#FASTLY hit
+}
+
+sub vcl_miss {
+#FASTLY miss
+}
+
+sub vcl_deliver {
+  # Set the A/B cookies
+  # Only set the A/B example cookie if the request is to the A/B test page. This
+  # ensures that most visitors to the site aren't assigned an irrelevant test
+  # cookie.
+  if (req.url ~ "^/help/ab-testing"
+    && req.http.User-Agent !~ "^GOV\.UK Crawler Worker"
+    && req.http.Cookie !~ "ABTest-Example") {
+    # Set a fairly short cookie expiry because this is just an A/B test demo.
+    add resp.http.Set-Cookie = "ABTest-Example=" req.http.GOVUK-ABTest-Example "; expires=" now + 1d;
+  }
+
+  # Begin dynamic section
+  declare local var.expiry TIME;
+  if (table.lookup(active_ab_tests, "ViewDrivingLicence") == "true") {
+    if (req.http.Cookie !~ "ABTest-ViewDrivingLicence" || req.url ~ "[\?\&]ABTest-ViewDrivingLicence" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
+      set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "ViewDrivingLicence"))));
+      add resp.http.Set-Cookie = "ABTest-ViewDrivingLicence=" req.http.GOVUK-ABTest-ViewDrivingLicence "; expires=" var.expiry "; path=/";
+    }
+  }
+  if (table.lookup(active_ab_tests, "RelatedLinksAATest") == "true") {
+    if (req.http.Cookie !~ "ABTest-RelatedLinksAATest" || req.url ~ "[\?\&]ABTest-RelatedLinksAATest" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
+      set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "RelatedLinksAATest"))));
+      add resp.http.Set-Cookie = "ABTest-RelatedLinksAATest=" req.http.GOVUK-ABTest-RelatedLinksAATest "; expires=" var.expiry "; path=/";
+    }
+  }
+  # End dynamic section
+
+  # Set the TLS version session cookie with the raw protocol version from
+  # Fastly only if it isn't already set. We also check for a null TLS value,
+  # which can occur when trying to access over HTTP (http>https upgrading).
+  if (tls.client.protocol && req.http.Cookie !~ "TLSversion") {
+    add resp.http.Set-Cookie = "TLSversion=" tls.client.protocol "; secure";
+  }
+
+  # Set the Javascript detection cookie
+  if (req.http.User-Agent !~ "^GOV\.UK Crawler Worker" && req.http.Cookie !~ "JS-Detection") {
+    add resp.http.Set-Cookie = "JS-Detection=" req.http.GOVUK-JS-Detection "; expires=" now + 5w "; path=/";
+  }
+
+
+#FASTLY deliver
+}
+
+sub vcl_error {
+  if (obj.status == 801) {
+    set obj.status = 301;
+    set obj.response = "Moved Permanently";
+    set obj.http.Location = "https://" req.http.host req.url;
+    set obj.http.Fastly-Backend-Name = "force_ssl";
+    synthetic {""};
+    return (deliver);
+  }
+
+  
+
+  # Assume we've hit vcl_error() because the backend is unavailable
+  # for the first two retries. By restarting, vcl_recv() will try
+  # serving from stale before failing over to the mirrors.
+  if (req.restarts < 3) {
+    return (restart);
+  }
+
+  set obj.http.Fastly-Backend-Name = "error";
+  synthetic {"
+    <!DOCTYPE html>
+    <html>
+      <head>
+        <title>Welcome to GOV.UK</title>
+        <style>
+          body { font-family: Arial, sans-serif; margin: 0; }
+          header { background: black; }
+          h1 { color: white; font-size: 29px; margin: 0 auto; padding: 10px; max-width: 990px; }
+          p { color: black; margin: 30px auto; max-width: 990px; }
+        </style>
+      </head>
+      <body>
+        <header><h1>GOV.UK</h1></header>
+        <p>We're experiencing technical difficulties. Please try again later.</p>
+      </body>
+    </html>"};
+
+  return (deliver);
+
+#FASTLY error
+}
+
+# pipe cannot be included.
+
+sub vcl_pass {
+#FASTLY pass
+}
+
+sub vcl_hash {
+#FASTLY hash
+}

--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -1,0 +1,505 @@
+backend F_origin {
+    .connect_timeout = 5s;
+    .dynamic = true;
+    .port = "443";
+    .host = "foo";
+    .first_byte_timeout = 15s;
+    .max_connections = 200;
+    .between_bytes_timeout = 10s;
+    .share_key = "123";
+
+    .ssl = true;
+    .ssl_check_cert = always;
+    .min_tls_version = "1.2";
+    .ssl_cert_hostname = "foo";
+    .ssl_sni_hostname = "foo";
+
+    .probe = {
+        .request =
+            "HEAD / HTTP/1.1"
+            "Host: foo"
+            "User-Agent: Fastly healthcheck (git version: )"
+            "Connection: close";
+        .threshold = 1;
+        .window = 2;
+        .timeout = 5s;
+        .initial = 1;
+        .expected_response = 200;
+        .interval = 10s;
+    }
+}
+# Mirror backend for provider 0
+backend F_mirror1 {
+    .connect_timeout = 1s;
+    .dynamic = true;
+    .port = "443";
+    .host = "foo";
+    .first_byte_timeout = 15s;
+    .max_connections = 200;
+    .between_bytes_timeout = 10s;
+    .share_key = "123";
+
+    .ssl = true;
+    .ssl_check_cert = always;
+    .min_tls_version = "1.2";
+    .ssl_cert_hostname = "foo";
+    .ssl_sni_hostname = "foo";
+
+    .probe = {
+        .request =
+            "HEAD / HTTP/1.1"
+            "Host: foo"
+            "User-Agent: Fastly healthcheck (git version: )"
+            "Connection: close";
+        .threshold = 1;
+        .window = 2;
+        .timeout = 5s;
+        .initial = 1;
+        .expected_response = 200;
+        .interval = 10s;
+    }
+}
+# Mirror backend for S3
+backend F_mirrorS3 {
+    .connect_timeout = 1s;
+    .dynamic = true;
+    .port = "443";
+    .host = "bar";
+    .first_byte_timeout = 15s;
+    .max_connections = 200;
+    .between_bytes_timeout = 10s;
+    .share_key = "123";
+
+    .ssl = true;
+    .ssl_check_cert = always;
+    .min_tls_version = "1.2";
+    .ssl_cert_hostname = "bar";
+    .ssl_sni_hostname = "bar";
+
+    .probe = {
+        .request =
+            "HEAD / HTTP/1.1"
+            "Host: bar"
+            "User-Agent: Fastly healthcheck (git version: )"
+            "Connection: close";
+        .threshold = 1;
+        .window = 2;
+        .timeout = 5s;
+        .initial = 1;
+        .expected_response = 200;
+        .interval = 10s;
+    }
+}
+
+backend sick_force_grace {
+  .host = "127.0.0.1";
+  .port = "1";
+  .probe = {
+    .request = "invalid";
+    .interval = 365d;
+    .initial = 0;
+  }
+}
+
+
+acl purge_ip_whitelist {
+  "37.26.93.252";     # Skyscape mirrors
+  "31.210.241.100";   # Carrenza mirrors
+
+  "31.210.245.86";    # Carrenza Production
+
+  "23.235.32.0"/20;   # Fastly cache node
+  "43.249.72.0"/22;   # Fastly cache node
+  "103.244.50.0"/24;  # Fastly cache node
+  "103.245.222.0"/23; # Fastly cache node
+  "103.245.224.0"/24; # Fastly cache node
+  "104.156.80.0"/20;  # Fastly cache node
+  "151.101.0.0"/16;   # Fastly cache node
+  "157.52.64.0"/18;   # Fastly cache node
+  "172.111.64.0"/18;  # Fastly cache node
+  "185.31.16.0"/22;   # Fastly cache node
+  "199.27.72.0"/21;   # Fastly cache node
+  "199.232.0.0"/16;   # Fastly cache node
+  "202.21.128.0"/24;  # Fastly cache node
+  "203.57.145.0"/24;  # Fastly cache node
+}
+
+
+
+sub vcl_recv {
+
+  # Allow FASTLYPURGE from IPs defined in the ACL only, else return a HTTP 403
+  if (req.request == "FASTLYPURGE") {
+    if (client.ip ~ purge_ip_whitelist) {
+      return (lookup);
+    }
+    error 403 "Forbidden";
+  }
+
+  
+
+  # Check whether the remote IP address is in the list of blocked IPs
+  if (table.lookup(ip_address_blacklist, client.ip)) {
+    error 403 "Forbidden";
+  }
+
+  
+
+  # Force SSL.
+  if (!req.http.Fastly-SSL) {
+     error 801 "Force SSL";
+  }
+
+  # Serve a 404 Not Found response if request URL matches "/autodiscover/autodiscover.xml"
+  # This is to avoid a Denial of Service "attack" from certain government machines.
+  if (req.url ~ "(?i)^/autodiscover/autodiscover.xml") {
+    error 404 "Not Found";
+  }
+
+  # Serve from stale for 24 hours if origin is sick
+  set req.grace = 24h;
+
+  # Default backend.
+  set req.backend = F_origin;
+  set req.http.Fastly-Backend-Name = "origin";
+
+  # Serve stale if it exists.
+  if (req.restarts > 0) {
+    set req.backend = sick_force_grace;
+    set req.http.Fastly-Backend-Name = "stale";
+  }
+
+  # Failover to mirror.
+  if (req.restarts > 1) {
+    # Don't serve from stale for mirrors
+    set req.grace = 0s;
+    set req.http.Fastly-Failover = "1";
+
+    set req.backend = F_mirror1;
+    set req.http.host = "foo";
+    set req.http.Fastly-Backend-Name = "mirror1";
+  }
+
+  # FIXME: Prefer a fallback director if we move to Varnish 3
+  if (req.restarts > 2) {
+    set req.backend = F_mirrorS3;
+    set req.http.host = "bar";
+    set req.http.Fastly-Backend-Name = "mirrorS3";
+
+    # Requests to home page, rewrite to index.html
+    if (req.url ~ "^/?([\?#].*)?$") {
+      set req.url = regsub(req.url, "^/?([\?#].*)?$", "/index.html\1");
+    }
+
+    # Replace multiple /
+    set req.url = regsuball(req.url, "([^:])//+", "\1/");
+
+    # Requests without document extension, rewrite adding .html
+    if (req.url !~ "^([^#\?\s]+)\.(atom|chm|css|csv|diff|doc|docx|dot|dxf|eps|gif|gml|html|ico|ics|jpeg|jpg|JPG|js|json|kml|odp|ods|odt|pdf|PDF|png|ppt|pptx|ps|rdf|rtf|sch|txt|wsdl|xls|xlsm|xlsx|xlt|xml|xsd|xslt|zip)([\?#]+.*)?$") {
+      set req.url = regsub(req.url, "^([^#\?\s]+)([\?#]+.*)?$", "\1.html\2");
+    }
+    # Add bucket directory prefix to all the requests
+    set req.url = "/foo_" req.url;
+  }
+
+  # Unspoofable original client address.
+  set req.http.True-Client-IP = req.http.Fastly-Client-IP;
+
+  # Set a TLSversion request header for requests going to the Licensify application
+  # This is used to block unsecure requests at the application level for payment security reasons and an absence of caching in Licensify
+  if (req.url ~ "^/apply-for-a-licence/.*") {
+    set req.http.TLSversion = tls.client.protocol;
+  }
+
+
+#FASTLY recv
+
+  if (req.request != "HEAD" && req.request != "GET" && req.request != "FASTLYPURGE") {
+    return(pass);
+  }
+
+    # Begin dynamic section
+if (table.lookup(active_ab_tests, "Example") == "true") {
+  if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
+    set req.http.GOVUK-ABTest-Example = "A";
+  } else if (req.url ~ "[\?\&]ABTest-Example=A(&|$)") {
+    # Some users, such as remote testers, will be given a URL with a query string
+    # to place them into a specific bucket.
+    set req.http.GOVUK-ABTest-Example = "A";
+  } else if (req.url ~ "[\?\&]ABTest-Example=B(&|$)") {
+    # Some users, such as remote testers, will be given a URL with a query string
+    # to place them into a specific bucket.
+    set req.http.GOVUK-ABTest-Example = "B";
+  } else if (req.http.Cookie ~ "ABTest-Example") {
+    # Set the value of the header to whatever decision was previously made
+    set req.http.GOVUK-ABTest-Example = req.http.Cookie:ABTest-Example;
+  } else {
+    declare local var.denominator_Example INTEGER;
+    declare local var.denominator_Example_A INTEGER;
+    declare local var.nominator_Example_A INTEGER;
+    set var.nominator_Example_A = std.atoi(table.lookup(example_percentages, "A"));
+    set var.denominator_Example += var.nominator_Example_A;
+    declare local var.denominator_Example_B INTEGER;
+    declare local var.nominator_Example_B INTEGER;
+    set var.nominator_Example_B = std.atoi(table.lookup(example_percentages, "B"));
+    set var.denominator_Example += var.nominator_Example_B;
+    set var.denominator_Example_A = var.denominator_Example;
+    if (randombool(var.nominator_Example_A, var.denominator_Example_A)) {
+      set req.http.GOVUK-ABTest-Example = "A";
+    } else {
+      set req.http.GOVUK-ABTest-Example = "B";
+    }
+  }
+}
+if (table.lookup(active_ab_tests, "ViewDrivingLicence") == "true") {
+  if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
+    set req.http.GOVUK-ABTest-ViewDrivingLicence = "A";
+  } else if (req.url ~ "[\?\&]ABTest-ViewDrivingLicence=A(&|$)") {
+    # Some users, such as remote testers, will be given a URL with a query string
+    # to place them into a specific bucket.
+    set req.http.GOVUK-ABTest-ViewDrivingLicence = "A";
+  } else if (req.url ~ "[\?\&]ABTest-ViewDrivingLicence=B(&|$)") {
+    # Some users, such as remote testers, will be given a URL with a query string
+    # to place them into a specific bucket.
+    set req.http.GOVUK-ABTest-ViewDrivingLicence = "B";
+  } else if (req.http.Cookie ~ "ABTest-ViewDrivingLicence") {
+    # Set the value of the header to whatever decision was previously made
+    set req.http.GOVUK-ABTest-ViewDrivingLicence = req.http.Cookie:ABTest-ViewDrivingLicence;
+  } else {
+    declare local var.denominator_ViewDrivingLicence INTEGER;
+    declare local var.denominator_ViewDrivingLicence_A INTEGER;
+    declare local var.nominator_ViewDrivingLicence_A INTEGER;
+    set var.nominator_ViewDrivingLicence_A = std.atoi(table.lookup(viewdrivinglicence_percentages, "A"));
+    set var.denominator_ViewDrivingLicence += var.nominator_ViewDrivingLicence_A;
+    declare local var.denominator_ViewDrivingLicence_B INTEGER;
+    declare local var.nominator_ViewDrivingLicence_B INTEGER;
+    set var.nominator_ViewDrivingLicence_B = std.atoi(table.lookup(viewdrivinglicence_percentages, "B"));
+    set var.denominator_ViewDrivingLicence += var.nominator_ViewDrivingLicence_B;
+    set var.denominator_ViewDrivingLicence_A = var.denominator_ViewDrivingLicence;
+    if (randombool(var.nominator_ViewDrivingLicence_A, var.denominator_ViewDrivingLicence_A)) {
+      set req.http.GOVUK-ABTest-ViewDrivingLicence = "A";
+    } else {
+      set req.http.GOVUK-ABTest-ViewDrivingLicence = "B";
+    }
+  }
+}
+if (table.lookup(active_ab_tests, "RelatedLinksAATest") == "true") {
+  if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
+    set req.http.GOVUK-ABTest-RelatedLinksAATest = "A";
+  } else if (req.url ~ "[\?\&]ABTest-RelatedLinksAATest=A(&|$)") {
+    # Some users, such as remote testers, will be given a URL with a query string
+    # to place them into a specific bucket.
+    set req.http.GOVUK-ABTest-RelatedLinksAATest = "A";
+  } else if (req.url ~ "[\?\&]ABTest-RelatedLinksAATest=B(&|$)") {
+    # Some users, such as remote testers, will be given a URL with a query string
+    # to place them into a specific bucket.
+    set req.http.GOVUK-ABTest-RelatedLinksAATest = "B";
+  } else if (req.http.Cookie ~ "ABTest-RelatedLinksAATest") {
+    # Set the value of the header to whatever decision was previously made
+    set req.http.GOVUK-ABTest-RelatedLinksAATest = req.http.Cookie:ABTest-RelatedLinksAATest;
+  } else {
+    declare local var.denominator_RelatedLinksAATest INTEGER;
+    declare local var.denominator_RelatedLinksAATest_A INTEGER;
+    declare local var.nominator_RelatedLinksAATest_A INTEGER;
+    set var.nominator_RelatedLinksAATest_A = std.atoi(table.lookup(relatedlinksaatest_percentages, "A"));
+    set var.denominator_RelatedLinksAATest += var.nominator_RelatedLinksAATest_A;
+    declare local var.denominator_RelatedLinksAATest_B INTEGER;
+    declare local var.nominator_RelatedLinksAATest_B INTEGER;
+    set var.nominator_RelatedLinksAATest_B = std.atoi(table.lookup(relatedlinksaatest_percentages, "B"));
+    set var.denominator_RelatedLinksAATest += var.nominator_RelatedLinksAATest_B;
+    set var.denominator_RelatedLinksAATest_A = var.denominator_RelatedLinksAATest;
+    if (randombool(var.nominator_RelatedLinksAATest_A, var.denominator_RelatedLinksAATest_A)) {
+      set req.http.GOVUK-ABTest-RelatedLinksAATest = "A";
+    } else {
+      set req.http.GOVUK-ABTest-RelatedLinksAATest = "B";
+    }
+  }
+}
+# End dynamic section
+
+
+  if (req.http.Cookie ~ "JS-Detection") {
+    set req.http.GOVUK-JS-Detection = req.http.Cookie:JS-Detection;
+  } else {
+  # If the identifier cookie isn't present, set the header to a unique value,
+  # derived as per the suggestion in https://community.fastly.com/t/unique-request-identifier/468/2
+    set req.http.GOVUK-JS-Detection = digest.hash_sha1(now randomstr(64) req.http.host req.url req.http.Fastly-Client-IP server.identity);
+
+  }
+
+  return(lookup);
+}
+
+sub vcl_fetch {
+#FASTLY fetch
+
+  set beresp.http.Fastly-Backend-Name = req.http.Fastly-Backend-Name;
+
+  if ((beresp.status >= 500 && beresp.status <= 599) && req.restarts < 3 && (req.request == "GET" || req.request == "HEAD") && !beresp.http.No-Fallback) {
+    set beresp.saintmode = 5s;
+    return (restart);
+  }
+
+  if (req.restarts == 0) {
+    # Keep stale for origin
+    set beresp.grace = 24h;
+  }
+
+  if(req.restarts > 0 ) {
+    set beresp.http.Fastly-Restarts = req.restarts;
+  }
+
+  if (beresp.http.Cache-Control ~ "private") {
+    set req.http.Fastly-Cachetype = "PRIVATE";
+    return (pass);
+  }
+
+  if (beresp.http.Cache-Control ~ "max-age=0") {
+    return (pass);
+  }
+
+  if (beresp.http.Cache-Control ~ "no-(store|cache)") {
+    return (pass);
+  }
+
+  # The only valid status from our mirrors is a 200. They cannot return e.g.
+  # a 301 status code. All errors from the mirrors are set to 503 as they
+  # cannot know whether or not a page actually exists (e.g. /search is a valid
+  # URL but the mirror cannot return it).
+  if (beresp.status != 200 && beresp.http.Fastly-Backend-Name ~ "mirror") {
+    set beresp.status = 503;
+  }
+
+  if (beresp.status >= 500 && beresp.status <= 599) {
+    set req.http.Fastly-Cachetype = "ERROR";
+    set beresp.ttl = 1s;
+    set beresp.grace = 5s;
+    if (beresp.http.Fastly-Backend-Name ~ "mirrorS3") {
+      error 503 "Error page";
+    }
+    return (deliver);
+  }
+
+  if (beresp.http.Expires || beresp.http.Surrogate-Control ~ "max-age" || beresp.http.Cache-Control ~"(s-maxage|max-age)") {
+    # keep the ttl here
+  } else {
+    # apply the default ttl
+    set beresp.ttl = 5000s;
+
+    # S3 does not set cache headers by default. Override TTL and add cache-control with 15 minutes
+    if (beresp.http.Fastly-Backend-Name ~ "mirrorS3") {
+      set beresp.ttl = 900s;
+      set beresp.http.Cache-Control = "max-age=900";
+    }
+  }
+
+  # Override default.vcl behaviour of return(pass).
+  if (beresp.http.Set-Cookie) {
+    return (deliver);
+  }
+}
+
+sub vcl_hit {
+#FASTLY hit
+}
+
+sub vcl_miss {
+#FASTLY miss
+}
+
+sub vcl_deliver {
+  # Set the A/B cookies
+  # Only set the A/B example cookie if the request is to the A/B test page. This
+  # ensures that most visitors to the site aren't assigned an irrelevant test
+  # cookie.
+  if (req.url ~ "^/help/ab-testing"
+    && req.http.User-Agent !~ "^GOV\.UK Crawler Worker"
+    && req.http.Cookie !~ "ABTest-Example") {
+    # Set a fairly short cookie expiry because this is just an A/B test demo.
+    add resp.http.Set-Cookie = "ABTest-Example=" req.http.GOVUK-ABTest-Example "; expires=" now + 1d;
+  }
+
+  # Begin dynamic section
+  declare local var.expiry TIME;
+  if (table.lookup(active_ab_tests, "ViewDrivingLicence") == "true") {
+    if (req.http.Cookie !~ "ABTest-ViewDrivingLicence" || req.url ~ "[\?\&]ABTest-ViewDrivingLicence" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
+      set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "ViewDrivingLicence"))));
+      add resp.http.Set-Cookie = "ABTest-ViewDrivingLicence=" req.http.GOVUK-ABTest-ViewDrivingLicence "; expires=" var.expiry "; path=/";
+    }
+  }
+  if (table.lookup(active_ab_tests, "RelatedLinksAATest") == "true") {
+    if (req.http.Cookie !~ "ABTest-RelatedLinksAATest" || req.url ~ "[\?\&]ABTest-RelatedLinksAATest" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
+      set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "RelatedLinksAATest"))));
+      add resp.http.Set-Cookie = "ABTest-RelatedLinksAATest=" req.http.GOVUK-ABTest-RelatedLinksAATest "; expires=" var.expiry "; path=/";
+    }
+  }
+  # End dynamic section
+
+  # Set the TLS version session cookie with the raw protocol version from
+  # Fastly only if it isn't already set. We also check for a null TLS value,
+  # which can occur when trying to access over HTTP (http>https upgrading).
+  if (tls.client.protocol && req.http.Cookie !~ "TLSversion") {
+    add resp.http.Set-Cookie = "TLSversion=" tls.client.protocol "; secure";
+  }
+
+  # Set the Javascript detection cookie
+  if (req.http.User-Agent !~ "^GOV\.UK Crawler Worker" && req.http.Cookie !~ "JS-Detection") {
+    add resp.http.Set-Cookie = "JS-Detection=" req.http.GOVUK-JS-Detection "; expires=" now + 5w "; path=/";
+  }
+
+
+#FASTLY deliver
+}
+
+sub vcl_error {
+  if (obj.status == 801) {
+    set obj.status = 301;
+    set obj.response = "Moved Permanently";
+    set obj.http.Location = "https://" req.http.host req.url;
+    set obj.http.Fastly-Backend-Name = "force_ssl";
+    synthetic {""};
+    return (deliver);
+  }
+
+  
+
+  # Assume we've hit vcl_error() because the backend is unavailable
+  # for the first two retries. By restarting, vcl_recv() will try
+  # serving from stale before failing over to the mirrors.
+  if (req.restarts < 3) {
+    return (restart);
+  }
+
+  set obj.http.Fastly-Backend-Name = "error";
+  synthetic {"
+    <!DOCTYPE html>
+    <html>
+      <head>
+        <title>Welcome to GOV.UK</title>
+        <style>
+          body { font-family: Arial, sans-serif; margin: 0; }
+          header { background: black; }
+          h1 { color: white; font-size: 29px; margin: 0 auto; padding: 10px; max-width: 990px; }
+          p { color: black; margin: 30px auto; max-width: 990px; }
+        </style>
+      </head>
+      <body>
+        <header><h1>GOV.UK</h1></header>
+        <p>We're experiencing technical difficulties. Please try again later.</p>
+      </body>
+    </html>"};
+
+  return (deliver);
+
+#FASTLY error
+}
+
+# pipe cannot be included.
+
+sub vcl_pass {
+#FASTLY pass
+}
+
+sub vcl_hash {
+#FASTLY hash
+}

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -1,0 +1,514 @@
+backend F_origin {
+    .connect_timeout = 5s;
+    .dynamic = true;
+    .port = "443";
+    .host = "foo";
+    .first_byte_timeout = 15s;
+    .max_connections = 200;
+    .between_bytes_timeout = 10s;
+    .share_key = "123";
+
+    .ssl = true;
+    .ssl_check_cert = always;
+    .min_tls_version = "1.2";
+    .ssl_cert_hostname = "foo";
+    .ssl_sni_hostname = "foo";
+
+    .probe = {
+        .request =
+            "HEAD / HTTP/1.1"
+            "Host: foo"
+            "User-Agent: Fastly healthcheck (git version: )"
+            "Connection: close";
+        .threshold = 1;
+        .window = 2;
+        .timeout = 5s;
+        .initial = 1;
+        .expected_response = 200;
+        .interval = 10s;
+    }
+}
+# Mirror backend for provider 0
+backend F_mirror1 {
+    .connect_timeout = 1s;
+    .dynamic = true;
+    .port = "443";
+    .host = "foo";
+    .first_byte_timeout = 15s;
+    .max_connections = 200;
+    .between_bytes_timeout = 10s;
+    .share_key = "123";
+
+    .ssl = true;
+    .ssl_check_cert = always;
+    .min_tls_version = "1.2";
+    .ssl_cert_hostname = "foo";
+    .ssl_sni_hostname = "foo";
+
+    .probe = {
+        .request =
+            "HEAD / HTTP/1.1"
+            "Host: foo"
+            "User-Agent: Fastly healthcheck (git version: )"
+            "Connection: close";
+        .threshold = 1;
+        .window = 2;
+        .timeout = 5s;
+        .initial = 1;
+        .expected_response = 200;
+        .interval = 10s;
+    }
+}
+# Mirror backend for S3
+backend F_mirrorS3 {
+    .connect_timeout = 1s;
+    .dynamic = true;
+    .port = "443";
+    .host = "bar";
+    .first_byte_timeout = 15s;
+    .max_connections = 200;
+    .between_bytes_timeout = 10s;
+    .share_key = "123";
+
+    .ssl = true;
+    .ssl_check_cert = always;
+    .min_tls_version = "1.2";
+    .ssl_cert_hostname = "bar";
+    .ssl_sni_hostname = "bar";
+
+    .probe = {
+        .request =
+            "HEAD / HTTP/1.1"
+            "Host: bar"
+            "User-Agent: Fastly healthcheck (git version: )"
+            "Connection: close";
+        .threshold = 1;
+        .window = 2;
+        .timeout = 5s;
+        .initial = 1;
+        .expected_response = 200;
+        .interval = 10s;
+    }
+}
+
+backend sick_force_grace {
+  .host = "127.0.0.1";
+  .port = "1";
+  .probe = {
+    .request = "invalid";
+    .interval = 365d;
+    .initial = 0;
+  }
+}
+
+
+acl purge_ip_whitelist {
+  "37.26.93.252";     # Skyscape mirrors
+  "31.210.241.100";   # Carrenza mirrors
+
+  "31.210.245.70";    # Carrenza Staging
+
+  "23.235.32.0"/20;   # Fastly cache node
+  "43.249.72.0"/22;   # Fastly cache node
+  "103.244.50.0"/24;  # Fastly cache node
+  "103.245.222.0"/23; # Fastly cache node
+  "103.245.224.0"/24; # Fastly cache node
+  "104.156.80.0"/20;  # Fastly cache node
+  "151.101.0.0"/16;   # Fastly cache node
+  "157.52.64.0"/18;   # Fastly cache node
+  "172.111.64.0"/18;  # Fastly cache node
+  "185.31.16.0"/22;   # Fastly cache node
+  "199.27.72.0"/21;   # Fastly cache node
+  "199.232.0.0"/16;   # Fastly cache node
+  "202.21.128.0"/24;  # Fastly cache node
+  "203.57.145.0"/24;  # Fastly cache node
+}
+
+
+acl allowed_ip_addresses {
+  
+}
+
+
+sub vcl_recv {
+
+  # Allow FASTLYPURGE from IPs defined in the ACL only, else return a HTTP 403
+  if (req.request == "FASTLYPURGE") {
+    if (client.ip ~ purge_ip_whitelist) {
+      return (lookup);
+    }
+    error 403 "Forbidden";
+  }
+
+  
+  # Only allow connections from allowed IP addresses in staging
+  if (! (client.ip ~ allowed_ip_addresses)) {
+    error 403 "Forbidden";
+  }
+  
+
+  # Check whether the remote IP address is in the list of blocked IPs
+  if (table.lookup(ip_address_blacklist, client.ip)) {
+    error 403 "Forbidden";
+  }
+
+  
+
+  # Force SSL.
+  if (!req.http.Fastly-SSL) {
+     error 801 "Force SSL";
+  }
+
+  # Serve a 404 Not Found response if request URL matches "/autodiscover/autodiscover.xml"
+  # This is to avoid a Denial of Service "attack" from certain government machines.
+  if (req.url ~ "(?i)^/autodiscover/autodiscover.xml") {
+    error 404 "Not Found";
+  }
+
+  # Serve from stale for 24 hours if origin is sick
+  set req.grace = 24h;
+
+  # Default backend.
+  set req.backend = F_origin;
+  set req.http.Fastly-Backend-Name = "origin";
+
+  # Serve stale if it exists.
+  if (req.restarts > 0) {
+    set req.backend = sick_force_grace;
+    set req.http.Fastly-Backend-Name = "stale";
+  }
+
+  # Failover to mirror.
+  if (req.restarts > 1) {
+    # Don't serve from stale for mirrors
+    set req.grace = 0s;
+    set req.http.Fastly-Failover = "1";
+
+    set req.backend = F_mirror1;
+    set req.http.host = "foo";
+    set req.http.Fastly-Backend-Name = "mirror1";
+  }
+
+  # FIXME: Prefer a fallback director if we move to Varnish 3
+  if (req.restarts > 2) {
+    set req.backend = F_mirrorS3;
+    set req.http.host = "bar";
+    set req.http.Fastly-Backend-Name = "mirrorS3";
+
+    # Requests to home page, rewrite to index.html
+    if (req.url ~ "^/?([\?#].*)?$") {
+      set req.url = regsub(req.url, "^/?([\?#].*)?$", "/index.html\1");
+    }
+
+    # Replace multiple /
+    set req.url = regsuball(req.url, "([^:])//+", "\1/");
+
+    # Requests without document extension, rewrite adding .html
+    if (req.url !~ "^([^#\?\s]+)\.(atom|chm|css|csv|diff|doc|docx|dot|dxf|eps|gif|gml|html|ico|ics|jpeg|jpg|JPG|js|json|kml|odp|ods|odt|pdf|PDF|png|ppt|pptx|ps|rdf|rtf|sch|txt|wsdl|xls|xlsm|xlsx|xlt|xml|xsd|xslt|zip)([\?#]+.*)?$") {
+      set req.url = regsub(req.url, "^([^#\?\s]+)([\?#]+.*)?$", "\1.html\2");
+    }
+    # Add bucket directory prefix to all the requests
+    set req.url = "/foo_" req.url;
+  }
+
+  # Unspoofable original client address.
+  set req.http.True-Client-IP = req.http.Fastly-Client-IP;
+
+  # Set a TLSversion request header for requests going to the Licensify application
+  # This is used to block unsecure requests at the application level for payment security reasons and an absence of caching in Licensify
+  if (req.url ~ "^/apply-for-a-licence/.*") {
+    set req.http.TLSversion = tls.client.protocol;
+  }
+
+
+#FASTLY recv
+
+  if (req.request != "HEAD" && req.request != "GET" && req.request != "FASTLYPURGE") {
+    return(pass);
+  }
+
+    # Begin dynamic section
+if (table.lookup(active_ab_tests, "Example") == "true") {
+  if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
+    set req.http.GOVUK-ABTest-Example = "A";
+  } else if (req.url ~ "[\?\&]ABTest-Example=A(&|$)") {
+    # Some users, such as remote testers, will be given a URL with a query string
+    # to place them into a specific bucket.
+    set req.http.GOVUK-ABTest-Example = "A";
+  } else if (req.url ~ "[\?\&]ABTest-Example=B(&|$)") {
+    # Some users, such as remote testers, will be given a URL with a query string
+    # to place them into a specific bucket.
+    set req.http.GOVUK-ABTest-Example = "B";
+  } else if (req.http.Cookie ~ "ABTest-Example") {
+    # Set the value of the header to whatever decision was previously made
+    set req.http.GOVUK-ABTest-Example = req.http.Cookie:ABTest-Example;
+  } else {
+    declare local var.denominator_Example INTEGER;
+    declare local var.denominator_Example_A INTEGER;
+    declare local var.nominator_Example_A INTEGER;
+    set var.nominator_Example_A = std.atoi(table.lookup(example_percentages, "A"));
+    set var.denominator_Example += var.nominator_Example_A;
+    declare local var.denominator_Example_B INTEGER;
+    declare local var.nominator_Example_B INTEGER;
+    set var.nominator_Example_B = std.atoi(table.lookup(example_percentages, "B"));
+    set var.denominator_Example += var.nominator_Example_B;
+    set var.denominator_Example_A = var.denominator_Example;
+    if (randombool(var.nominator_Example_A, var.denominator_Example_A)) {
+      set req.http.GOVUK-ABTest-Example = "A";
+    } else {
+      set req.http.GOVUK-ABTest-Example = "B";
+    }
+  }
+}
+if (table.lookup(active_ab_tests, "ViewDrivingLicence") == "true") {
+  if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
+    set req.http.GOVUK-ABTest-ViewDrivingLicence = "A";
+  } else if (req.url ~ "[\?\&]ABTest-ViewDrivingLicence=A(&|$)") {
+    # Some users, such as remote testers, will be given a URL with a query string
+    # to place them into a specific bucket.
+    set req.http.GOVUK-ABTest-ViewDrivingLicence = "A";
+  } else if (req.url ~ "[\?\&]ABTest-ViewDrivingLicence=B(&|$)") {
+    # Some users, such as remote testers, will be given a URL with a query string
+    # to place them into a specific bucket.
+    set req.http.GOVUK-ABTest-ViewDrivingLicence = "B";
+  } else if (req.http.Cookie ~ "ABTest-ViewDrivingLicence") {
+    # Set the value of the header to whatever decision was previously made
+    set req.http.GOVUK-ABTest-ViewDrivingLicence = req.http.Cookie:ABTest-ViewDrivingLicence;
+  } else {
+    declare local var.denominator_ViewDrivingLicence INTEGER;
+    declare local var.denominator_ViewDrivingLicence_A INTEGER;
+    declare local var.nominator_ViewDrivingLicence_A INTEGER;
+    set var.nominator_ViewDrivingLicence_A = std.atoi(table.lookup(viewdrivinglicence_percentages, "A"));
+    set var.denominator_ViewDrivingLicence += var.nominator_ViewDrivingLicence_A;
+    declare local var.denominator_ViewDrivingLicence_B INTEGER;
+    declare local var.nominator_ViewDrivingLicence_B INTEGER;
+    set var.nominator_ViewDrivingLicence_B = std.atoi(table.lookup(viewdrivinglicence_percentages, "B"));
+    set var.denominator_ViewDrivingLicence += var.nominator_ViewDrivingLicence_B;
+    set var.denominator_ViewDrivingLicence_A = var.denominator_ViewDrivingLicence;
+    if (randombool(var.nominator_ViewDrivingLicence_A, var.denominator_ViewDrivingLicence_A)) {
+      set req.http.GOVUK-ABTest-ViewDrivingLicence = "A";
+    } else {
+      set req.http.GOVUK-ABTest-ViewDrivingLicence = "B";
+    }
+  }
+}
+if (table.lookup(active_ab_tests, "RelatedLinksAATest") == "true") {
+  if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
+    set req.http.GOVUK-ABTest-RelatedLinksAATest = "A";
+  } else if (req.url ~ "[\?\&]ABTest-RelatedLinksAATest=A(&|$)") {
+    # Some users, such as remote testers, will be given a URL with a query string
+    # to place them into a specific bucket.
+    set req.http.GOVUK-ABTest-RelatedLinksAATest = "A";
+  } else if (req.url ~ "[\?\&]ABTest-RelatedLinksAATest=B(&|$)") {
+    # Some users, such as remote testers, will be given a URL with a query string
+    # to place them into a specific bucket.
+    set req.http.GOVUK-ABTest-RelatedLinksAATest = "B";
+  } else if (req.http.Cookie ~ "ABTest-RelatedLinksAATest") {
+    # Set the value of the header to whatever decision was previously made
+    set req.http.GOVUK-ABTest-RelatedLinksAATest = req.http.Cookie:ABTest-RelatedLinksAATest;
+  } else {
+    declare local var.denominator_RelatedLinksAATest INTEGER;
+    declare local var.denominator_RelatedLinksAATest_A INTEGER;
+    declare local var.nominator_RelatedLinksAATest_A INTEGER;
+    set var.nominator_RelatedLinksAATest_A = std.atoi(table.lookup(relatedlinksaatest_percentages, "A"));
+    set var.denominator_RelatedLinksAATest += var.nominator_RelatedLinksAATest_A;
+    declare local var.denominator_RelatedLinksAATest_B INTEGER;
+    declare local var.nominator_RelatedLinksAATest_B INTEGER;
+    set var.nominator_RelatedLinksAATest_B = std.atoi(table.lookup(relatedlinksaatest_percentages, "B"));
+    set var.denominator_RelatedLinksAATest += var.nominator_RelatedLinksAATest_B;
+    set var.denominator_RelatedLinksAATest_A = var.denominator_RelatedLinksAATest;
+    if (randombool(var.nominator_RelatedLinksAATest_A, var.denominator_RelatedLinksAATest_A)) {
+      set req.http.GOVUK-ABTest-RelatedLinksAATest = "A";
+    } else {
+      set req.http.GOVUK-ABTest-RelatedLinksAATest = "B";
+    }
+  }
+}
+# End dynamic section
+
+
+  if (req.http.Cookie ~ "JS-Detection") {
+    set req.http.GOVUK-JS-Detection = req.http.Cookie:JS-Detection;
+  } else {
+  # If the identifier cookie isn't present, set the header to a unique value,
+  # derived as per the suggestion in https://community.fastly.com/t/unique-request-identifier/468/2
+    set req.http.GOVUK-JS-Detection = digest.hash_sha1(now randomstr(64) req.http.host req.url req.http.Fastly-Client-IP server.identity);
+
+  }
+
+  return(lookup);
+}
+
+sub vcl_fetch {
+#FASTLY fetch
+
+  set beresp.http.Fastly-Backend-Name = req.http.Fastly-Backend-Name;
+
+  if ((beresp.status >= 500 && beresp.status <= 599) && req.restarts < 3 && (req.request == "GET" || req.request == "HEAD") && !beresp.http.No-Fallback) {
+    set beresp.saintmode = 5s;
+    return (restart);
+  }
+
+  if (req.restarts == 0) {
+    # Keep stale for origin
+    set beresp.grace = 24h;
+  }
+
+  if(req.restarts > 0 ) {
+    set beresp.http.Fastly-Restarts = req.restarts;
+  }
+
+  if (beresp.http.Cache-Control ~ "private") {
+    set req.http.Fastly-Cachetype = "PRIVATE";
+    return (pass);
+  }
+
+  if (beresp.http.Cache-Control ~ "max-age=0") {
+    return (pass);
+  }
+
+  if (beresp.http.Cache-Control ~ "no-(store|cache)") {
+    return (pass);
+  }
+
+  # The only valid status from our mirrors is a 200. They cannot return e.g.
+  # a 301 status code. All errors from the mirrors are set to 503 as they
+  # cannot know whether or not a page actually exists (e.g. /search is a valid
+  # URL but the mirror cannot return it).
+  if (beresp.status != 200 && beresp.http.Fastly-Backend-Name ~ "mirror") {
+    set beresp.status = 503;
+  }
+
+  if (beresp.status >= 500 && beresp.status <= 599) {
+    set req.http.Fastly-Cachetype = "ERROR";
+    set beresp.ttl = 1s;
+    set beresp.grace = 5s;
+    if (beresp.http.Fastly-Backend-Name ~ "mirrorS3") {
+      error 503 "Error page";
+    }
+    return (deliver);
+  }
+
+  if (beresp.http.Expires || beresp.http.Surrogate-Control ~ "max-age" || beresp.http.Cache-Control ~"(s-maxage|max-age)") {
+    # keep the ttl here
+  } else {
+    # apply the default ttl
+    set beresp.ttl = 5000s;
+
+    # S3 does not set cache headers by default. Override TTL and add cache-control with 15 minutes
+    if (beresp.http.Fastly-Backend-Name ~ "mirrorS3") {
+      set beresp.ttl = 900s;
+      set beresp.http.Cache-Control = "max-age=900";
+    }
+  }
+
+  # Override default.vcl behaviour of return(pass).
+  if (beresp.http.Set-Cookie) {
+    return (deliver);
+  }
+}
+
+sub vcl_hit {
+#FASTLY hit
+}
+
+sub vcl_miss {
+#FASTLY miss
+}
+
+sub vcl_deliver {
+  # Set the A/B cookies
+  # Only set the A/B example cookie if the request is to the A/B test page. This
+  # ensures that most visitors to the site aren't assigned an irrelevant test
+  # cookie.
+  if (req.url ~ "^/help/ab-testing"
+    && req.http.User-Agent !~ "^GOV\.UK Crawler Worker"
+    && req.http.Cookie !~ "ABTest-Example") {
+    # Set a fairly short cookie expiry because this is just an A/B test demo.
+    add resp.http.Set-Cookie = "ABTest-Example=" req.http.GOVUK-ABTest-Example "; expires=" now + 1d;
+  }
+
+  # Begin dynamic section
+  declare local var.expiry TIME;
+  if (table.lookup(active_ab_tests, "ViewDrivingLicence") == "true") {
+    if (req.http.Cookie !~ "ABTest-ViewDrivingLicence" || req.url ~ "[\?\&]ABTest-ViewDrivingLicence" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
+      set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "ViewDrivingLicence"))));
+      add resp.http.Set-Cookie = "ABTest-ViewDrivingLicence=" req.http.GOVUK-ABTest-ViewDrivingLicence "; expires=" var.expiry "; path=/";
+    }
+  }
+  if (table.lookup(active_ab_tests, "RelatedLinksAATest") == "true") {
+    if (req.http.Cookie !~ "ABTest-RelatedLinksAATest" || req.url ~ "[\?\&]ABTest-RelatedLinksAATest" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
+      set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "RelatedLinksAATest"))));
+      add resp.http.Set-Cookie = "ABTest-RelatedLinksAATest=" req.http.GOVUK-ABTest-RelatedLinksAATest "; expires=" var.expiry "; path=/";
+    }
+  }
+  # End dynamic section
+
+  # Set the TLS version session cookie with the raw protocol version from
+  # Fastly only if it isn't already set. We also check for a null TLS value,
+  # which can occur when trying to access over HTTP (http>https upgrading).
+  if (tls.client.protocol && req.http.Cookie !~ "TLSversion") {
+    add resp.http.Set-Cookie = "TLSversion=" tls.client.protocol "; secure";
+  }
+
+  # Set the Javascript detection cookie
+  if (req.http.User-Agent !~ "^GOV\.UK Crawler Worker" && req.http.Cookie !~ "JS-Detection") {
+    add resp.http.Set-Cookie = "JS-Detection=" req.http.GOVUK-JS-Detection "; expires=" now + 5w "; path=/";
+  }
+
+
+#FASTLY deliver
+}
+
+sub vcl_error {
+  if (obj.status == 801) {
+    set obj.status = 301;
+    set obj.response = "Moved Permanently";
+    set obj.http.Location = "https://" req.http.host req.url;
+    set obj.http.Fastly-Backend-Name = "force_ssl";
+    synthetic {""};
+    return (deliver);
+  }
+
+  
+
+  # Assume we've hit vcl_error() because the backend is unavailable
+  # for the first two retries. By restarting, vcl_recv() will try
+  # serving from stale before failing over to the mirrors.
+  if (req.restarts < 3) {
+    return (restart);
+  }
+
+  set obj.http.Fastly-Backend-Name = "error";
+  synthetic {"
+    <!DOCTYPE html>
+    <html>
+      <head>
+        <title>Welcome to GOV.UK</title>
+        <style>
+          body { font-family: Arial, sans-serif; margin: 0; }
+          header { background: black; }
+          h1 { color: white; font-size: 29px; margin: 0 auto; padding: 10px; max-width: 990px; }
+          p { color: black; margin: 30px auto; max-width: 990px; }
+        </style>
+      </head>
+      <body>
+        <header><h1>GOV.UK</h1></header>
+        <p>We're experiencing technical difficulties. Please try again later.</p>
+      </body>
+    </html>"};
+
+  return (deliver);
+
+#FASTLY error
+}
+
+# pipe cannot be included.
+
+sub vcl_pass {
+#FASTLY pass
+}
+
+sub vcl_hash {
+#FASTLY hash
+}

--- a/spec/vcl_generation_spec.rb
+++ b/spec/vcl_generation_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+require_relative './../lib/render_template'
+
+# This
+RSpec.describe "VCL generation" do
+  # Fill in the required test data. Normally this would come from
+  # https://github.com/alphagov/cdn-configs/blob/master/fastly/fastly.yaml
+  config = {
+    "origin_hostname" => "foo",
+    "service_id" => "123",
+    "provider1_mirror_hostname" => "foo",
+    "s3_mirror_hostname" => "bar",
+    "s3_mirror_prefix" => "foo_",
+    "default_ttl" => "5000",
+    "apt_hostname" => "foo",
+    "origin_domain_suffix" => "boo",
+    "domain_suffix" => "boo",
+  }
+
+  Dir.glob("vcl_templates/*.erb").each do |template|
+    service = template.sub("vcl_templates/", "").sub(".vcl.erb", "")
+    next if service[0] == "_" # Skip partials
+    next if service == "bouncer" # Bouncer is not deployed from this repo
+    next if service == "test" # For another test
+
+    %w[production staging integration].each do |environment|
+      it "renders the #{service} VCL for #{environment} correctly" do
+        generated_vcl = RenderTemplate.render_template(service, environment, config, "unused variable")
+        expected_vcl_filename = "spec/test-outputs/#{service}-#{environment}.out.vcl"
+
+        if ENV["REGENERATE_EXPECTATIONS"]
+          File.write(expected_vcl_filename, generated_vcl)
+        end
+
+        expect(generated_vcl).to eql(File.read(expected_vcl_filename)),
+          "The generated VCL doesn't matched the test output VCL. If you're sure the generated VCL is correct, regenerate the test files with `REGENERATE_EXPECTATIONS=1 bundle exec rspec`."
+      end
+    end
+  end
+end


### PR DESCRIPTION
We intend to do some refactoring of the code in this repo. To make sure that we don't unintentionally change the VCL that we send to Fastly, this commit adds a test that generates the VCL for each environment and service combination, and checks that against the VCL that we know is good.

You can use `REGENERATE_EXPECTATIONS=1 bundle exec rspec` to regenerate the files. That's useful if you've made changes that you know are fine.

https://trello.com/c/y6MIgxjp