### PR TITLE
Add logic to re-route asset traffic

### DIFF
--- a/spec/test-outputs/assets-integration.out.vcl
+++ b/spec/test-outputs/assets-integration.out.vcl
@@ -1,4 +1,4 @@
-backend F_origin {
+backend F_carrenzaorigin {
     .connect_timeout = 5s;
     .dynamic = true;
     .port = "443";
@@ -17,7 +17,7 @@ backend F_origin {
     .probe = {
         .request =
             "HEAD /__canary__ HTTP/1.1"
-            "Host: assets.publishing.service.gov.uk"
+            "Host: foo"
             "User-Agent: Fastly healthcheck (git version: )"
 
             "Connection: close";
@@ -29,7 +29,7 @@ backend F_origin {
         .interval = 10s;
       }
 }
-backend F_aws_origin {
+backend F_awsorigin {
     .connect_timeout = 5s;
     .dynamic = true;
     .port = "443";
@@ -48,7 +48,7 @@ backend F_aws_origin {
     .probe = {
         .request =
             "HEAD /__canary__ HTTP/1.1"
-            "Host: assets.production.govuk.digital"
+            "Host: foo"
             "User-Agent: Fastly healthcheck (git version: )"
 
             "Connection: close";
@@ -179,21 +179,19 @@ sub vcl_recv {
   set req.grace = 24h;
 
   # Default backend.
-  set req.backend = F_aws_origin;
-  set req.http.Fastly-Backend-Name = "origin";
+  set req.backend = F_awsorigin;
+  set req.http.Fastly-Backend-Name = "awsorigin";
+  set req.http.host = "foo";
 
-  # Force host header for staging and integration.
-  set req.http.host = "assets.publishing.service.gov.uk";
-
-
-  if (req.url ~ "^/asset-manager\?" ||
-      req.url ~ "^/government/uploads\?" ||
-      req.url ~ "^/media\?" ||
-      req.url ~ "^/government/assets\?" ||
-      req.url ~ "^/government/placeholder\?" ||
-      req.url ~ "^/government/uploads/system/uploads/attachment_data/file/[0-9]+/.*/preview\?"
+  if (req.url ~ "^/asset-manager" ||
+      req.url ~ "^/government/uploads" ||
+      req.url ~ "^/media" ||
+      req.url ~ "^/government/assets" ||
+      req.url ~ "^/government/placeholder"
       ) {
-    set req.backend = F_origin;
+      set req.backend = F_carrenzaorigin;
+      set req.http.Fastly-Backend-Name = "carrenzaorigin";
+      set req.http.host = "foo";
   }
 
   # Serve stale if it exists.

--- a/spec/test-outputs/assets-production.out.vcl
+++ b/spec/test-outputs/assets-production.out.vcl
@@ -1,4 +1,4 @@
-backend F_origin {
+backend F_carrenzaorigin {
     .connect_timeout = 5s;
     .dynamic = true;
     .port = "443";
@@ -29,7 +29,7 @@ backend F_origin {
         .interval = 10s;
       }
 }
-backend F_aws_origin {
+backend F_awsorigin {
     .connect_timeout = 5s;
     .dynamic = true;
     .port = "443";
@@ -181,18 +181,19 @@ sub vcl_recv {
   set req.grace = 24h;
 
   # Default backend.
-  set req.backend = F_aws_origin;
-  set req.http.Fastly-Backend-Name = "origin";
+  set req.backend = F_awsorigin;
+  set req.http.Fastly-Backend-Name = "awsorigin";
+  set req.http.host = "foo";
 
-
-  if (req.url ~ "^/asset-manager\?" ||
-      req.url ~ "^/government/uploads\?" ||
-      req.url ~ "^/media\?" ||
-      req.url ~ "^/government/assets\?" ||
-      req.url ~ "^/government/placeholder\?" ||
-      req.url ~ "^/government/uploads/system/uploads/attachment_data/file/[0-9]+/.*/preview\?"
+  if (req.url ~ "^/asset-manager" ||
+      req.url ~ "^/government/uploads" ||
+      req.url ~ "^/media" ||
+      req.url ~ "^/government/assets" ||
+      req.url ~ "^/government/placeholder"
       ) {
-    set req.backend = F_origin;
+      set req.backend = F_carrenzaorigin;
+      set req.http.Fastly-Backend-Name = "carrenzaorigin";
+      set req.http.host = "foo";
   }
 
   # Serve stale if it exists.

--- a/spec/test-outputs/assets-staging.out.vcl
+++ b/spec/test-outputs/assets-staging.out.vcl
@@ -1,4 +1,4 @@
-backend F_origin {
+backend F_carrenzaorigin {
     .connect_timeout = 5s;
     .dynamic = true;
     .port = "443";
@@ -17,7 +17,7 @@ backend F_origin {
     .probe = {
         .request =
             "HEAD /__canary__ HTTP/1.1"
-            "Host: assets.publishing.service.gov.uk"
+            "Host: foo"
             "User-Agent: Fastly healthcheck (git version: )"
 
             "Connection: close";
@@ -29,7 +29,7 @@ backend F_origin {
         .interval = 10s;
       }
 }
-backend F_aws_origin {
+backend F_awsorigin {
     .connect_timeout = 5s;
     .dynamic = true;
     .port = "443";
@@ -48,7 +48,7 @@ backend F_aws_origin {
     .probe = {
         .request =
             "HEAD /__canary__ HTTP/1.1"
-            "Host: assets.production.govuk.digital"
+            "Host: foo"
             "User-Agent: Fastly healthcheck (git version: )"
 
             "Connection: close";
@@ -181,21 +181,19 @@ sub vcl_recv {
   set req.grace = 24h;
 
   # Default backend.
-  set req.backend = F_aws_origin;
-  set req.http.Fastly-Backend-Name = "origin";
+  set req.backend = F_awsorigin;
+  set req.http.Fastly-Backend-Name = "awsorigin";
+  set req.http.host = "foo";
 
-  # Force host header for staging and integration.
-  set req.http.host = "assets.publishing.service.gov.uk";
-
-
-  if (req.url ~ "^/asset-manager\?" ||
-      req.url ~ "^/government/uploads\?" ||
-      req.url ~ "^/media\?" ||
-      req.url ~ "^/government/assets\?" ||
-      req.url ~ "^/government/placeholder\?" ||
-      req.url ~ "^/government/uploads/system/uploads/attachment_data/file/[0-9]+/.*/preview\?"
+  if (req.url ~ "^/asset-manager" ||
+      req.url ~ "^/government/uploads" ||
+      req.url ~ "^/media" ||
+      req.url ~ "^/government/assets" ||
+      req.url ~ "^/government/placeholder"
       ) {
-    set req.backend = F_origin;
+      set req.backend = F_carrenzaorigin;
+      set req.http.Fastly-Backend-Name = "carrenzaorigin";
+      set req.http.host = "foo";
   }
 
   # Serve stale if it exists.

--- a/spec/vcl_generation_spec.rb
+++ b/spec/vcl_generation_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "VCL generation" do
   config = {
     "origin_hostname" => "foo",
     "aws_origin_hostname" => "foo",
-    "whitehall_origin_hostname" => "foo",
+    "carrenza_origin_hostname" => "foo",
     "service_id" => "123",
     "provider1_mirror_hostname" => "foo",
     "s3_mirror_hostname" => "bar",

--- a/vcl_templates/assets.vcl.erb
+++ b/vcl_templates/assets.vcl.erb
@@ -1,8 +1,8 @@
-backend F_origin {
+backend F_carrenzaorigin {
     .connect_timeout = 5s;
     .dynamic = true;
-    .port = "<%= config.fetch('origin_port', '443') %>";
-    .host = "<%= config.fetch('origin_hostname') %>";
+    .port = "<%= config.fetch('carrenza_origin_port', '443') %>";
+    .host = "<%= config.fetch('carrenza_origin_hostname') %>";
     .first_byte_timeout = 15s;
     .max_connections = 200;
     .between_bytes_timeout = 10s;
@@ -14,13 +14,13 @@ backend F_origin {
     <%- if config['ssl_ciphers'] -%>
     .ssl_ciphers = "<%= config['ssl_ciphers'] -%>";
     <%- end -%>
-    .ssl_cert_hostname = "<%= config.fetch('ssl_cert_hostname', config.fetch('origin_hostname')) %>";
-    .ssl_sni_hostname = "<%= config.fetch('ssl_sni_hostname', config.fetch('origin_hostname')) %>";
+    .ssl_cert_hostname = "<%= config.fetch('ssl_cert_hostname', config.fetch('carrenza_origin_hostname')) %>";
+    .ssl_sni_hostname = "<%= config.fetch('ssl_sni_hostname', config.fetch('carrenza_origin_hostname')) %>";
 
     .probe = {
         .request =
             "HEAD /__canary__ HTTP/1.1"
-            "Host: <%= environment == 'staging' || environment == 'integration' ? 'assets.publishing.service.gov.uk' : config.fetch('origin_hostname') %>"
+            "Host: <%= config.fetch('carrenza_origin_hostname') %>"
             "User-Agent: Fastly healthcheck (git version: <%= config['git_version'] %>)"
 <% if config['rate_limit_token'] %>
             "Rate-Limit-Token: <%= config['rate_limit_token'] %>"
@@ -34,7 +34,7 @@ backend F_origin {
         .interval = 10s;
       }
 }
-backend F_aws_origin {
+backend F_awsorigin {
     .connect_timeout = 5s;
     .dynamic = true;
     .port = "<%= config.fetch('aws_origin_port', '443') %>";
@@ -56,7 +56,7 @@ backend F_aws_origin {
     .probe = {
         .request =
             "HEAD /__canary__ HTTP/1.1"
-            "Host: <%= environment == 'staging' || environment == 'integration' ? 'assets.production.govuk.digital' : config.fetch('aws_origin_hostname') %>"
+            "Host: <%= config.fetch('aws_origin_hostname') %>"
             "User-Agent: Fastly healthcheck (git version: <%= config['git_version'] %>)"
 <% if config['rate_limit_token'] %>
             "Rate-Limit-Token: <%= config['rate_limit_token'] %>"
@@ -199,21 +199,19 @@ sub vcl_recv {
   set req.grace = 24h;
 
   # Default backend.
-  set req.backend = F_aws_origin;
-  set req.http.Fastly-Backend-Name = "origin";
-<% if environment == 'staging' || environment == 'integration' %>
-  # Force host header for staging and integration.
-  set req.http.host = "assets.publishing.service.gov.uk";
-<% end %>
+  set req.backend = F_awsorigin;
+  set req.http.Fastly-Backend-Name = "awsorigin";
+  set req.http.host = "<%= config.fetch('aws_origin_hostname') %>";
 
-  if (req.url ~ "^/asset-manager\?" ||
-      req.url ~ "^/government/uploads\?" ||
-      req.url ~ "^/media\?" ||
-      req.url ~ "^/government/assets\?" ||
-      req.url ~ "^/government/placeholder\?" ||
-      req.url ~ "^/government/uploads/system/uploads/attachment_data/file/[0-9]+/.*/preview\?"
+  if (req.url ~ "^/asset-manager" ||
+      req.url ~ "^/government/uploads" ||
+      req.url ~ "^/media" ||
+      req.url ~ "^/government/assets" ||
+      req.url ~ "^/government/placeholder"
       ) {
-    set req.backend = F_origin;
+      set req.backend = F_carrenzaorigin;
+      set req.http.Fastly-Backend-Name = "carrenzaorigin";
+      set req.http.host = "<%= config.fetch('carrenza_origin_hostname') %>";
   }
 
   # Serve stale if it exists.


### PR DESCRIPTION
[DO NOT MERGE]: While this is safe to merge, deployment would break Fastly ATM - so keep it out of the loop for now.

- During the migration the asset-manager and whitehall assets remains in Carrenza
environments close to Publishing-API and Whitehall, whereas frontends
are located in AWS.
- Assets are served both from asset-manager and frontends, so we need to
separate the traffic for Carrenza and AWS
- We have decided to put the logic to do this into Fastly.
- We filter assets paths with regexp
- Carrenza-side this requires creation of a new nginx proxy
assets-carrenza in order to be able to turn off the cache boxes
post-migration

solo: @schmie