### PR TITLE
Increase test coverage

### DIFF
--- a/lib/deploy_dictionaries.rb
+++ b/lib/deploy_dictionaries.rb
@@ -24,15 +24,17 @@ class DeployDictionaries
     version = get_dev_version(service)
     puts "Using version #{version.number} of #{service.name}"
 
+    dictionaries = version.dictionaries
+
     expected_dictionaries = Dir.glob("configs/dictionaries/*.yaml").map { |filename| File.basename(filename, '.yaml') }
-    existing_dictionaries = version.dictionaries.map { |dictionary| dictionary.name }
+    existing_dictionaries = dictionaries.map { |dictionary| dictionary.name }
 
     # Clean up dictionaries which are no longer used
     dictionaries_to_remove = existing_dictionaries - expected_dictionaries
 
     dictionaries_to_remove.each do |name|
       puts "Deleting existing dictionary '#{name}' from Fastly because it is no longer configured"
-      dictionary = version.dictionaries.detect { |d| d.name == name }
+      dictionary = dictionaries.detect { |d| d.name == name }
       @fastly.delete_dictionary(dictionary)
     end
 

--- a/spec/deploy_bouncer_spec.rb
+++ b/spec/deploy_bouncer_spec.rb
@@ -1,0 +1,80 @@
+require './lib/deploy_bouncer'
+
+describe DeployBouncer do
+  describe '#deploy' do
+    it 'deploys the VCL for bouncer' do
+      @requests = []
+
+      # This call is made by the Fastly library when you call `Fastly.new`
+      @requests << stub_request(:post, "https://api.fastly.com/login").to_return(body: "{}")
+
+      # Fastly#get_service. Return a service with two VCL "versions" (https://docs.fastly.com/api/config#version)
+      @requests << stub_request(:get, "https://api.fastly.com/service/123321abc").
+        to_return(body: File.read("spec/fixtures/fastly-get-service-response.json"))
+
+      # We clone the latest active VCL version, which returns the latest version
+      @requests << stub_request(:put, "https://api.fastly.com/service/123321abc/version/2/clone").
+        to_return(body: File.read("spec/fixtures/fastly-put-clone.json"))
+
+      # Given Transition has 2 hosts
+      @requests << stub_request(:get, "https://transition.publishing.service.gov.uk/hosts.json").
+        to_return(body: JSON.dump(results: [{ hostname: "existing.example.com" }, { hostname: "newly-added.example.com" }]))
+
+      # And Fastly has 2 hosts, but one is different from transition
+      @requests << stub_request(:get, "https://api.fastly.com/service/123321abc/version/3/domain").
+        to_return(body: JSON.dump([{ name: "existing.example.com" }, { name: "old.example.com" }]))
+
+      # One domain will be deleted
+      @requests << stub_request(:delete, "https://api.fastly.com/service/123321abc/version/3/domain/old.example.com").
+        to_return(body: "{}")
+
+      # And the new one will be created
+      @requests << stub_request(:post, "https://api.fastly.com/service/123321abc/version/3/domain").
+        with(
+          body: { "comment" => "", "name" => "newly-added.example.com", "service_id" => "123321abc", "version" => "3" }
+        ).
+        to_return(body: "{}")
+
+      # Stub calls to delete the "UI objects"
+      %w[backend healthcheck cache_settings condition request_settings response_object header gzip].each do |thing|
+        @requests << stub_request(:get, "https://api.fastly.com/service/123321abc/version/3/#{thing}").
+          to_return(body: "{}")
+      end
+
+      # We first check the latest version
+      @requests << stub_request(:get, "https://api.fastly.com/service/123321abc/version/3/vcl/main").
+        to_return(body: "{}")
+
+      # We then delete it
+      @requests << stub_request(:delete, "https://api.fastly.com/service/123321abc/version/3/vcl/main").
+        to_return(body: "{}")
+
+      # Then send the actual VCL
+      # https://docs.fastly.com/api/config#vcl_7ade6ab5926b903b6acf3335a85060cc
+      @requests << stub_request(:post, "https://api.fastly.com/service/123321abc/version/3/vcl").
+        to_return(body: File.read("spec/fixtures/fastly-post-vcl.json"))
+
+      # Test the VCL of the previous version
+      @requests << stub_request(:put, "https://api.fastly.com/service/123321abc/version/2/vcl/test-vcl/main").
+        to_return(body: "{}")
+
+      @requests << stub_request(:get, "https://api.fastly.com/service/123321abc/version/2/generated_vcl").
+        to_return(body: "{}")
+
+      @requests << stub_request(:get, "https://api.fastly.com/service/123321abc/version/3/generated_vcl").
+        to_return(body: "{}")
+
+      # Activate the version we've just created
+      @requests << stub_request(:put, "https://api.fastly.com/service/123321abc/version/3/activate").
+        to_return(body: "{}")
+
+      ClimateControl.modify APP_DOMAIN: "gov.uk", FASTLY_SERVICE_ID: "123321abc", FASTLY_USER: 'fastly@example.com', FASTLY_PASS: '123' do
+        DeployBouncer.new.deploy!
+
+        @requests.each do |request|
+          expect(request).to have_been_requested.at_least_once
+        end
+      end
+    end
+  end
+end

--- a/spec/deploy_dictionaries_spec.rb
+++ b/spec/deploy_dictionaries_spec.rb
@@ -1,0 +1,62 @@
+require './lib/deploy_dictionaries'
+
+describe DeployDictionaries do
+  describe '#deploy' do
+    it 'deploys the dictionaries' do
+      @requests = []
+
+      # This call is made by the Fastly library when you call `Fastly.new`
+      @requests << stub_request(:post, "https://api.fastly.com/login").to_return(body: "{}")
+
+      # Fastly#get_service. Return a service with two VCL "versions" (https://docs.fastly.com/api/config#version)
+      @requests << stub_request(:get, "https://api.fastly.com/service/123321abc").
+        to_return(body: File.read("spec/fixtures/fastly-get-service-response.json"))
+
+      # We clone the latest active VCL version, which returns the latest version
+      @requests << stub_request(:put, "https://api.fastly.com/service/123321abc/version/2/clone").
+        to_return(body: File.read("spec/fixtures/fastly-put-clone.json"))
+
+      @requests << stub_request(:get, "https://api.fastly.com/service/123321abc/version/3/dictionary").
+        to_return { |request|
+          if @deleted
+            { body: JSON.dump([{ id: "qwerty", name: "example_percentages", version: 1, service_id: "123321abc" }]) }
+          else
+            @deleted = true
+            { body: JSON.dump([{ id: "qwerty", name: "example_percentages", version: 1, service_id: "123321abc" }, { name: "to_be_deleted_because_theres_no_yaml_file", version: 1, service_id: "123321abc" }]) }
+          end
+        }
+
+      @requests << stub_request(:delete, "https://api.fastly.com/service/123321abc/version/1/dictionary/to_be_deleted_because_theres_no_yaml_file").
+        to_return(body: "{}")
+
+      @requests << stub_request(:post, "https://api.fastly.com/service/123321abc/version/3/dictionary").
+        to_return(body: "{}")
+
+      @requests << stub_request(:get, "https://api.fastly.com/service/123321abc/dictionary/qwerty/items").
+          to_return(body: "{}")
+
+      @requests << stub_request(:post, "https://api.fastly.com/service/123321abc/dictionary/qwerty/item").
+        with(
+          body: {"dictionary_id"=>"qwerty", "item_key"=>"A", "item_value"=>"50", "service_id"=>"123321abc"},
+        ).
+        to_return(body: "{}")
+
+      @requests << stub_request(:post, "https://api.fastly.com/service/123321abc/dictionary/qwerty/item").
+        with(
+          body: {"dictionary_id"=>"qwerty", "item_key"=>"B", "item_value"=>"50", "service_id"=>"123321abc"},
+        ).
+        to_return(body: "{}")
+
+      @requests << stub_request(:put, "https://api.fastly.com/service/123321abc/version/3/activate").
+          to_return(body: "{}")
+
+      ClimateControl.modify FASTLY_USER: 'fastly@example.com', FASTLY_PASS: '123' do
+        DeployDictionaries.new.deploy!(['test', 'production'])
+
+        @requests.each do |request|
+          expect(request).to have_been_requested.at_least_once
+        end
+      end
+    end
+  end
+end

--- a/spec/deploy_service_spec.rb
+++ b/spec/deploy_service_spec.rb
@@ -3,66 +3,72 @@ require './lib/deploy_service'
 describe DeployService do
   describe '#deploy' do
     it 'deploys the VCL' do
+      @requests = []
+
       # This call is made by the Fastly library when you call `Fastly.new`
-      stub_request(:post, "https://api.fastly.com/login").to_return(body: "{}")
+      @requests << stub_request(:post, "https://api.fastly.com/login").to_return(body: "{}")
 
       # Fastly#get_service. Return a service with two VCL "versions" (https://docs.fastly.com/api/config#version)
-      stub_request(:get, "https://api.fastly.com/service/123321abc").
+      @requests << stub_request(:get, "https://api.fastly.com/service/123321abc").
         to_return(body: File.read("spec/fixtures/fastly-get-service-response.json"))
 
       # We clone the latest active VCL version, which returns the latest version
-      stub_request(:put, "https://api.fastly.com/service/123321abc/version/2/clone").
+      @requests << stub_request(:put, "https://api.fastly.com/service/123321abc/version/2/clone").
         to_return(body: File.read("spec/fixtures/fastly-put-clone.json"))
 
       # Stub calls to delete the "UI objects"
       %w[backend healthcheck cache_settings request_settings response_object header gzip].each do |thing|
-        stub_request(:get, "https://api.fastly.com/service/123321abc/version/3/#{thing}").
+        @requests << stub_request(:get, "https://api.fastly.com/service/123321abc/version/3/#{thing}").
           to_return(body: "{}")
       end
 
       # We first check the latest version
-      stub_request(:get, "https://api.fastly.com/service/123321abc/version/3/vcl/main").
+      @requests << stub_request(:get, "https://api.fastly.com/service/123321abc/version/3/vcl/main").
         to_return(body: "{}")
 
       # We then delete it
-      stub_request(:delete, "https://api.fastly.com/service/123321abc/version/3/vcl/main").
+      @requests << stub_request(:delete, "https://api.fastly.com/service/123321abc/version/3/vcl/main").
         to_return(body: "{}")
 
       # Then send the actual VCL
       # https://docs.fastly.com/api/config#vcl_7ade6ab5926b903b6acf3335a85060cc
-      stub_request(:post, "https://api.fastly.com/service/123321abc/version/3/vcl").
+      @requests << stub_request(:post, "https://api.fastly.com/service/123321abc/version/3/vcl").
         to_return(body: File.read("spec/fixtures/fastly-post-vcl.json"))
 
       # Test the VCL of the previous version
-      stub_request(:put, "https://api.fastly.com/service/123321abc/version/2/vcl/test-vcl/main").
+      @requests << stub_request(:put, "https://api.fastly.com/service/123321abc/version/2/vcl/test-vcl/main").
         to_return(body: "{}")
 
-      stub_request(:get, "https://api.fastly.com/service/123321abc/version/2/generated_vcl").
+      @requests << stub_request(:get, "https://api.fastly.com/service/123321abc/version/2/generated_vcl").
         to_return(body: "{}")
 
-      stub_request(:get, "https://api.fastly.com/service/123321abc/version/3/generated_vcl").
+      @requests << stub_request(:get, "https://api.fastly.com/service/123321abc/version/3/generated_vcl").
         to_return(body: "{}")
 
       # Get the settings
-      stub_request(:get, "https://api.fastly.com/service/123321abc/version/3/settings").
+      @requests << stub_request(:get, "https://api.fastly.com/service/123321abc/version/3/settings").
         to_return(body: File.read("spec/fixtures/fastly-get-settings.json"))
 
       # And update them
-      stub_request(:put, "https://api.fastly.com/service/123321abc/version/3/settings").
+      @requests << stub_request(:put, "https://api.fastly.com/service/123321abc/version/3/settings").
         to_return(body: "{}")
 
       # Check that the new config is good
-      stub_request(:get, "https://api.fastly.com/service/123321abc/version/3/validate").
+      @requests << stub_request(:get, "https://api.fastly.com/service/123321abc/version/3/validate").
         to_return(body: JSON.dump(status: "ok"))
 
       # Activate the version we've just created
-      stub_request(:put, "https://api.fastly.com/service/123321abc/version/3/activate").
+      @requests << stub_request(:put, "https://api.fastly.com/service/123321abc/version/3/activate").
         to_return(body: "{}")
 
       deployer = DeployService.new
 
       ClimateControl.modify FASTLY_USER: 'fastly@example.com', FASTLY_PASS: '123' do
         deployer.deploy!(['test', 'production'])
+
+        @requests.each do |request|
+          expect(request).to have_been_requested.at_least_once
+        end
       end
     end
   end


### PR DESCRIPTION
This adds some tests for the bouncer and dictionary deploy code, which is possible after https://github.com/alphagov/govuk-cdn-config/pull/114 and https://github.com/alphagov/govuk-cdn-config/pull/115.

The tests themselves aren't particularly nice, but they exercise most of the functionality. During refactoring we should make the tests nicer as well.

https://trello.com/c/y6MIgxjp