### PR TITLE
Fix CSP font-src source declaration

### DIFF
--- a/lib/csp.rb
+++ b/lib/csp.rb
@@ -59,7 +59,7 @@ class CSP
     # https://www.staging.publishing.service.gov.uk/apply-for-a-licence/test-licence/westminster/apply-1
     #
     # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/font-src
-    policies << "font-src :data *.publishing.service.gov.uk"
+    policies << "font-src data: *.publishing.service.gov.uk"
 
     # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/connect-src
     policies << [

--- a/spec/test-outputs/www-integration.out.vcl
+++ b/spec/test-outputs/www-integration.out.vcl
@@ -431,7 +431,7 @@ sub vcl_deliver {
     add resp.http.Set-Cookie = "TLSversion=" tls.client.protocol "; secure";
   }
 
-  add resp.http.Content-Security-Policy-Report-Only = "default-src https 'self' *.publishing.service.gov.uk; img-src 'self' data: www.google-analytics.com *.publishing.service.gov.uk; script-src 'self' www.google-analytics.com ssl.google-analytics.com *.publishing.service.gov.uk 'sha256-G29/qSW/JHHANtFhlrZVDZW1HOkCDRc78ggbqwwIJ2g=' 'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU=' 'unsafe-inline'; style-src 'self' *.publishing.service.gov.uk 'unsafe-inline'; font-src :data *.publishing.service.gov.uk; connect-src 'self' www.google-analytics.com *.publishing.service.gov.uk www.tax.service.gov.uk www.signin.service.gov.uk; object-src 'none'; report-uri https://sentry.io/api/1377947/security/?sentry_key=f7898bf4858d436aa3568ae042371b94;";
+  add resp.http.Content-Security-Policy-Report-Only = "default-src https 'self' *.publishing.service.gov.uk; img-src 'self' data: www.google-analytics.com *.publishing.service.gov.uk; script-src 'self' www.google-analytics.com ssl.google-analytics.com *.publishing.service.gov.uk 'sha256-G29/qSW/JHHANtFhlrZVDZW1HOkCDRc78ggbqwwIJ2g=' 'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU=' 'unsafe-inline'; style-src 'self' *.publishing.service.gov.uk 'unsafe-inline'; font-src data: *.publishing.service.gov.uk; connect-src 'self' www.google-analytics.com *.publishing.service.gov.uk www.tax.service.gov.uk www.signin.service.gov.uk; object-src 'none'; report-uri https://sentry.io/api/1377947/security/?sentry_key=f7898bf4858d436aa3568ae042371b94;";
 
 #FASTLY deliver
 }

--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -433,7 +433,7 @@ sub vcl_deliver {
     add resp.http.Set-Cookie = "TLSversion=" tls.client.protocol "; secure";
   }
 
-  add resp.http.Content-Security-Policy-Report-Only = "default-src https 'self' *.publishing.service.gov.uk; img-src 'self' data: www.google-analytics.com *.publishing.service.gov.uk; script-src 'self' www.google-analytics.com ssl.google-analytics.com *.publishing.service.gov.uk 'sha256-G29/qSW/JHHANtFhlrZVDZW1HOkCDRc78ggbqwwIJ2g=' 'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU=' 'unsafe-inline'; style-src 'self' *.publishing.service.gov.uk 'unsafe-inline'; font-src :data *.publishing.service.gov.uk; connect-src 'self' www.google-analytics.com *.publishing.service.gov.uk www.tax.service.gov.uk www.signin.service.gov.uk; object-src 'none'; report-uri https://sentry.io/api/1377947/security/?sentry_key=f7898bf4858d436aa3568ae042371b94;";
+  add resp.http.Content-Security-Policy-Report-Only = "default-src https 'self' *.publishing.service.gov.uk; img-src 'self' data: www.google-analytics.com *.publishing.service.gov.uk; script-src 'self' www.google-analytics.com ssl.google-analytics.com *.publishing.service.gov.uk 'sha256-G29/qSW/JHHANtFhlrZVDZW1HOkCDRc78ggbqwwIJ2g=' 'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU=' 'unsafe-inline'; style-src 'self' *.publishing.service.gov.uk 'unsafe-inline'; font-src data: *.publishing.service.gov.uk; connect-src 'self' www.google-analytics.com *.publishing.service.gov.uk www.tax.service.gov.uk www.signin.service.gov.uk; object-src 'none'; report-uri https://sentry.io/api/1377947/security/?sentry_key=f7898bf4858d436aa3568ae042371b94;";
 
 #FASTLY deliver
 }

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -442,7 +442,7 @@ sub vcl_deliver {
     add resp.http.Set-Cookie = "TLSversion=" tls.client.protocol "; secure";
   }
 
-  add resp.http.Content-Security-Policy-Report-Only = "default-src https 'self' *.publishing.service.gov.uk; img-src 'self' data: www.google-analytics.com *.publishing.service.gov.uk; script-src 'self' www.google-analytics.com ssl.google-analytics.com *.publishing.service.gov.uk 'sha256-G29/qSW/JHHANtFhlrZVDZW1HOkCDRc78ggbqwwIJ2g=' 'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU=' 'unsafe-inline'; style-src 'self' *.publishing.service.gov.uk 'unsafe-inline'; font-src :data *.publishing.service.gov.uk; connect-src 'self' www.google-analytics.com *.publishing.service.gov.uk www.tax.service.gov.uk www.signin.service.gov.uk; object-src 'none'; report-uri https://sentry.io/api/1377947/security/?sentry_key=f7898bf4858d436aa3568ae042371b94;";
+  add resp.http.Content-Security-Policy-Report-Only = "default-src https 'self' *.publishing.service.gov.uk; img-src 'self' data: www.google-analytics.com *.publishing.service.gov.uk; script-src 'self' www.google-analytics.com ssl.google-analytics.com *.publishing.service.gov.uk 'sha256-G29/qSW/JHHANtFhlrZVDZW1HOkCDRc78ggbqwwIJ2g=' 'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU=' 'unsafe-inline'; style-src 'self' *.publishing.service.gov.uk 'unsafe-inline'; font-src data: *.publishing.service.gov.uk; connect-src 'self' www.google-analytics.com *.publishing.service.gov.uk www.tax.service.gov.uk www.signin.service.gov.uk; object-src 'none'; report-uri https://sentry.io/api/1377947/security/?sentry_key=f7898bf4858d436aa3568ae042371b94;";
 
 #FASTLY deliver
 }


### PR DESCRIPTION
Follow up to https://github.com/alphagov/govuk-cdn-config/pull/96.

`:data` should be `data:` because it's a URL and not a Ruby symbol.

https://sentry.io/govuk/govuk-frontend-csp/issues/874477487

Captain Hindsight: I should've tested the CSP with https://cspvalidator.org too, because that correctly identifies this error.

<img width="1228" alt="screenshot 2019-02-06 at 13 16 10" src="https://user-images.githubusercontent.com/233676/52343999-88d54680-2a11-11e9-9015-e29306290f5a.png">

[Test it yourself](https://cspvalidator.org/#headerValue%5B%5D=default-src+https+'self'+*.publishing.service.gov.uk%3B+img-src+'self'+data%3A+www.google-analytics.com+*.publishing.service.gov.uk%3B+script-src+'self'+www.google-analytics.com+ssl.google-analytics.com+*.publishing.service.gov.uk+'sha256-G29%2FqSW%2FJHHANtFhlrZVDZW1HOkCDRc78ggbqwwIJ2g%3D'+'sha256-%2B6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU%3D'+'unsafe-inline'%3B+style-src+'self'+*.publishing.service.gov.uk+'unsafe-inline'%3B+font-src+%3Adata+*.publishing.service.gov.uk%3B+connect-src+'self'+www.google-analytics.com+*.publishing.service.gov.uk+www.tax.service.gov.uk+www.signin.service.gov.uk%3B+object-src+'none'%3B&strategy=intersection)