### PR TITLE
Cache responses to POSTs that are the result of a client error

### DIFF
--- a/spec/test-outputs/www-integration.out.vcl
+++ b/spec/test-outputs/www-integration.out.vcl
@@ -217,11 +217,8 @@ sub vcl_recv {
 
 #FASTLY recv
 
-  if (req.request != "HEAD" && req.request != "GET" && req.request != "FASTLYPURGE") {
-    return(pass);
-  }
-
-    # Begin dynamic section
+  if (req.request != "POST") {
+        # Begin dynamic section
 if (table.lookup(active_ab_tests, "Example") == "true") {
   if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
     set req.http.GOVUK-ABTest-Example = "A";
@@ -352,6 +349,7 @@ if (table.lookup(active_ab_tests, "RelatedLinksABTest1") == "true") {
 }
 # End dynamic section
 
+  }
 
   return(lookup);
 }
@@ -385,6 +383,12 @@ sub vcl_fetch {
   }
 
   if (beresp.http.Cache-Control ~ "no-(store|cache)") {
+    return (pass);
+  }
+
+  # Pass through good responses to POST requests (i.e. cache responses to POST
+  # requests that are the result of client error).
+  if (req.request == "POST" && !(beresp.status >= 400 && beresp.status <= 499)) {
     return (pass);
   }
 

--- a/spec/test-outputs/www-integration.out.vcl
+++ b/spec/test-outputs/www-integration.out.vcl
@@ -148,6 +148,12 @@ sub vcl_recv {
      error 801 "Force SSL";
   }
 
+  # Reject any methods other than the ones we support.
+  # No need to include FASTLYPURGE here as that's handled above.
+  if (req.request != "HEAD" && req.request != "GET" && req.request != "POST") {
+    error 804 "Invalid Method";
+  {
+
   # Serve a 404 Not Found response if request URL matches "/autodiscover/autodiscover.xml"
   if (req.url.path ~ "(?i)/autodiscover/autodiscover.xml$") {
     error 804 "Not Found";

--- a/spec/test-outputs/www-integration.out.vcl
+++ b/spec/test-outputs/www-integration.out.vcl
@@ -150,7 +150,7 @@ sub vcl_recv {
 
   # Serve a 404 Not Found response if request URL matches "/autodiscover/autodiscover.xml"
   if (req.url.path ~ "(?i)/autodiscover/autodiscover.xml$") {
-    error 404 "Not Found";
+    error 804 "Not Found";
   }
 
   # Serve from stale for 24 hours if origin is sick
@@ -478,6 +478,32 @@ sub vcl_error {
     set obj.http.Location = "https://" req.http.host req.url;
     set obj.http.Fastly-Backend-Name = "force_ssl";
     synthetic {""};
+    return (deliver);
+  }
+
+  if (obj.status == 804) {
+    set obj.status = 404;
+    set obj.response = "Not Found";
+    set obj.http.Fastly-Backend-Name = "force_not_found";
+
+    synthetic {"
+      <!DOCTYPE html>
+      <html>
+        <head>
+          <title>Welcome to GOV.UK</title>
+          <style>
+            body { font-family: Arial, sans-serif; margin: 0; }
+            header { background: black; }
+            h1 { color: white; font-size: 29px; margin: 0 auto; padding: 10px; max-width: 990px; }
+            p { color: black; margin: 30px auto; max-width: 990px; }
+          </style>
+        </head>
+        <body>
+          <header><h1>GOV.UK</h1></header>
+          <p>We cannot find the page you're looking for. Please try searching on <a href="https://www.gov.uk/">GOV.UK</a>.</p>
+        </body>
+      </html>"};
+
     return (deliver);
   }
 

--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -150,6 +150,12 @@ sub vcl_recv {
      error 801 "Force SSL";
   }
 
+  # Reject any methods other than the ones we support.
+  # No need to include FASTLYPURGE here as that's handled above.
+  if (req.request != "HEAD" && req.request != "GET" && req.request != "POST") {
+    error 804 "Invalid Method";
+  {
+
   # Serve a 404 Not Found response if request URL matches "/autodiscover/autodiscover.xml"
   if (req.url.path ~ "(?i)/autodiscover/autodiscover.xml$") {
     error 804 "Not Found";

--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -219,11 +219,8 @@ sub vcl_recv {
 
 #FASTLY recv
 
-  if (req.request != "HEAD" && req.request != "GET" && req.request != "FASTLYPURGE") {
-    return(pass);
-  }
-
-    # Begin dynamic section
+  if (req.request != "POST") {
+        # Begin dynamic section
 if (table.lookup(active_ab_tests, "Example") == "true") {
   if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
     set req.http.GOVUK-ABTest-Example = "A";
@@ -354,6 +351,7 @@ if (table.lookup(active_ab_tests, "RelatedLinksABTest1") == "true") {
 }
 # End dynamic section
 
+  }
 
   return(lookup);
 }
@@ -387,6 +385,12 @@ sub vcl_fetch {
   }
 
   if (beresp.http.Cache-Control ~ "no-(store|cache)") {
+    return (pass);
+  }
+
+  # Pass through good responses to POST requests (i.e. cache responses to POST
+  # requests that are the result of client error).
+  if (req.request == "POST" && !(beresp.status >= 400 && beresp.status <= 499)) {
     return (pass);
   }
 

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -161,7 +161,7 @@ sub vcl_recv {
 
   # Serve a 404 Not Found response if request URL matches "/autodiscover/autodiscover.xml"
   if (req.url.path ~ "(?i)/autodiscover/autodiscover.xml$") {
-    error 404 "Not Found";
+    error 804 "Not Found";
   }
 
   # Serve from stale for 24 hours if origin is sick
@@ -489,6 +489,32 @@ sub vcl_error {
     set obj.http.Location = "https://" req.http.host req.url;
     set obj.http.Fastly-Backend-Name = "force_ssl";
     synthetic {""};
+    return (deliver);
+  }
+
+  if (obj.status == 804) {
+    set obj.status = 404;
+    set obj.response = "Not Found";
+    set obj.http.Fastly-Backend-Name = "force_not_found";
+
+    synthetic {"
+      <!DOCTYPE html>
+      <html>
+        <head>
+          <title>Welcome to GOV.UK</title>
+          <style>
+            body { font-family: Arial, sans-serif; margin: 0; }
+            header { background: black; }
+            h1 { color: white; font-size: 29px; margin: 0 auto; padding: 10px; max-width: 990px; }
+            p { color: black; margin: 30px auto; max-width: 990px; }
+          </style>
+        </head>
+        <body>
+          <header><h1>GOV.UK</h1></header>
+          <p>We cannot find the page you're looking for. Please try searching on <a href="https://www.gov.uk/">GOV.UK</a>.</p>
+        </body>
+      </html>"};
+
     return (deliver);
   }
 

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -159,6 +159,12 @@ sub vcl_recv {
      error 801 "Force SSL";
   }
 
+  # Reject any methods other than the ones we support.
+  # No need to include FASTLYPURGE here as that's handled above.
+  if (req.request != "HEAD" && req.request != "GET" && req.request != "POST") {
+    error 804 "Invalid Method";
+  {
+
   # Serve a 404 Not Found response if request URL matches "/autodiscover/autodiscover.xml"
   if (req.url.path ~ "(?i)/autodiscover/autodiscover.xml$") {
     error 804 "Not Found";

--- a/vcl_templates/bouncer.vcl.erb
+++ b/vcl_templates/bouncer.vcl.erb
@@ -72,7 +72,7 @@ sub vcl_recv {
 
   # Serve a 404 Not Found response if request URL matches "/autodiscover/autodiscover.xml"
   if (req.url.path ~ "(?i)/autodiscover/autodiscover.xml$") {
-    error 404 "Not Found";
+    error 804 "Not Found";
   }
 
   # Append to XFF. Unsure about this restart condition?
@@ -166,6 +166,31 @@ sub vcl_deliver {
 }
 
 sub vcl_error {
+  if (obj.status == 804) {
+    set obj.status = 404;
+    set obj.response = "Not Found";
+    set obj.http.Fastly-Backend-Name = "force_not_found";
+
+    synthetic {"
+      <!DOCTYPE html>
+      <html>
+        <head>
+          <title>Welcome to GOV.UK</title>
+          <style>
+            body { font-family: Arial, sans-serif; margin: 0; }
+            header { background: black; }
+            h1 { color: white; font-size: 29px; margin: 0 auto; padding: 10px; max-width: 990px; }
+            p { color: black; margin: 30px auto; max-width: 990px; }
+          </style>
+        </head>
+        <body>
+          <header><h1>GOV.UK</h1></header>
+          <p>We cannot find the page you're looking for. Please try searching on <a href="https://www.gov.uk/">GOV.UK</a>.</p>
+        </body>
+      </html>"};
+
+    return (deliver);
+  }
 
   # Assume we've hit vcl_error() because the backend is unavailable
   if (req.restarts < 2) {

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -257,12 +257,10 @@ sub vcl_recv {
 
 #FASTLY recv
 
-  if (req.request != "HEAD" && req.request != "GET" && req.request != "FASTLYPURGE") {
-    return(pass);
+  if (req.request != "POST") {
+    <% template_path = File.join(File.dirname(__FILE__), "vcl_templates/_multivariate_tests.vcl.erb") -%>
+    <%= ERB.new(File.new(template_path).read, nil, "-", "_erbout2").result(binding) %>
   }
-
-  <% template_path = File.join(File.dirname(__FILE__), "vcl_templates/_multivariate_tests.vcl.erb") -%>
-  <%= ERB.new(File.new(template_path).read, nil, "-", "_erbout2").result(binding) %>
 
   return(lookup);
 }
@@ -296,6 +294,12 @@ sub vcl_fetch {
   }
 
   if (beresp.http.Cache-Control ~ "no-(store|cache)") {
+    return (pass);
+  }
+
+  # Pass through good responses to POST requests (i.e. cache responses to POST
+  # requests that are the result of client error).
+  if (req.request == "POST" && !(beresp.status >= 400 && beresp.status <= 499)) {
     return (pass);
   }
 

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -185,7 +185,7 @@ sub vcl_recv {
 
   # Serve a 404 Not Found response if request URL matches "/autodiscover/autodiscover.xml"
   if (req.url.path ~ "(?i)/autodiscover/autodiscover.xml$") {
-    error 404 "Not Found";
+    error 804 "Not Found";
   }
 
   # Serve from stale for 24 hours if origin is sick
@@ -385,6 +385,32 @@ sub vcl_error {
     set obj.http.Location = "https://" req.http.host req.url;
     set obj.http.Fastly-Backend-Name = "force_ssl";
     synthetic {""};
+    return (deliver);
+  }
+
+  if (obj.status == 804) {
+    set obj.status = 404;
+    set obj.response = "Not Found";
+    set obj.http.Fastly-Backend-Name = "force_not_found";
+
+    synthetic {"
+      <!DOCTYPE html>
+      <html>
+        <head>
+          <title>Welcome to GOV.UK</title>
+          <style>
+            body { font-family: Arial, sans-serif; margin: 0; }
+            header { background: black; }
+            h1 { color: white; font-size: 29px; margin: 0 auto; padding: 10px; max-width: 990px; }
+            p { color: black; margin: 30px auto; max-width: 990px; }
+          </style>
+        </head>
+        <body>
+          <header><h1>GOV.UK</h1></header>
+          <p>We cannot find the page you're looking for. Please try searching on <a href="https://www.gov.uk/">GOV.UK</a>.</p>
+        </body>
+      </html>"};
+
     return (deliver);
   }
 

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -183,6 +183,12 @@ sub vcl_recv {
      error 801 "Force SSL";
   }
 
+  # Reject any methods other than the ones we support.
+  # No need to include FASTLYPURGE here as that's handled above.
+  if (req.request != "HEAD" && req.request != "GET" && req.request != "POST") {
+    error 804 "Invalid Method";
+  {
+
   # Serve a 404 Not Found response if request URL matches "/autodiscover/autodiscover.xml"
   if (req.url.path ~ "(?i)/autodiscover/autodiscover.xml$") {
     error 804 "Not Found";


### PR DESCRIPTION
As a general precaution (and to somewhat protect the origin servers) cache the responses to POST requests that are the result of a client error (e.g. a POST that results in a 404).

Also fix up the synthetic response to forced-404s for `autodiscover.xml` paths, and use the same method to quick-fail for non-supported HTTP methods.