### PR TITLE
Iterate Content Security Policy

### DIFF
--- a/lib/csp.rb
+++ b/lib/csp.rb
@@ -50,10 +50,15 @@ class CSP
     # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/style-src
     policies << "style-src 'self' *.publishing.service.gov.uk 'unsafe-inline'"
 
-    # Scripts can only load data using Ajax from Google Analytics and the publishing domains
-    #
     # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/connect-src
-    policies << "connect-src 'self' www.google-analytics.com *.publishing.service.gov.uk"
+    policies << [
+      # Scripts can only load data using Ajax from Google Analytics and the publishing domains
+      "connect-src 'self' www.google-analytics.com *.publishing.service.gov.uk",
+
+      # Allow connecting to web chat from HMRC contact pages like
+      # https://www.staging.publishing.service.gov.uk/government/organisations/hm-revenue-customs/contact/child-benefit
+      "www.tax.service.gov.uk",
+    ].join(" ")
 
     # Disallow all <object>, <embed>, and <applet> elements
     #

--- a/lib/csp.rb
+++ b/lib/csp.rb
@@ -29,7 +29,7 @@ class CSP
     # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src
     policies << [
       # Allow scripts from Google Analytics and publishing domains
-      "script-src 'self' www.google-analytics.com *.publishing.service.gov.uk",
+      "script-src 'self' www.google-analytics.com ssl.google-analytics.com *.publishing.service.gov.uk",
 
       # Allow the script that adds `js-enabled` to the body from govuk_template
       # https://github.com/alphagov/govuk_template/blob/79340eb91ad8c4279d16da302765d0946d89b1ca/source/views/layouts/govuk_template.html.erb#L40

--- a/lib/csp.rb
+++ b/lib/csp.rb
@@ -53,6 +53,14 @@ class CSP
     # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/style-src
     policies << "style-src 'self' *.publishing.service.gov.uk 'unsafe-inline'"
 
+    # Allow fonts to be loaded from data-uri's (this is the old way of doing things)
+    # or from the publishing asset domains.
+    #
+    # https://www.staging.publishing.service.gov.uk/apply-for-a-licence/test-licence/westminster/apply-1
+    #
+    # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/font-src
+    policies << "font-src :data *.publishing.service.gov.uk"
+
     # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/connect-src
     policies << [
       # Scripts can only load data using Ajax from Google Analytics and the publishing domains

--- a/lib/csp.rb
+++ b/lib/csp.rb
@@ -18,11 +18,14 @@ class CSP
     # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/default-src
     policies << "default-src https 'self' *.publishing.service.gov.uk"
 
-    # Allow images from the current domain, Google Analytics (the tracking
-    # pixel), and publishing domains
+    # Allow images from the current domain, Google Analytics (the tracking pixel),
+    # and publishing domains. Also allow `data:` images for Base64-encoded images
+    # in CSS like:
+    #
+    # https://github.com/alphagov/service-manual-frontend/blob/1db99ed48de0dfc794b9686a98e6c62f8435ae80/app/assets/stylesheets/modules/_search.scss#L106
     #
     # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/img-src
-    policies << "img-src 'self' www.google-analytics.com *.publishing.service.gov.uk"
+    policies << "img-src 'self' data: www.google-analytics.com *.publishing.service.gov.uk"
 
     # script-src determines the scripts that the browser can load
     #

--- a/lib/csp.rb
+++ b/lib/csp.rb
@@ -58,6 +58,10 @@ class CSP
       # Allow connecting to web chat from HMRC contact pages like
       # https://www.staging.publishing.service.gov.uk/government/organisations/hm-revenue-customs/contact/child-benefit
       "www.tax.service.gov.uk",
+
+      # Allow connecting to Verify to check whether the user is logged in
+      # https://www.staging.publishing.service.gov.uk/log-in-file-self-assessment-tax-return/sign-in/prove-identity
+      "www.signin.service.gov.uk",
     ].join(" ")
 
     # Disallow all <object>, <embed>, and <applet> elements

--- a/spec/test-outputs/www-integration.out.vcl
+++ b/spec/test-outputs/www-integration.out.vcl
@@ -431,7 +431,7 @@ sub vcl_deliver {
     add resp.http.Set-Cookie = "TLSversion=" tls.client.protocol "; secure";
   }
 
-  add resp.http.Content-Security-Policy-Report-Only = "default-src https 'self' *.publishing.service.gov.uk; img-src 'self' www.google-analytics.com *.publishing.service.gov.uk; script-src 'self' www.google-analytics.com *.publishing.service.gov.uk 'sha256-G29/qSW/JHHANtFhlrZVDZW1HOkCDRc78ggbqwwIJ2g=' 'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU=' 'unsafe-inline'; style-src 'self' *.publishing.service.gov.uk 'unsafe-inline'; connect-src 'self' www.google-analytics.com *.publishing.service.gov.uk; object-src 'none'; report-uri https://sentry.io/api/1377947/security/?sentry_key=f7898bf4858d436aa3568ae042371b94;";
+  add resp.http.Content-Security-Policy-Report-Only = "default-src https 'self' *.publishing.service.gov.uk; img-src 'self' data: www.google-analytics.com *.publishing.service.gov.uk; script-src 'self' www.google-analytics.com ssl.google-analytics.com *.publishing.service.gov.uk 'sha256-G29/qSW/JHHANtFhlrZVDZW1HOkCDRc78ggbqwwIJ2g=' 'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU=' 'unsafe-inline'; style-src 'self' *.publishing.service.gov.uk 'unsafe-inline'; font-src :data *.publishing.service.gov.uk; connect-src 'self' www.google-analytics.com *.publishing.service.gov.uk www.tax.service.gov.uk www.signin.service.gov.uk; object-src 'none'; report-uri https://sentry.io/api/1377947/security/?sentry_key=f7898bf4858d436aa3568ae042371b94;";
 
 #FASTLY deliver
 }

--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -433,7 +433,7 @@ sub vcl_deliver {
     add resp.http.Set-Cookie = "TLSversion=" tls.client.protocol "; secure";
   }
 
-  add resp.http.Content-Security-Policy-Report-Only = "default-src https 'self' *.publishing.service.gov.uk; img-src 'self' www.google-analytics.com *.publishing.service.gov.uk; script-src 'self' www.google-analytics.com *.publishing.service.gov.uk 'sha256-G29/qSW/JHHANtFhlrZVDZW1HOkCDRc78ggbqwwIJ2g=' 'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU=' 'unsafe-inline'; style-src 'self' *.publishing.service.gov.uk 'unsafe-inline'; connect-src 'self' www.google-analytics.com *.publishing.service.gov.uk; object-src 'none'; report-uri https://sentry.io/api/1377947/security/?sentry_key=f7898bf4858d436aa3568ae042371b94;";
+  add resp.http.Content-Security-Policy-Report-Only = "default-src https 'self' *.publishing.service.gov.uk; img-src 'self' data: www.google-analytics.com *.publishing.service.gov.uk; script-src 'self' www.google-analytics.com ssl.google-analytics.com *.publishing.service.gov.uk 'sha256-G29/qSW/JHHANtFhlrZVDZW1HOkCDRc78ggbqwwIJ2g=' 'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU=' 'unsafe-inline'; style-src 'self' *.publishing.service.gov.uk 'unsafe-inline'; font-src :data *.publishing.service.gov.uk; connect-src 'self' www.google-analytics.com *.publishing.service.gov.uk www.tax.service.gov.uk www.signin.service.gov.uk; object-src 'none'; report-uri https://sentry.io/api/1377947/security/?sentry_key=f7898bf4858d436aa3568ae042371b94;";
 
 #FASTLY deliver
 }

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -442,7 +442,7 @@ sub vcl_deliver {
     add resp.http.Set-Cookie = "TLSversion=" tls.client.protocol "; secure";
   }
 
-  add resp.http.Content-Security-Policy-Report-Only = "default-src https 'self' *.publishing.service.gov.uk; img-src 'self' www.google-analytics.com *.publishing.service.gov.uk; script-src 'self' www.google-analytics.com *.publishing.service.gov.uk 'sha256-G29/qSW/JHHANtFhlrZVDZW1HOkCDRc78ggbqwwIJ2g=' 'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU=' 'unsafe-inline'; style-src 'self' *.publishing.service.gov.uk 'unsafe-inline'; connect-src 'self' www.google-analytics.com *.publishing.service.gov.uk; object-src 'none'; report-uri https://sentry.io/api/1377947/security/?sentry_key=f7898bf4858d436aa3568ae042371b94;";
+  add resp.http.Content-Security-Policy-Report-Only = "default-src https 'self' *.publishing.service.gov.uk; img-src 'self' data: www.google-analytics.com *.publishing.service.gov.uk; script-src 'self' www.google-analytics.com ssl.google-analytics.com *.publishing.service.gov.uk 'sha256-G29/qSW/JHHANtFhlrZVDZW1HOkCDRc78ggbqwwIJ2g=' 'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU=' 'unsafe-inline'; style-src 'self' *.publishing.service.gov.uk 'unsafe-inline'; font-src :data *.publishing.service.gov.uk; connect-src 'self' www.google-analytics.com *.publishing.service.gov.uk www.tax.service.gov.uk www.signin.service.gov.uk; object-src 'none'; report-uri https://sentry.io/api/1377947/security/?sentry_key=f7898bf4858d436aa3568ae042371b94;";
 
 #FASTLY deliver
 }


### PR DESCRIPTION
Follow up to https://github.com/alphagov/govuk-cdn-config/pull/94. See commits for details. The changes are all based on violations reported to Sentry in https://sentry.io/govuk/govuk-frontend-csp.

I've tested the resulting policy with https://csp-evaluator.withgoogle.com

<img width="884" alt="screenshot 2019-02-06 at 12 58 21" src="https://user-images.githubusercontent.com/233676/52343214-5fb3b680-2a0f-11e9-8eaa-5a92a2ebff64.png">
