### PR TITLE
Rename cdn-configs repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ We use edge dictionaries to define the configuration for A/B and multivariate te
 
 ## IP address blocking
 
-We use an edge dictionary to block IP addresses, which lives in [alphagov/cdn-configs](https://github.com/alphagov/cdn-configs).
+We use an edge dictionary to block IP addresses, which lives in [alphagov/govuk-cdn-config-secrets](https://github.com/alphagov/govuk-cdn-config-secrets).
 
 - `ip_address_blacklist.yaml`: This controls whether an IP address is blocked or not.
 

--- a/deploy-dictionaries.sh
+++ b/deploy-dictionaries.sh
@@ -2,11 +2,11 @@
 set -eu
 
 # Copy secret dictionaries over into /configs
-rm -rf cdn-configs
-git clone git@github.com:alphagov/cdn-configs.git
+rm -rf govuk-cdn-config-secrets
+git clone git@github.com:alphagov/govuk-cdn-config-secrets.git
 
-cp cdn-configs/fastly/dictionaries/config/* configs/dictionaries
-cp cdn-configs/fastly/fastly.yaml .
+cp govuk-cdn-config-secrets/fastly/dictionaries/config/* configs/dictionaries
+cp govuk-cdn-config-secrets/fastly/fastly.yaml .
 
 bundle install --path "${HOME}/bundles/${JOB_NAME}"
 bundle exec ./configure_dictionaries ${vhost} ${ENVIRONMENT}

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -2,9 +2,9 @@
 
 set -e
 
-git clone 'git@github.com:alphagov/cdn-configs.git'
+git clone 'git@github.com:alphagov/govuk-cdn-config-secrets.git'
 
-cp cdn-configs/fastly/fastly.yaml .
+cp govuk-cdn-config-secrets/fastly/fastly.yaml .
 
 bundle install --path "${HOME}/bundles/${JOB_NAME}"
 bundle exec ./deploy_vcl ${vhost} ${ENVIRONMENT}

--- a/spec/vcl_generation_spec.rb
+++ b/spec/vcl_generation_spec.rb
@@ -4,7 +4,7 @@ require_relative './../lib/render_template'
 # This
 RSpec.describe "VCL generation" do
   # Fill in the required test data. Normally this would come from
-  # https://github.com/alphagov/cdn-configs/blob/master/fastly/fastly.yaml
+  # https://github.com/alphagov/govuk-cdn-config-secrets/blob/master/fastly/fastly.yaml
   config = {
     "origin_hostname" => "foo",
     "service_id" => "123",


### PR DESCRIPTION
We've renamed this repo:

https://github.com/alphagov/govuk-cdn-config-secrets