### PR TITLE
Remove Related Links A/A test

### DIFF
--- a/ab_tests/ab_tests.yaml
+++ b/ab_tests/ab_tests.yaml
@@ -7,9 +7,6 @@
 - ViewDrivingLicence:
   - A
   - B
-- RelatedLinksAATest:
-  - A
-  - B
 - RelatedLinksABTest1:
   - A
   - B

--- a/configs/dictionaries/ab_test_expiries.yaml
+++ b/configs/dictionaries/ab_test_expiries.yaml
@@ -6,6 +6,5 @@
 # ExampleTest: 86400
 ---
 Example: 86400
-RelatedLinksAATest: 2419200  # 4 weeks
 RelatedLinksABTest1: 43200 # 12 hours
 ViewDrivingLicence: 259200

--- a/configs/dictionaries/active_ab_tests.yaml
+++ b/configs/dictionaries/active_ab_tests.yaml
@@ -4,6 +4,5 @@
 # bucket allocations. See example_percentages.yaml for format.
 ---
 Example: true
-RelatedLinksAATest: true
 RelatedLinksABTest1: true
 ViewDrivingLicence: false

--- a/spec/test-outputs/www-integration.out.vcl
+++ b/spec/test-outputs/www-integration.out.vcl
@@ -280,38 +280,6 @@ if (table.lookup(active_ab_tests, "ViewDrivingLicence") == "true") {
     }
   }
 }
-if (table.lookup(active_ab_tests, "RelatedLinksAATest") == "true") {
-  if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
-    set req.http.GOVUK-ABTest-RelatedLinksAATest = "A";
-  } else if (req.url ~ "[\?\&]ABTest-RelatedLinksAATest=A(&|$)") {
-    # Some users, such as remote testers, will be given a URL with a query string
-    # to place them into a specific bucket.
-    set req.http.GOVUK-ABTest-RelatedLinksAATest = "A";
-  } else if (req.url ~ "[\?\&]ABTest-RelatedLinksAATest=B(&|$)") {
-    # Some users, such as remote testers, will be given a URL with a query string
-    # to place them into a specific bucket.
-    set req.http.GOVUK-ABTest-RelatedLinksAATest = "B";
-  } else if (req.http.Cookie ~ "ABTest-RelatedLinksAATest") {
-    # Set the value of the header to whatever decision was previously made
-    set req.http.GOVUK-ABTest-RelatedLinksAATest = req.http.Cookie:ABTest-RelatedLinksAATest;
-  } else {
-    declare local var.denominator_RelatedLinksAATest INTEGER;
-    declare local var.denominator_RelatedLinksAATest_A INTEGER;
-    declare local var.nominator_RelatedLinksAATest_A INTEGER;
-    set var.nominator_RelatedLinksAATest_A = std.atoi(table.lookup(relatedlinksaatest_percentages, "A"));
-    set var.denominator_RelatedLinksAATest += var.nominator_RelatedLinksAATest_A;
-    declare local var.denominator_RelatedLinksAATest_B INTEGER;
-    declare local var.nominator_RelatedLinksAATest_B INTEGER;
-    set var.nominator_RelatedLinksAATest_B = std.atoi(table.lookup(relatedlinksaatest_percentages, "B"));
-    set var.denominator_RelatedLinksAATest += var.nominator_RelatedLinksAATest_B;
-    set var.denominator_RelatedLinksAATest_A = var.denominator_RelatedLinksAATest;
-    if (randombool(var.nominator_RelatedLinksAATest_A, var.denominator_RelatedLinksAATest_A)) {
-      set req.http.GOVUK-ABTest-RelatedLinksAATest = "A";
-    } else {
-      set req.http.GOVUK-ABTest-RelatedLinksAATest = "B";
-    }
-  }
-}
 if (table.lookup(active_ab_tests, "RelatedLinksABTest1") == "true") {
   if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
     set req.http.GOVUK-ABTest-RelatedLinksABTest1 = "A";
@@ -445,12 +413,6 @@ sub vcl_deliver {
     if (req.http.Cookie !~ "ABTest-ViewDrivingLicence" || req.url ~ "[\?\&]ABTest-ViewDrivingLicence" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
       set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "ViewDrivingLicence"))));
       add resp.http.Set-Cookie = "ABTest-ViewDrivingLicence=" req.http.GOVUK-ABTest-ViewDrivingLicence "; expires=" var.expiry "; path=/";
-    }
-  }
-  if (table.lookup(active_ab_tests, "RelatedLinksAATest") == "true") {
-    if (req.http.Cookie !~ "ABTest-RelatedLinksAATest" || req.url ~ "[\?\&]ABTest-RelatedLinksAATest" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
-      set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "RelatedLinksAATest"))));
-      add resp.http.Set-Cookie = "ABTest-RelatedLinksAATest=" req.http.GOVUK-ABTest-RelatedLinksAATest "; expires=" var.expiry "; path=/";
     }
   }
   if (table.lookup(active_ab_tests, "RelatedLinksABTest1") == "true") {

--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -282,38 +282,6 @@ if (table.lookup(active_ab_tests, "ViewDrivingLicence") == "true") {
     }
   }
 }
-if (table.lookup(active_ab_tests, "RelatedLinksAATest") == "true") {
-  if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
-    set req.http.GOVUK-ABTest-RelatedLinksAATest = "A";
-  } else if (req.url ~ "[\?\&]ABTest-RelatedLinksAATest=A(&|$)") {
-    # Some users, such as remote testers, will be given a URL with a query string
-    # to place them into a specific bucket.
-    set req.http.GOVUK-ABTest-RelatedLinksAATest = "A";
-  } else if (req.url ~ "[\?\&]ABTest-RelatedLinksAATest=B(&|$)") {
-    # Some users, such as remote testers, will be given a URL with a query string
-    # to place them into a specific bucket.
-    set req.http.GOVUK-ABTest-RelatedLinksAATest = "B";
-  } else if (req.http.Cookie ~ "ABTest-RelatedLinksAATest") {
-    # Set the value of the header to whatever decision was previously made
-    set req.http.GOVUK-ABTest-RelatedLinksAATest = req.http.Cookie:ABTest-RelatedLinksAATest;
-  } else {
-    declare local var.denominator_RelatedLinksAATest INTEGER;
-    declare local var.denominator_RelatedLinksAATest_A INTEGER;
-    declare local var.nominator_RelatedLinksAATest_A INTEGER;
-    set var.nominator_RelatedLinksAATest_A = std.atoi(table.lookup(relatedlinksaatest_percentages, "A"));
-    set var.denominator_RelatedLinksAATest += var.nominator_RelatedLinksAATest_A;
-    declare local var.denominator_RelatedLinksAATest_B INTEGER;
-    declare local var.nominator_RelatedLinksAATest_B INTEGER;
-    set var.nominator_RelatedLinksAATest_B = std.atoi(table.lookup(relatedlinksaatest_percentages, "B"));
-    set var.denominator_RelatedLinksAATest += var.nominator_RelatedLinksAATest_B;
-    set var.denominator_RelatedLinksAATest_A = var.denominator_RelatedLinksAATest;
-    if (randombool(var.nominator_RelatedLinksAATest_A, var.denominator_RelatedLinksAATest_A)) {
-      set req.http.GOVUK-ABTest-RelatedLinksAATest = "A";
-    } else {
-      set req.http.GOVUK-ABTest-RelatedLinksAATest = "B";
-    }
-  }
-}
 if (table.lookup(active_ab_tests, "RelatedLinksABTest1") == "true") {
   if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
     set req.http.GOVUK-ABTest-RelatedLinksABTest1 = "A";
@@ -447,12 +415,6 @@ sub vcl_deliver {
     if (req.http.Cookie !~ "ABTest-ViewDrivingLicence" || req.url ~ "[\?\&]ABTest-ViewDrivingLicence" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
       set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "ViewDrivingLicence"))));
       add resp.http.Set-Cookie = "ABTest-ViewDrivingLicence=" req.http.GOVUK-ABTest-ViewDrivingLicence "; expires=" var.expiry "; path=/";
-    }
-  }
-  if (table.lookup(active_ab_tests, "RelatedLinksAATest") == "true") {
-    if (req.http.Cookie !~ "ABTest-RelatedLinksAATest" || req.url ~ "[\?\&]ABTest-RelatedLinksAATest" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
-      set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "RelatedLinksAATest"))));
-      add resp.http.Set-Cookie = "ABTest-RelatedLinksAATest=" req.http.GOVUK-ABTest-RelatedLinksAATest "; expires=" var.expiry "; path=/";
     }
   }
   if (table.lookup(active_ab_tests, "RelatedLinksABTest1") == "true") {

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -291,38 +291,6 @@ if (table.lookup(active_ab_tests, "ViewDrivingLicence") == "true") {
     }
   }
 }
-if (table.lookup(active_ab_tests, "RelatedLinksAATest") == "true") {
-  if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
-    set req.http.GOVUK-ABTest-RelatedLinksAATest = "A";
-  } else if (req.url ~ "[\?\&]ABTest-RelatedLinksAATest=A(&|$)") {
-    # Some users, such as remote testers, will be given a URL with a query string
-    # to place them into a specific bucket.
-    set req.http.GOVUK-ABTest-RelatedLinksAATest = "A";
-  } else if (req.url ~ "[\?\&]ABTest-RelatedLinksAATest=B(&|$)") {
-    # Some users, such as remote testers, will be given a URL with a query string
-    # to place them into a specific bucket.
-    set req.http.GOVUK-ABTest-RelatedLinksAATest = "B";
-  } else if (req.http.Cookie ~ "ABTest-RelatedLinksAATest") {
-    # Set the value of the header to whatever decision was previously made
-    set req.http.GOVUK-ABTest-RelatedLinksAATest = req.http.Cookie:ABTest-RelatedLinksAATest;
-  } else {
-    declare local var.denominator_RelatedLinksAATest INTEGER;
-    declare local var.denominator_RelatedLinksAATest_A INTEGER;
-    declare local var.nominator_RelatedLinksAATest_A INTEGER;
-    set var.nominator_RelatedLinksAATest_A = std.atoi(table.lookup(relatedlinksaatest_percentages, "A"));
-    set var.denominator_RelatedLinksAATest += var.nominator_RelatedLinksAATest_A;
-    declare local var.denominator_RelatedLinksAATest_B INTEGER;
-    declare local var.nominator_RelatedLinksAATest_B INTEGER;
-    set var.nominator_RelatedLinksAATest_B = std.atoi(table.lookup(relatedlinksaatest_percentages, "B"));
-    set var.denominator_RelatedLinksAATest += var.nominator_RelatedLinksAATest_B;
-    set var.denominator_RelatedLinksAATest_A = var.denominator_RelatedLinksAATest;
-    if (randombool(var.nominator_RelatedLinksAATest_A, var.denominator_RelatedLinksAATest_A)) {
-      set req.http.GOVUK-ABTest-RelatedLinksAATest = "A";
-    } else {
-      set req.http.GOVUK-ABTest-RelatedLinksAATest = "B";
-    }
-  }
-}
 if (table.lookup(active_ab_tests, "RelatedLinksABTest1") == "true") {
   if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
     set req.http.GOVUK-ABTest-RelatedLinksABTest1 = "A";
@@ -456,12 +424,6 @@ sub vcl_deliver {
     if (req.http.Cookie !~ "ABTest-ViewDrivingLicence" || req.url ~ "[\?\&]ABTest-ViewDrivingLicence" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
       set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "ViewDrivingLicence"))));
       add resp.http.Set-Cookie = "ABTest-ViewDrivingLicence=" req.http.GOVUK-ABTest-ViewDrivingLicence "; expires=" var.expiry "; path=/";
-    }
-  }
-  if (table.lookup(active_ab_tests, "RelatedLinksAATest") == "true") {
-    if (req.http.Cookie !~ "ABTest-RelatedLinksAATest" || req.url ~ "[\?\&]ABTest-RelatedLinksAATest" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
-      set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "RelatedLinksAATest"))));
-      add resp.http.Set-Cookie = "ABTest-RelatedLinksAATest=" req.http.GOVUK-ABTest-RelatedLinksAATest "; expires=" var.expiry "; path=/";
     }
   }
   if (table.lookup(active_ab_tests, "RelatedLinksABTest1") == "true") {


### PR DESCRIPTION
This PR removes the related links A/A test. We have the required data for analysis of our measurement metrics and as a result no longer need to run this test.