### PR TITLE
Don't use CSP on production

### DIFF
--- a/spec/test-outputs/www-integration.out.vcl
+++ b/spec/test-outputs/www-integration.out.vcl
@@ -431,7 +431,9 @@ sub vcl_deliver {
     add resp.http.Set-Cookie = "TLSversion=" tls.client.protocol "; secure";
   }
 
+  
   add resp.http.Content-Security-Policy-Report-Only = "default-src https 'self' *.publishing.service.gov.uk; img-src 'self' data: www.google-analytics.com *.publishing.service.gov.uk; script-src 'self' www.google-analytics.com ssl.google-analytics.com *.publishing.service.gov.uk 'sha256-G29/qSW/JHHANtFhlrZVDZW1HOkCDRc78ggbqwwIJ2g=' 'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU=' www.signin.service.gov.uk 'unsafe-inline'; style-src 'self' *.publishing.service.gov.uk 'unsafe-inline'; font-src data: *.publishing.service.gov.uk; connect-src 'self' www.google-analytics.com *.publishing.service.gov.uk www.tax.service.gov.uk www.signin.service.gov.uk; object-src 'none'; report-uri https://sentry.io/api/1377947/security/?sentry_key=f7898bf4858d436aa3568ae042371b94;";
+  
 
 #FASTLY deliver
 }

--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -433,7 +433,7 @@ sub vcl_deliver {
     add resp.http.Set-Cookie = "TLSversion=" tls.client.protocol "; secure";
   }
 
-  add resp.http.Content-Security-Policy-Report-Only = "default-src https 'self' *.publishing.service.gov.uk; img-src 'self' data: www.google-analytics.com *.publishing.service.gov.uk; script-src 'self' www.google-analytics.com ssl.google-analytics.com *.publishing.service.gov.uk 'sha256-G29/qSW/JHHANtFhlrZVDZW1HOkCDRc78ggbqwwIJ2g=' 'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU=' www.signin.service.gov.uk 'unsafe-inline'; style-src 'self' *.publishing.service.gov.uk 'unsafe-inline'; font-src data: *.publishing.service.gov.uk; connect-src 'self' www.google-analytics.com *.publishing.service.gov.uk www.tax.service.gov.uk www.signin.service.gov.uk; object-src 'none'; report-uri https://sentry.io/api/1377947/security/?sentry_key=f7898bf4858d436aa3568ae042371b94;";
+  
 
 #FASTLY deliver
 }

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -442,7 +442,9 @@ sub vcl_deliver {
     add resp.http.Set-Cookie = "TLSversion=" tls.client.protocol "; secure";
   }
 
+  
   add resp.http.Content-Security-Policy-Report-Only = "default-src https 'self' *.publishing.service.gov.uk; img-src 'self' data: www.google-analytics.com *.publishing.service.gov.uk; script-src 'self' www.google-analytics.com ssl.google-analytics.com *.publishing.service.gov.uk 'sha256-G29/qSW/JHHANtFhlrZVDZW1HOkCDRc78ggbqwwIJ2g=' 'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU=' www.signin.service.gov.uk 'unsafe-inline'; style-src 'self' *.publishing.service.gov.uk 'unsafe-inline'; font-src data: *.publishing.service.gov.uk; connect-src 'self' www.google-analytics.com *.publishing.service.gov.uk www.tax.service.gov.uk www.signin.service.gov.uk; object-src 'none'; report-uri https://sentry.io/api/1377947/security/?sentry_key=f7898bf4858d436aa3568ae042371b94;";
+  
 
 #FASTLY deliver
 }

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -376,7 +376,9 @@ sub vcl_deliver {
     add resp.http.Set-Cookie = "TLSversion=" tls.client.protocol "; secure";
   }
 
+  <% unless environment == 'production' %>
   add resp.http.Content-Security-Policy-Report-Only = "<%= CSP.generate %>";
+  <% end %>
 
 #FASTLY deliver
 }


### PR DESCRIPTION
We've collected data in Sentry on CSP and we're going to analyse and fix the reported violations.

Keep CSP on staging & integration for testing purposes.

https://sentry.io/govuk/govuk-frontend-csp