### PR TITLE
Handle autodiscover paths that aren't at the root

### DIFF
--- a/spec/test-outputs/www-integration.out.vcl
+++ b/spec/test-outputs/www-integration.out.vcl
@@ -149,8 +149,7 @@ sub vcl_recv {
   }
 
   # Serve a 404 Not Found response if request URL matches "/autodiscover/autodiscover.xml"
-  # This is to avoid a Denial of Service "attack" from certain government machines.
-  if (req.url ~ "(?i)^/autodiscover/autodiscover.xml") {
+  if (req.url.path ~ "(?i)/autodiscover/autodiscover.xml$") {
     error 404 "Not Found";
   }
 

--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -151,8 +151,7 @@ sub vcl_recv {
   }
 
   # Serve a 404 Not Found response if request URL matches "/autodiscover/autodiscover.xml"
-  # This is to avoid a Denial of Service "attack" from certain government machines.
-  if (req.url ~ "(?i)^/autodiscover/autodiscover.xml") {
+  if (req.url.path ~ "(?i)/autodiscover/autodiscover.xml$") {
     error 404 "Not Found";
   }
 

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -160,8 +160,7 @@ sub vcl_recv {
   }
 
   # Serve a 404 Not Found response if request URL matches "/autodiscover/autodiscover.xml"
-  # This is to avoid a Denial of Service "attack" from certain government machines.
-  if (req.url ~ "(?i)^/autodiscover/autodiscover.xml") {
+  if (req.url.path ~ "(?i)/autodiscover/autodiscover.xml$") {
     error 404 "Not Found";
   }
 

--- a/vcl_templates/bouncer.vcl.erb
+++ b/vcl_templates/bouncer.vcl.erb
@@ -71,8 +71,7 @@ sub vcl_recv {
   }
 
   # Serve a 404 Not Found response if request URL matches "/autodiscover/autodiscover.xml"
-  # This is to avoid a Denial of Service "attack" from certain government machines.
-  if (req.url ~ "(?i)^/autodiscover/autodiscover.xml") {
+  if (req.url.path ~ "(?i)/autodiscover/autodiscover.xml$") {
     error 404 "Not Found";
   }
 

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -184,8 +184,7 @@ sub vcl_recv {
   }
 
   # Serve a 404 Not Found response if request URL matches "/autodiscover/autodiscover.xml"
-  # This is to avoid a Denial of Service "attack" from certain government machines.
-  if (req.url ~ "(?i)^/autodiscover/autodiscover.xml") {
+  if (req.url.path ~ "(?i)/autodiscover/autodiscover.xml$") {
     error 404 "Not Found";
   }
 


### PR DESCRIPTION
Due to the way transitioned domains redirect to paths on GOV.UK (usually
department pages), autodiscover lookups can also happen at paths other
than the route.