### PR TITLE
Allow script loading from Verify

### DIFF
--- a/lib/csp.rb
+++ b/lib/csp.rb
@@ -42,6 +42,11 @@ class CSP
       # https://github.com/alphagov/govuk_template/blob/79340eb91ad8c4279d16da302765d0946d89b1ca/source/views/layouts/govuk_template.html.erb#L112-L113
       "'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU='",
 
+      # Allow JSONP call to Verify to check whether the user is logged in
+      # https://www.staging.publishing.service.gov.uk/log-in-file-self-assessment-tax-return/sign-in/prove-identity
+      # https://github.com/alphagov/government-frontend/blob/71aca4df9b74366618a5a93acdb5cd2715f94f49/app/assets/javascripts/modules/track-radio-group.js
+      "www.signin.service.gov.uk",
+
       # In browsers that don't support the sha256 whitelisting we allow unsafe
       # inline scripts
       "'unsafe-inline'"
@@ -71,6 +76,7 @@ class CSP
       "www.tax.service.gov.uk",
 
       # Allow connecting to Verify to check whether the user is logged in
+      # https://github.com/alphagov/government-frontend/blob/71aca4df9b74366618a5a93acdb5cd2715f94f49/app/assets/javascripts/modules/track-radio-group.js
       # https://www.staging.publishing.service.gov.uk/log-in-file-self-assessment-tax-return/sign-in/prove-identity
       "www.signin.service.gov.uk",
     ].join(" ")

--- a/spec/test-outputs/www-integration.out.vcl
+++ b/spec/test-outputs/www-integration.out.vcl
@@ -431,7 +431,7 @@ sub vcl_deliver {
     add resp.http.Set-Cookie = "TLSversion=" tls.client.protocol "; secure";
   }
 
-  add resp.http.Content-Security-Policy-Report-Only = "default-src https 'self' *.publishing.service.gov.uk; img-src 'self' data: www.google-analytics.com *.publishing.service.gov.uk; script-src 'self' www.google-analytics.com ssl.google-analytics.com *.publishing.service.gov.uk 'sha256-G29/qSW/JHHANtFhlrZVDZW1HOkCDRc78ggbqwwIJ2g=' 'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU=' 'unsafe-inline'; style-src 'self' *.publishing.service.gov.uk 'unsafe-inline'; font-src data: *.publishing.service.gov.uk; connect-src 'self' www.google-analytics.com *.publishing.service.gov.uk www.tax.service.gov.uk www.signin.service.gov.uk; object-src 'none'; report-uri https://sentry.io/api/1377947/security/?sentry_key=f7898bf4858d436aa3568ae042371b94;";
+  add resp.http.Content-Security-Policy-Report-Only = "default-src https 'self' *.publishing.service.gov.uk; img-src 'self' data: www.google-analytics.com *.publishing.service.gov.uk; script-src 'self' www.google-analytics.com ssl.google-analytics.com *.publishing.service.gov.uk 'sha256-G29/qSW/JHHANtFhlrZVDZW1HOkCDRc78ggbqwwIJ2g=' 'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU=' www.signin.service.gov.uk 'unsafe-inline'; style-src 'self' *.publishing.service.gov.uk 'unsafe-inline'; font-src data: *.publishing.service.gov.uk; connect-src 'self' www.google-analytics.com *.publishing.service.gov.uk www.tax.service.gov.uk www.signin.service.gov.uk; object-src 'none'; report-uri https://sentry.io/api/1377947/security/?sentry_key=f7898bf4858d436aa3568ae042371b94;";
 
 #FASTLY deliver
 }

--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -433,7 +433,7 @@ sub vcl_deliver {
     add resp.http.Set-Cookie = "TLSversion=" tls.client.protocol "; secure";
   }
 
-  add resp.http.Content-Security-Policy-Report-Only = "default-src https 'self' *.publishing.service.gov.uk; img-src 'self' data: www.google-analytics.com *.publishing.service.gov.uk; script-src 'self' www.google-analytics.com ssl.google-analytics.com *.publishing.service.gov.uk 'sha256-G29/qSW/JHHANtFhlrZVDZW1HOkCDRc78ggbqwwIJ2g=' 'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU=' 'unsafe-inline'; style-src 'self' *.publishing.service.gov.uk 'unsafe-inline'; font-src data: *.publishing.service.gov.uk; connect-src 'self' www.google-analytics.com *.publishing.service.gov.uk www.tax.service.gov.uk www.signin.service.gov.uk; object-src 'none'; report-uri https://sentry.io/api/1377947/security/?sentry_key=f7898bf4858d436aa3568ae042371b94;";
+  add resp.http.Content-Security-Policy-Report-Only = "default-src https 'self' *.publishing.service.gov.uk; img-src 'self' data: www.google-analytics.com *.publishing.service.gov.uk; script-src 'self' www.google-analytics.com ssl.google-analytics.com *.publishing.service.gov.uk 'sha256-G29/qSW/JHHANtFhlrZVDZW1HOkCDRc78ggbqwwIJ2g=' 'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU=' www.signin.service.gov.uk 'unsafe-inline'; style-src 'self' *.publishing.service.gov.uk 'unsafe-inline'; font-src data: *.publishing.service.gov.uk; connect-src 'self' www.google-analytics.com *.publishing.service.gov.uk www.tax.service.gov.uk www.signin.service.gov.uk; object-src 'none'; report-uri https://sentry.io/api/1377947/security/?sentry_key=f7898bf4858d436aa3568ae042371b94;";
 
 #FASTLY deliver
 }

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -442,7 +442,7 @@ sub vcl_deliver {
     add resp.http.Set-Cookie = "TLSversion=" tls.client.protocol "; secure";
   }
 
-  add resp.http.Content-Security-Policy-Report-Only = "default-src https 'self' *.publishing.service.gov.uk; img-src 'self' data: www.google-analytics.com *.publishing.service.gov.uk; script-src 'self' www.google-analytics.com ssl.google-analytics.com *.publishing.service.gov.uk 'sha256-G29/qSW/JHHANtFhlrZVDZW1HOkCDRc78ggbqwwIJ2g=' 'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU=' 'unsafe-inline'; style-src 'self' *.publishing.service.gov.uk 'unsafe-inline'; font-src data: *.publishing.service.gov.uk; connect-src 'self' www.google-analytics.com *.publishing.service.gov.uk www.tax.service.gov.uk www.signin.service.gov.uk; object-src 'none'; report-uri https://sentry.io/api/1377947/security/?sentry_key=f7898bf4858d436aa3568ae042371b94;";
+  add resp.http.Content-Security-Policy-Report-Only = "default-src https 'self' *.publishing.service.gov.uk; img-src 'self' data: www.google-analytics.com *.publishing.service.gov.uk; script-src 'self' www.google-analytics.com ssl.google-analytics.com *.publishing.service.gov.uk 'sha256-G29/qSW/JHHANtFhlrZVDZW1HOkCDRc78ggbqwwIJ2g=' 'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU=' www.signin.service.gov.uk 'unsafe-inline'; style-src 'self' *.publishing.service.gov.uk 'unsafe-inline'; font-src data: *.publishing.service.gov.uk; connect-src 'self' www.google-analytics.com *.publishing.service.gov.uk www.tax.service.gov.uk www.signin.service.gov.uk; object-src 'none'; report-uri https://sentry.io/api/1377947/security/?sentry_key=f7898bf4858d436aa3568ae042371b94;";
 
 #FASTLY deliver
 }


### PR DESCRIPTION
This was missed in https://github.com/alphagov/govuk-cdn-config/pull/96, which only allowed `connect-src` from Verify. We also use JSONP, which is governed by script-src.

[CSP validator](https://cspvalidator.org/#headerValue%5B%5D=default-src+https+'self'+*.publishing.service.gov.uk%3B+img-src+'self'+data%3A+www.google-analytics.com+*.publishing.service.gov.uk%3B+script-src+'self'+www.google-analytics.com+ssl.google-analytics.com+*.publishing.service.gov.uk+'sha256-G29%2FqSW%2FJHHANtFhlrZVDZW1HOkCDRc78ggbqwwIJ2g%3D'+'sha256-%2B6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU%3D'+www.signin.service.gov.uk+'unsafe-inline'%3B+style-src+'self'+*.publishing.service.gov.uk+'unsafe-inline'%3B+font-src+data%3A+*.publishing.service.gov.uk%3B+connect-src+'self'+www.google-analytics.com+*.publishing.service.gov.uk+www.tax.service.gov.uk+www.signin.service.gov.uk%3B+object-src+'none'%3B+report-uri+https%3A%2F%2Fsentry.io%2Fapi%2F1377947%2Fsecurity%2F%3Fsentry_key%3Df7898bf4858d436aa3568ae042371b94&strategy=intersection)

https://sentry.io/govuk/govuk-frontend-csp/issues/874478132