### PR TITLE
Improve handling for forced-404 responses

### DIFF
--- a/spec/test-outputs/www-integration.out.vcl
+++ b/spec/test-outputs/www-integration.out.vcl
@@ -150,7 +150,7 @@ sub vcl_recv {
 
   # Serve a 404 Not Found response if request URL matches "/autodiscover/autodiscover.xml"
   if (req.url.path ~ "(?i)/autodiscover/autodiscover.xml$") {
-    error 404 "Not Found";
+    error 804 "Not Found";
   }
 
   # Serve from stale for 24 hours if origin is sick
@@ -478,6 +478,32 @@ sub vcl_error {
     set obj.http.Location = "https://" req.http.host req.url;
     set obj.http.Fastly-Backend-Name = "force_ssl";
     synthetic {""};
+    return (deliver);
+  }
+
+  if (obj.status == 804) {
+    set obj.status = 404;
+    set obj.response = "Not Found";
+    set obj.http.Fastly-Backend-Name = "force_not_found";
+
+    synthetic {"
+      <!DOCTYPE html>
+      <html>
+        <head>
+          <title>Welcome to GOV.UK</title>
+          <style>
+            body { font-family: Arial, sans-serif; margin: 0; }
+            header { background: black; }
+            h1 { color: white; font-size: 29px; margin: 0 auto; padding: 10px; max-width: 990px; }
+            p { color: black; margin: 30px auto; max-width: 990px; }
+          </style>
+        </head>
+        <body>
+          <header><h1>GOV.UK</h1></header>
+          <p>We cannot find the page you're looking for. Please try searching on <a href="https://www.gov.uk/">GOV.UK</a>.</p>
+        </body>
+      </html>"};
+
     return (deliver);
   }
 

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -161,7 +161,7 @@ sub vcl_recv {
 
   # Serve a 404 Not Found response if request URL matches "/autodiscover/autodiscover.xml"
   if (req.url.path ~ "(?i)/autodiscover/autodiscover.xml$") {
-    error 404 "Not Found";
+    error 804 "Not Found";
   }
 
   # Serve from stale for 24 hours if origin is sick
@@ -489,6 +489,32 @@ sub vcl_error {
     set obj.http.Location = "https://" req.http.host req.url;
     set obj.http.Fastly-Backend-Name = "force_ssl";
     synthetic {""};
+    return (deliver);
+  }
+
+  if (obj.status == 804) {
+    set obj.status = 404;
+    set obj.response = "Not Found";
+    set obj.http.Fastly-Backend-Name = "force_not_found";
+
+    synthetic {"
+      <!DOCTYPE html>
+      <html>
+        <head>
+          <title>Welcome to GOV.UK</title>
+          <style>
+            body { font-family: Arial, sans-serif; margin: 0; }
+            header { background: black; }
+            h1 { color: white; font-size: 29px; margin: 0 auto; padding: 10px; max-width: 990px; }
+            p { color: black; margin: 30px auto; max-width: 990px; }
+          </style>
+        </head>
+        <body>
+          <header><h1>GOV.UK</h1></header>
+          <p>We cannot find the page you're looking for. Please try searching on <a href="https://www.gov.uk/">GOV.UK</a>.</p>
+        </body>
+      </html>"};
+
     return (deliver);
   }
 

--- a/vcl_templates/bouncer.vcl.erb
+++ b/vcl_templates/bouncer.vcl.erb
@@ -72,7 +72,7 @@ sub vcl_recv {
 
   # Serve a 404 Not Found response if request URL matches "/autodiscover/autodiscover.xml"
   if (req.url.path ~ "(?i)/autodiscover/autodiscover.xml$") {
-    error 404 "Not Found";
+    error 804 "Not Found";
   }
 
   # Append to XFF. Unsure about this restart condition?
@@ -166,6 +166,31 @@ sub vcl_deliver {
 }
 
 sub vcl_error {
+  if (obj.status == 804) {
+    set obj.status = 404;
+    set obj.response = "Not Found";
+    set obj.http.Fastly-Backend-Name = "force_not_found";
+
+    synthetic {"
+      <!DOCTYPE html>
+      <html>
+        <head>
+          <title>Welcome to GOV.UK</title>
+          <style>
+            body { font-family: Arial, sans-serif; margin: 0; }
+            header { background: black; }
+            h1 { color: white; font-size: 29px; margin: 0 auto; padding: 10px; max-width: 990px; }
+            p { color: black; margin: 30px auto; max-width: 990px; }
+          </style>
+        </head>
+        <body>
+          <header><h1>GOV.UK</h1></header>
+          <p>We cannot find the page you're looking for. Please try searching on <a href="https://www.gov.uk/">GOV.UK</a>.</p>
+        </body>
+      </html>"};
+
+    return (deliver);
+  }
 
   # Assume we've hit vcl_error() because the backend is unavailable
   if (req.restarts < 2) {

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -185,7 +185,7 @@ sub vcl_recv {
 
   # Serve a 404 Not Found response if request URL matches "/autodiscover/autodiscover.xml"
   if (req.url.path ~ "(?i)/autodiscover/autodiscover.xml$") {
-    error 404 "Not Found";
+    error 804 "Not Found";
   }
 
   # Serve from stale for 24 hours if origin is sick
@@ -385,6 +385,32 @@ sub vcl_error {
     set obj.http.Location = "https://" req.http.host req.url;
     set obj.http.Fastly-Backend-Name = "force_ssl";
     synthetic {""};
+    return (deliver);
+  }
+
+  if (obj.status == 804) {
+    set obj.status = 404;
+    set obj.response = "Not Found";
+    set obj.http.Fastly-Backend-Name = "force_not_found";
+
+    synthetic {"
+      <!DOCTYPE html>
+      <html>
+        <head>
+          <title>Welcome to GOV.UK</title>
+          <style>
+            body { font-family: Arial, sans-serif; margin: 0; }
+            header { background: black; }
+            h1 { color: white; font-size: 29px; margin: 0 auto; padding: 10px; max-width: 990px; }
+            p { color: black; margin: 30px auto; max-width: 990px; }
+          </style>
+        </head>
+        <body>
+          <header><h1>GOV.UK</h1></header>
+          <p>We cannot find the page you're looking for. Please try searching on <a href="https://www.gov.uk/">GOV.UK</a>.</p>
+        </body>
+      </html>"};
+
     return (deliver);
   }
 


### PR DESCRIPTION
We use a synthetic 404 response for handling requests for `autodiscover.xml` paths (see #86), but the way these are handled isn't optimal:

* It gets treated as a generic error, which is assumed to be due to a backend being unavailable, and gets retried.
* The response sent back implies that an error occurred.

This change uses a custom HTTP status to skip retrying, and provides a more user-friendly (and correct) response body.