### PR TITLE
Changing CDN configuration for asset-origin around

### DIFF
--- a/spec/test-outputs/assets-integration.out.vcl
+++ b/spec/test-outputs/assets-integration.out.vcl
@@ -224,7 +224,6 @@ sub vcl_recv {
     set req.backend = F_whitehall_origin;
   }
 
-
   # Serve stale if it exists.
   if (req.restarts > 0) {
     set req.backend = sick_force_grace;

--- a/spec/test-outputs/assets-production.out.vcl
+++ b/spec/test-outputs/assets-production.out.vcl
@@ -223,7 +223,6 @@ sub vcl_recv {
     set req.backend = F_whitehall_origin;
   }
 
-
   # Serve stale if it exists.
   if (req.restarts > 0) {
     set req.backend = sick_force_grace;

--- a/spec/test-outputs/assets-production.out.vcl
+++ b/spec/test-outputs/assets-production.out.vcl
@@ -29,6 +29,69 @@ backend F_origin {
         .interval = 10s;
       }
 }
+backend F_aws_origin {
+    .connect_timeout = 5s;
+    .dynamic = true;
+    .port = "443";
+    .host = "foo";
+    .first_byte_timeout = 15s;
+    .max_connections = 200;
+    .between_bytes_timeout = 10s;
+    .share_key = "123";
+
+    .ssl = true;
+    .ssl_check_cert = always;
+    .min_tls_version = "1.2";
+    .ssl_cert_hostname = "foo";
+    .ssl_sni_hostname = "foo";
+
+    .probe = {
+        .request =
+            "HEAD /__canary__ HTTP/1.1"
+            "Host: foo"
+            "User-Agent: Fastly healthcheck (git version: )"
+
+            "Connection: close";
+        .threshold = 1;
+        .window = 2;
+        .timeout = 5s;
+        .initial = 1;
+        .expected_response = 200;
+        .interval = 10s;
+      }
+}
+
+backend F_whitehall_origin {
+    .connect_timeout = 5s;
+    .dynamic = true;
+    .port = "443";
+    .host = "foo";
+    .first_byte_timeout = 15s;
+    .max_connections = 200;
+    .between_bytes_timeout = 10s;
+    .share_key = "123";
+
+    .ssl = true;
+    .ssl_check_cert = always;
+    .min_tls_version = "1.2";
+    .ssl_cert_hostname = "foo";
+    .ssl_sni_hostname = "foo";
+
+    .probe = {
+        .request =
+            "HEAD /__canary__ HTTP/1.1"
+            "Host: foo"
+            "User-Agent: Fastly healthcheck (git version: )"
+
+            "Connection: close";
+        .threshold = 1;
+        .window = 2;
+        .timeout = 5s;
+        .initial = 1;
+        .expected_response = 200;
+        .interval = 10s;
+      }
+}
 # Mirror backend for provider 0
 backend F_mirror1 {
     .connect_timeout = 1s;
@@ -149,9 +212,16 @@ sub vcl_recv {
   set req.grace = 24h;
 
   # Default backend.
-  set req.backend = F_origin;
+  set req.backend = F_aws_origin;
   set req.http.Fastly-Backend-Name = "origin";
 
+
+  if (req.url ~ "^/asset-manager\?" || req.url ~ "^/government/uploads\?" || req.url ~ "^/media\?") {
+    set req.backend = F_origin;
+  }
+  if (req.url ~ "^/government/assets\?" || req.url ~ "^/government/placeholder\?" || req.url ~ "^/government/uploads/system/uploads/attachment_data/file/[0-9]+/.*/preview\?") {
+    set req.backend = F_whitehall_origin;
+  }
 
   # Serve stale if it exists.
   if (req.restarts > 0) {

--- a/spec/test-outputs/assets-staging.out.vcl
+++ b/spec/test-outputs/assets-staging.out.vcl
@@ -29,6 +29,69 @@ backend F_origin {
         .interval = 10s;
       }
 }
+backend F_aws_origin {
+    .connect_timeout = 5s;
+    .dynamic = true;
+    .port = "443";
+    .host = "foo";
+    .first_byte_timeout = 15s;
+    .max_connections = 200;
+    .between_bytes_timeout = 10s;
+    .share_key = "123";
+
+    .ssl = true;
+    .ssl_check_cert = always;
+    .min_tls_version = "1.2";
+    .ssl_cert_hostname = "foo";
+    .ssl_sni_hostname = "foo";
+
+    .probe = {
+        .request =
+            "HEAD /__canary__ HTTP/1.1"
+            "Host: assets.production.govuk.digital"
+            "User-Agent: Fastly healthcheck (git version: )"
+
+            "Connection: close";
+        .threshold = 1;
+        .window = 2;
+        .timeout = 5s;
+        .initial = 1;
+        .expected_response = 200;
+        .interval = 10s;
+      }
+}
+
+backend F_whitehall_origin {
+    .connect_timeout = 5s;
+    .dynamic = true;
+    .port = "443";
+    .host = "foo";
+    .first_byte_timeout = 15s;
+    .max_connections = 200;
+    .between_bytes_timeout = 10s;
+    .share_key = "123";
+
+    .ssl = true;
+    .ssl_check_cert = always;
+    .min_tls_version = "1.2";
+    .ssl_cert_hostname = "foo";
+    .ssl_sni_hostname = "foo";
+
+    .probe = {
+        .request =
+            "HEAD /__canary__ HTTP/1.1"
+            "Host: whitehall-frontend.production.govuk.digital"
+            "User-Agent: Fastly healthcheck (git version: )"
+
+            "Connection: close";
+        .threshold = 1;
+        .window = 2;
+        .timeout = 5s;
+        .initial = 1;
+        .expected_response = 200;
+        .interval = 10s;
+      }
+}
 # Mirror backend for provider 0
 backend F_mirror1 {
     .connect_timeout = 1s;
@@ -149,12 +212,19 @@ sub vcl_recv {
   set req.grace = 24h;
 
   # Default backend.
-  set req.backend = F_origin;
+  set req.backend = F_aws_origin;
   set req.http.Fastly-Backend-Name = "origin";
 
   # Force host header for staging and integration.
   set req.http.host = "assets.publishing.service.gov.uk";
 
+
+  if (req.url ~ "^/asset-manager\?" || req.url ~ "^/government/uploads\?" || req.url ~ "^/media\?") {
+    set req.backend = F_origin;
+  }
+  if (req.url ~ "^/government/assets\?" || req.url ~ "^/government/placeholder\?" || req.url ~ "^/government/uploads/system/uploads/attachment_data/file/[0-9]+/.*/preview\?") {
+    set req.backend = F_whitehall_origin;
+  }
 
   # Serve stale if it exists.
   if (req.restarts > 0) {

--- a/spec/test-outputs/assets-staging.out.vcl
+++ b/spec/test-outputs/assets-staging.out.vcl
@@ -219,14 +219,12 @@ sub vcl_recv {
   set req.http.host = "assets.publishing.service.gov.uk";
 
 
-
   if (req.url ~ "^/asset-manager\?" || req.url ~ "^/government/uploads\?" || req.url ~ "^/media\?") {
     set req.backend = F_origin;
   }
   if (req.url ~ "^/government/assets\?" || req.url ~ "^/government/placeholder\?" || req.url ~ "^/government/uploads/system/uploads/attachment_data/file/[0-9]+/.*/preview\?") {
     set req.backend = F_whitehall_origin;
   }
-
 
   # Serve stale if it exists.
   if (req.restarts > 0) {

--- a/vcl_templates/assets.vcl.erb
+++ b/vcl_templates/assets.vcl.erb
@@ -242,12 +242,12 @@ sub vcl_recv {
   set req.http.host = "assets.publishing.service.gov.uk";
 <% end %>
 
-  if (req.url ~ "^/asset-manager\?" || req.url ~ "^/government/uploads\?" || req.url ~ "^/media\?")
+  if (req.url ~ "^/asset-manager\?" || req.url ~ "^/government/uploads\?" || req.url ~ "^/media\?") {
     set req.backend = F_origin;
-  end if
-  if (req.url ~ "^/government/assets\?" || req.url ~ "^/government/placeholder\?" || req.url ~ "^/government/uploads/system/uploads/attachment_data/file/[0-9]+/.*/preview\?")
+  }
+  if (req.url ~ "^/government/assets\?" || req.url ~ "^/government/placeholder\?" || req.url ~ "^/government/uploads/system/uploads/attachment_data/file/[0-9]+/.*/preview\?") {
     set req.backend = F_whitehall_origin;
-  end if
+  }
 
   # Serve stale if it exists.
   if (req.restarts > 0) {


### PR DESCRIPTION
  - For AWS migration in staging, we switch around the asset handling
    routes on the level of Fastly
    
    - The new default is AWS, holding the frontends, which special cases of
    the asset-manager and whitehall-frontend still remaining in Carrenza