### PR TITLE
Changing CDN configuration for asset-origin around

### DIFF
--- a/vcl_templates/assets.vcl.erb
+++ b/vcl_templates/assets.vcl.erb
@@ -1,3 +1,4 @@
+# stupid ci
 backend F_origin {
     .connect_timeout = 5s;
     .dynamic = true;
@@ -21,6 +22,79 @@ backend F_origin {
         .request =
             "HEAD /__canary__ HTTP/1.1"
             "Host: <%= environment == 'staging' || environment == 'integration' ? 'assets.publishing.service.gov.uk' : config.fetch('origin_hostname') %>"
+            "User-Agent: Fastly healthcheck (git version: <%= config['git_version'] %>)"
+<% if config['rate_limit_token'] %>
+            "Rate-Limit-Token: <%= config['rate_limit_token'] %>"
+<% end %>
+            "Connection: close";
+        .threshold = 1;
+        .window = 2;
+        .timeout = 5s;
+        .initial = 1;
+        .expected_response = 200;
+        .interval = 10s;
+      }
+}
+backend F_aws_origin {
+    .connect_timeout = 5s;
+    .dynamic = true;
+    .port = "<%= config.fetch('aws_origin_port', '443') %>";
+    .host = "<%= config.fetch('aws_origin_hostname') %>";
+    .first_byte_timeout = 15s;
+    .max_connections = 200;
+    .between_bytes_timeout = 10s;
+    .share_key = "<%= config.fetch('service_id') %>";
+
+    .ssl = true;
+    .ssl_check_cert = <%= config['disable_tls_validation'] ? 'never' : 'always' %>;
+    .min_tls_version = "<%= config.fetch('min_tls_version', '1.2') %>";
+    <%- if config['ssl_ciphers'] -%>
+    .ssl_ciphers = "<%= config['ssl_ciphers'] -%>";
+    <%- end -%>
+    .ssl_cert_hostname = "<%= config.fetch('aws_ssl_cert_hostname', config.fetch('aws_origin_hostname')) %>";
+    .ssl_sni_hostname = "<%= config.fetch('aws_ssl_sni_hostname', config.fetch('aws_origin_hostname')) %>";
+
+    .probe = {
+        .request =
+            "HEAD /__canary__ HTTP/1.1"
+            "Host: <%= environment == 'staging' || environment == 'integration' ? 'assets.production.govuk.digital' : config.fetch('aws_origin_hostname') %>"
+            "User-Agent: Fastly healthcheck (git version: <%= config['git_version'] %>)"
+<% if config['rate_limit_token'] %>
+            "Rate-Limit-Token: <%= config['rate_limit_token'] %>"
+<% end %>
+            "Connection: close";
+        .threshold = 1;
+        .window = 2;
+        .timeout = 5s;
+        .initial = 1;
+        .expected_response = 200;
+        .interval = 10s;
+      }
+}
+
+backend F_whitehall_origin {
+    .connect_timeout = 5s;
+    .dynamic = true;
+    .port = "<%= config.fetch('whitehall_origin_port', '443') %>";
+    .host = "<%= config.fetch('whitehall_origin_hostname') %>";
+    .first_byte_timeout = 15s;
+    .max_connections = 200;
+    .between_bytes_timeout = 10s;
+    .share_key = "<%= config.fetch('service_id') %>";
+
+    .ssl = true;
+    .ssl_check_cert = <%= config['disable_tls_validation'] ? 'never' : 'always' %>;
+    .min_tls_version = "<%= config.fetch('min_tls_version', '1.2') %>";
+    <%- if config['ssl_ciphers'] -%>
+    .ssl_ciphers = "<%= config['ssl_ciphers'] -%>";
+    <%- end -%>
+    .ssl_cert_hostname = "<%= config.fetch('whitehall_ssl_cert_hostname', config.fetch('whitehall_origin_hostname')) %>";
+    .ssl_sni_hostname = "<%= config.fetch('whitehall_ssl_sni_hostname', config.fetch('whitehall_origin_hostname')) %>";
+
+    .probe = {
+        .request =
+            "HEAD /__canary__ HTTP/1.1"
+            "Host: <%= environment == 'staging' || environment == 'integration' ? 'whitehall-frontend.production.govuk.digital' : config.fetch('whitehall_origin_hostname') %>"
             "User-Agent: Fastly healthcheck (git version: <%= config['git_version'] %>)"
 <% if config['rate_limit_token'] %>
             "Rate-Limit-Token: <%= config['rate_limit_token'] %>"
@@ -162,12 +236,19 @@ sub vcl_recv {
   set req.grace = 24h;
 
   # Default backend.
-  set req.backend = F_origin;
+  set req.backend = F_aws_origin;
   set req.http.Fastly-Backend-Name = "origin";
 <% if environment == 'staging' || environment == 'integration' %>
   # Force host header for staging and integration.
   set req.http.host = "assets.publishing.service.gov.uk";
 <% end %>
+
+  if (req.url ~ "^/asset-manager\?" || req.url ~ "^/government/uploads\?" || req.url ~ "^/media\?")
+    set req.backend = F_origin;
+  end if
+  if (req.url ~ "^/government/assets\?" || req.url ~ "^/government/placeholder\?" || req.url ~ "^/government/uploads/system/uploads/attachment_data/file/[0-9]+/.*/preview\?")
+    set req.backend = F_whitehall_origin;
+  end if
 
   # Serve stale if it exists.
   if (req.restarts > 0) {

--- a/vcl_templates/assets.vcl.erb
+++ b/vcl_templates/assets.vcl.erb
@@ -1,4 +1,3 @@
-# stupid ci
 backend F_origin {
     .connect_timeout = 5s;
     .dynamic = true;


### PR DESCRIPTION
- For AWS migration in staging, we switch around the asset handling
routes on the level of Fastly

- The new default is AWS, holding the frontends, which special cases of
the asset-manager and whitehall-frontend still remaining in Carrenza

solo: @schmie