### PR TITLE
Remove Javascript tracking cookies

### DIFF
--- a/spec/test-outputs/www-integration.out.vcl
+++ b/spec/test-outputs/www-integration.out.vcl
@@ -316,15 +316,6 @@ if (table.lookup(active_ab_tests, "RelatedLinksAATest") == "true") {
 # End dynamic section
 
 
-  if (req.http.Cookie ~ "JS-Detection") {
-    set req.http.GOVUK-JS-Detection = req.http.Cookie:JS-Detection;
-  } else {
-  # If the identifier cookie isn't present, set the header to a unique value,
-  # derived as per the suggestion in https://community.fastly.com/t/unique-request-identifier/468/2
-    set req.http.GOVUK-JS-Detection = digest.hash_sha1(now randomstr(64) req.http.host req.url req.http.Fastly-Client-IP server.identity);
-
-  }
-
   return(lookup);
 }
 
@@ -441,12 +432,6 @@ sub vcl_deliver {
   }
 
   add resp.http.Content-Security-Policy-Report-Only = "default-src https 'self' *.publishing.service.gov.uk; img-src 'self' www.google-analytics.com *.publishing.service.gov.uk; script-src 'self' www.google-analytics.com *.publishing.service.gov.uk 'sha256-G29/qSW/JHHANtFhlrZVDZW1HOkCDRc78ggbqwwIJ2g=' 'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU=' 'unsafe-inline'; style-src 'self' *.publishing.service.gov.uk 'unsafe-inline'; connect-src 'self' www.google-analytics.com *.publishing.service.gov.uk; object-src 'none'; report-uri https://sentry.io/api/1377947/security/?sentry_key=f7898bf4858d436aa3568ae042371b94;";
-
-  # Set the Javascript detection cookie
-  if (req.http.User-Agent !~ "^GOV\.UK Crawler Worker" && req.http.Cookie !~ "JS-Detection") {
-    add resp.http.Set-Cookie = "JS-Detection=" req.http.GOVUK-JS-Detection "; expires=" now + 5w "; path=/";
-  }
-
 
 #FASTLY deliver
 }

--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -318,15 +318,6 @@ if (table.lookup(active_ab_tests, "RelatedLinksAATest") == "true") {
 # End dynamic section
 
 
-  if (req.http.Cookie ~ "JS-Detection") {
-    set req.http.GOVUK-JS-Detection = req.http.Cookie:JS-Detection;
-  } else {
-  # If the identifier cookie isn't present, set the header to a unique value,
-  # derived as per the suggestion in https://community.fastly.com/t/unique-request-identifier/468/2
-    set req.http.GOVUK-JS-Detection = digest.hash_sha1(now randomstr(64) req.http.host req.url req.http.Fastly-Client-IP server.identity);
-
-  }
-
   return(lookup);
 }
 
@@ -443,12 +434,6 @@ sub vcl_deliver {
   }
 
   add resp.http.Content-Security-Policy-Report-Only = "default-src https 'self' *.publishing.service.gov.uk; img-src 'self' www.google-analytics.com *.publishing.service.gov.uk; script-src 'self' www.google-analytics.com *.publishing.service.gov.uk 'sha256-G29/qSW/JHHANtFhlrZVDZW1HOkCDRc78ggbqwwIJ2g=' 'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU=' 'unsafe-inline'; style-src 'self' *.publishing.service.gov.uk 'unsafe-inline'; connect-src 'self' www.google-analytics.com *.publishing.service.gov.uk; object-src 'none'; report-uri https://sentry.io/api/1377947/security/?sentry_key=f7898bf4858d436aa3568ae042371b94;";
-
-  # Set the Javascript detection cookie
-  if (req.http.User-Agent !~ "^GOV\.UK Crawler Worker" && req.http.Cookie !~ "JS-Detection") {
-    add resp.http.Set-Cookie = "JS-Detection=" req.http.GOVUK-JS-Detection "; expires=" now + 5w "; path=/";
-  }
-
 
 #FASTLY deliver
 }

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -327,15 +327,6 @@ if (table.lookup(active_ab_tests, "RelatedLinksAATest") == "true") {
 # End dynamic section
 
 
-  if (req.http.Cookie ~ "JS-Detection") {
-    set req.http.GOVUK-JS-Detection = req.http.Cookie:JS-Detection;
-  } else {
-  # If the identifier cookie isn't present, set the header to a unique value,
-  # derived as per the suggestion in https://community.fastly.com/t/unique-request-identifier/468/2
-    set req.http.GOVUK-JS-Detection = digest.hash_sha1(now randomstr(64) req.http.host req.url req.http.Fastly-Client-IP server.identity);
-
-  }
-
   return(lookup);
 }
 
@@ -452,12 +443,6 @@ sub vcl_deliver {
   }
 
   add resp.http.Content-Security-Policy-Report-Only = "default-src https 'self' *.publishing.service.gov.uk; img-src 'self' www.google-analytics.com *.publishing.service.gov.uk; script-src 'self' www.google-analytics.com *.publishing.service.gov.uk 'sha256-G29/qSW/JHHANtFhlrZVDZW1HOkCDRc78ggbqwwIJ2g=' 'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU=' 'unsafe-inline'; style-src 'self' *.publishing.service.gov.uk 'unsafe-inline'; connect-src 'self' www.google-analytics.com *.publishing.service.gov.uk; object-src 'none'; report-uri https://sentry.io/api/1377947/security/?sentry_key=f7898bf4858d436aa3568ae042371b94;";
-
-  # Set the Javascript detection cookie
-  if (req.http.User-Agent !~ "^GOV\.UK Crawler Worker" && req.http.Cookie !~ "JS-Detection") {
-    add resp.http.Set-Cookie = "JS-Detection=" req.http.GOVUK-JS-Detection "; expires=" now + 5w "; path=/";
-  }
-
 
 #FASTLY deliver
 }

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -259,15 +259,6 @@ sub vcl_recv {
   <% template_path = File.join(File.dirname(__FILE__), "vcl_templates/_multivariate_tests.vcl.erb") -%>
   <%= ERB.new(File.new(template_path).read, nil, "-", "_erbout2").result(binding) %>
 
-  if (req.http.Cookie ~ "JS-Detection") {
-    set req.http.GOVUK-JS-Detection = req.http.Cookie:JS-Detection;
-  } else {
-  # If the identifier cookie isn't present, set the header to a unique value,
-  # derived as per the suggestion in https://community.fastly.com/t/unique-request-identifier/468/2
-    set req.http.GOVUK-JS-Detection = digest.hash_sha1(now randomstr(64) req.http.host req.url req.http.Fastly-Client-IP server.identity);
-
-  }
-
   return(lookup);
 }
 
@@ -386,12 +377,6 @@ sub vcl_deliver {
   }
 
   add resp.http.Content-Security-Policy-Report-Only = "<%= CSP.generate %>";
-
-  # Set the Javascript detection cookie
-  if (req.http.User-Agent !~ "^GOV\.UK Crawler Worker" && req.http.Cookie !~ "JS-Detection") {
-    add resp.http.Set-Cookie = "JS-Detection=" req.http.GOVUK-JS-Detection "; expires=" now + 5w "; path=/";
-  }
-
 
 #FASTLY deliver
 }


### PR DESCRIPTION
These cookies were used for the JS/No-JS experiment (https://github.com/alphagov/govuk-cdn-config/pull/39). We're removing the experiment in https://github.com/alphagov/frontend/pull/1747 and https://github.com/alphagov/govuk-puppet/pull/8643.