### PR TITLE
route whitehall assets via assets load balancer

### DIFF
--- a/spec/test-outputs/assets-integration.out.vcl
+++ b/spec/test-outputs/assets-integration.out.vcl
@@ -61,37 +61,6 @@ backend F_aws_origin {
       }
 }
 
-backend F_whitehall_origin {
-    .connect_timeout = 5s;
-    .dynamic = true;
-    .port = "443";
-    .host = "foo";
-    .first_byte_timeout = 15s;
-    .max_connections = 200;
-    .between_bytes_timeout = 10s;
-    .share_key = "123";
-
-    .ssl = true;
-    .ssl_check_cert = always;
-    .min_tls_version = "1.2";
-    .ssl_cert_hostname = "foo";
-    .ssl_sni_hostname = "foo";
-
-    .probe = {
-        .request =
-            "HEAD /__canary__ HTTP/1.1"
-            "Host: whitehall-frontend.production.govuk.digital"
-            "User-Agent: Fastly healthcheck (git version: )"
-
-            "Connection: close";
-        .threshold = 1;
-        .window = 2;
-        .timeout = 5s;
-        .initial = 1;
-        .expected_response = 200;
-        .interval = 10s;
-      }
-}
 # Mirror backend for provider 0
 backend F_mirror1 {
     .connect_timeout = 1s;
@@ -217,11 +186,14 @@ sub vcl_recv {
   set req.http.host = "assets.publishing.service.gov.uk";
 
 
-  if (req.url ~ "^/asset-manager\?" || req.url ~ "^/government/uploads\?" || req.url ~ "^/media\?") {
+  if (req.url ~ "^/asset-manager\?" ||
+      req.url ~ "^/government/uploads\?" ||
+      req.url ~ "^/media\?" ||
+      req.url ~ "^/government/assets\?" ||
+      req.url ~ "^/government/placeholder\?" ||
+      req.url ~ "^/government/uploads/system/uploads/attachment_data/file/[0-9]+/.*/preview\?"
+      ) {
     set req.backend = F_origin;
-  }
-  if (req.url ~ "^/government/assets\?" || req.url ~ "^/government/placeholder\?" || req.url ~ "^/government/uploads/system/uploads/attachment_data/file/[0-9]+/.*/preview\?") {
-    set req.backend = F_whitehall_origin;
   }
 
   # Serve stale if it exists.

--- a/spec/test-outputs/assets-production.out.vcl
+++ b/spec/test-outputs/assets-production.out.vcl
@@ -61,37 +61,6 @@ backend F_aws_origin {
       }
 }
 
-backend F_whitehall_origin {
-    .connect_timeout = 5s;
-    .dynamic = true;
-    .port = "443";
-    .host = "foo";
-    .first_byte_timeout = 15s;
-    .max_connections = 200;
-    .between_bytes_timeout = 10s;
-    .share_key = "123";
-
-    .ssl = true;
-    .ssl_check_cert = always;
-    .min_tls_version = "1.2";
-    .ssl_cert_hostname = "foo";
-    .ssl_sni_hostname = "foo";
-
-    .probe = {
-        .request =
-            "HEAD /__canary__ HTTP/1.1"
-            "Host: foo"
-            "User-Agent: Fastly healthcheck (git version: )"
-
-            "Connection: close";
-        .threshold = 1;
-        .window = 2;
-        .timeout = 5s;
-        .initial = 1;
-        .expected_response = 200;
-        .interval = 10s;
-      }
-}
 # Mirror backend for provider 0
 backend F_mirror1 {
     .connect_timeout = 1s;
@@ -216,11 +185,14 @@ sub vcl_recv {
   set req.http.Fastly-Backend-Name = "origin";
 
 
-  if (req.url ~ "^/asset-manager\?" || req.url ~ "^/government/uploads\?" || req.url ~ "^/media\?") {
+  if (req.url ~ "^/asset-manager\?" ||
+      req.url ~ "^/government/uploads\?" ||
+      req.url ~ "^/media\?" ||
+      req.url ~ "^/government/assets\?" ||
+      req.url ~ "^/government/placeholder\?" ||
+      req.url ~ "^/government/uploads/system/uploads/attachment_data/file/[0-9]+/.*/preview\?"
+      ) {
     set req.backend = F_origin;
-  }
-  if (req.url ~ "^/government/assets\?" || req.url ~ "^/government/placeholder\?" || req.url ~ "^/government/uploads/system/uploads/attachment_data/file/[0-9]+/.*/preview\?") {
-    set req.backend = F_whitehall_origin;
   }
 
   # Serve stale if it exists.

--- a/spec/test-outputs/assets-staging.out.vcl
+++ b/spec/test-outputs/assets-staging.out.vcl
@@ -61,37 +61,6 @@ backend F_aws_origin {
       }
 }
 
-backend F_whitehall_origin {
-    .connect_timeout = 5s;
-    .dynamic = true;
-    .port = "443";
-    .host = "foo";
-    .first_byte_timeout = 15s;
-    .max_connections = 200;
-    .between_bytes_timeout = 10s;
-    .share_key = "123";
-
-    .ssl = true;
-    .ssl_check_cert = always;
-    .min_tls_version = "1.2";
-    .ssl_cert_hostname = "foo";
-    .ssl_sni_hostname = "foo";
-
-    .probe = {
-        .request =
-            "HEAD /__canary__ HTTP/1.1"
-            "Host: whitehall-frontend.production.govuk.digital"
-            "User-Agent: Fastly healthcheck (git version: )"
-
-            "Connection: close";
-        .threshold = 1;
-        .window = 2;
-        .timeout = 5s;
-        .initial = 1;
-        .expected_response = 200;
-        .interval = 10s;
-      }
-}
 # Mirror backend for provider 0
 backend F_mirror1 {
     .connect_timeout = 1s;
@@ -219,11 +188,14 @@ sub vcl_recv {
   set req.http.host = "assets.publishing.service.gov.uk";
 
 
-  if (req.url ~ "^/asset-manager\?" || req.url ~ "^/government/uploads\?" || req.url ~ "^/media\?") {
+  if (req.url ~ "^/asset-manager\?" ||
+      req.url ~ "^/government/uploads\?" ||
+      req.url ~ "^/media\?" ||
+      req.url ~ "^/government/assets\?" ||
+      req.url ~ "^/government/placeholder\?" ||
+      req.url ~ "^/government/uploads/system/uploads/attachment_data/file/[0-9]+/.*/preview\?"
+      ) {
     set req.backend = F_origin;
-  }
-  if (req.url ~ "^/government/assets\?" || req.url ~ "^/government/placeholder\?" || req.url ~ "^/government/uploads/system/uploads/attachment_data/file/[0-9]+/.*/preview\?") {
-    set req.backend = F_whitehall_origin;
   }
 
   # Serve stale if it exists.

--- a/vcl_templates/assets.vcl.erb
+++ b/vcl_templates/assets.vcl.erb
@@ -71,42 +71,6 @@ backend F_aws_origin {
       }
 }
 
-backend F_whitehall_origin {
-    .connect_timeout = 5s;
-    .dynamic = true;
-    .port = "<%= config.fetch('whitehall_origin_port', '443') %>";
-    .host = "<%= config.fetch('whitehall_origin_hostname') %>";
-    .first_byte_timeout = 15s;
-    .max_connections = 200;
-    .between_bytes_timeout = 10s;
-    .share_key = "<%= config.fetch('service_id') %>";
-
-    .ssl = true;
-    .ssl_check_cert = <%= config['disable_tls_validation'] ? 'never' : 'always' %>;
-    .min_tls_version = "<%= config.fetch('min_tls_version', '1.2') %>";
-    <%- if config['ssl_ciphers'] -%>
-    .ssl_ciphers = "<%= config['ssl_ciphers'] -%>";
-    <%- end -%>
-    .ssl_cert_hostname = "<%= config.fetch('whitehall_ssl_cert_hostname', config.fetch('whitehall_origin_hostname')) %>";
-    .ssl_sni_hostname = "<%= config.fetch('whitehall_ssl_sni_hostname', config.fetch('whitehall_origin_hostname')) %>";
-
-    .probe = {
-        .request =
-            "HEAD /__canary__ HTTP/1.1"
-            "Host: <%= environment == 'staging' || environment == 'integration' ? 'whitehall-frontend.production.govuk.digital' : config.fetch('whitehall_origin_hostname') %>"
-            "User-Agent: Fastly healthcheck (git version: <%= config['git_version'] %>)"
-<% if config['rate_limit_token'] %>
-            "Rate-Limit-Token: <%= config['rate_limit_token'] %>"
-<% end %>
-            "Connection: close";
-        .threshold = 1;
-        .window = 2;
-        .timeout = 5s;
-        .initial = 1;
-        .expected_response = 200;
-        .interval = 10s;
-      }
-}
 # Mirror backend for provider 0
 backend F_mirror1 {
     .connect_timeout = 1s;
@@ -242,11 +206,14 @@ sub vcl_recv {
   set req.http.host = "assets.publishing.service.gov.uk";
 <% end %>
 
-  if (req.url ~ "^/asset-manager\?" || req.url ~ "^/government/uploads\?" || req.url ~ "^/media\?") {
+  if (req.url ~ "^/asset-manager\?" ||
+      req.url ~ "^/government/uploads\?" ||
+      req.url ~ "^/media\?" ||
+      req.url ~ "^/government/assets\?" ||
+      req.url ~ "^/government/placeholder\?" ||
+      req.url ~ "^/government/uploads/system/uploads/attachment_data/file/[0-9]+/.*/preview\?"
+      ) {
     set req.backend = F_origin;
-  }
-  if (req.url ~ "^/government/assets\?" || req.url ~ "^/government/placeholder\?" || req.url ~ "^/government/uploads/system/uploads/attachment_data/file/[0-9]+/.*/preview\?") {
-    set req.backend = F_whitehall_origin;
   }
 
   # Serve stale if it exists.


### PR DESCRIPTION
# Context

As part of the AWS migration of the frontends where the asset manager and whitehall frontend are left in Carrenza, there is a need to configure fastly to route any common and whitehall assets to the Carrenza load balancer which was setup to handle assets as part of the AWS migration. This change will allow us to use one less CDN backend and not exceed the 5 CDN backend limit that fastly has.

# Decisions
1. Change the `if` statement to route all common and whitehall assets to the Carrenza Assets load balancer.
2. delete the whitehall CDN backend. 