### PR TITLE
Disable related links AB1 test

### DIFF
--- a/configs/dictionaries/active_ab_tests.yaml
+++ b/configs/dictionaries/active_ab_tests.yaml
@@ -5,5 +5,5 @@
 ---
 Example: true
 RelatedLinksAATest: false
-RelatedLinksABTest1: true
+RelatedLinksABTest1: false
 ViewDrivingLicence: false


### PR DESCRIPTION
We now have the necessary data for this test, so we can disable it.