### PR TITLE
Use consistent naming for "deploy service" task

### DIFF
--- a/deploy_service
+++ b/deploy_service
@@ -3,6 +3,6 @@
 require 'erb'
 
 require_relative './lib/render_template'
-require_relative './lib/deploy_cdn'
+require_relative './lib/deploy_service'
 
-DeployCDN.new.deploy_the_vcl!(ARGV)
+DeployService.new.deploy!(ARGV)

--- a/lib/deploy_service.rb
+++ b/lib/deploy_service.rb
@@ -2,10 +2,10 @@ require 'yaml'
 require 'fastly'
 require 'diffy'
 
-class DeployCDN
+class DeployService
   CONFIGS = YAML.load_file(File.join(__dir__, "..", "fastly.yaml"))
 
-  def deploy_the_vcl!(argv)
+  def deploy!(argv)
     configuration, environment, config = get_config(argv)
 
     ['FASTLY_USER', 'FASTLY_PASS'].each do |envvar|

--- a/spec/deploy_service_spec.rb
+++ b/spec/deploy_service_spec.rb
@@ -1,7 +1,7 @@
-require './lib/deploy_cdn'
+require './lib/deploy_service'
 
-describe DeployCDN do
-  describe '#deploy_the_vcl' do
+describe DeployService do
+  describe '#deploy' do
     it 'deploys the VCL' do
       # This call is made by the Fastly library when you call `Fastly.new`
       stub_request(:post, "https://api.fastly.com/login").to_return(body: "{}")
@@ -59,10 +59,10 @@ describe DeployCDN do
       stub_request(:put, "https://api.fastly.com/service/123321abc/version/3/activate").
         to_return(body: "{}")
 
-      deployer = DeployCDN.new
+      deployer = DeployService.new
 
       ClimateControl.modify FASTLY_USER: 'fastly@example.com', FASTLY_PASS: '123' do
-        deployer.deploy_the_vcl!(['test', 'production'])
+        deployer.deploy!(['test', 'production'])
       end
     end
   end


### PR DESCRIPTION
This makes it consistent with "deploy bouncer" and "deploy dictionaries", and with the shell scripts.

https://trello.com/c/y6MIgxjp