### PR TITLE
Set preload for Strict-Transport-Security header

### DIFF
--- a/spec/test-outputs/tldredirect-integration.out.vcl
+++ b/spec/test-outputs/tldredirect-integration.out.vcl
@@ -44,7 +44,7 @@ sub vcl_error {
     set obj.status = 301;
     set obj.response = "Moved Permanently";
     set obj.http.Location = "https://www.gov.uk" req.url;
-    set obj.http.Strict-Transport-Security = "max-age=63072000";
+    set obj.http.Strict-Transport-Security = "max-age=63072000; preload";
   }
 
   synthetic {""};

--- a/spec/test-outputs/tldredirect-production.out.vcl
+++ b/spec/test-outputs/tldredirect-production.out.vcl
@@ -44,7 +44,7 @@ sub vcl_error {
     set obj.status = 301;
     set obj.response = "Moved Permanently";
     set obj.http.Location = "https://www.gov.uk" req.url;
-    set obj.http.Strict-Transport-Security = "max-age=63072000";
+    set obj.http.Strict-Transport-Security = "max-age=63072000; preload";
   }
 
   synthetic {""};

--- a/spec/test-outputs/tldredirect-staging.out.vcl
+++ b/spec/test-outputs/tldredirect-staging.out.vcl
@@ -44,7 +44,7 @@ sub vcl_error {
     set obj.status = 301;
     set obj.response = "Moved Permanently";
     set obj.http.Location = "https://www.gov.uk" req.url;
-    set obj.http.Strict-Transport-Security = "max-age=63072000";
+    set obj.http.Strict-Transport-Security = "max-age=63072000; preload";
   }
 
   synthetic {""};

--- a/vcl_templates/tldredirect.vcl.erb
+++ b/vcl_templates/tldredirect.vcl.erb
@@ -44,7 +44,7 @@ sub vcl_error {
     set obj.status = 301;
     set obj.response = "Moved Permanently";
     set obj.http.Location = "https://www.gov.uk" req.url;
-    set obj.http.Strict-Transport-Security = "max-age=63072000";
+    set obj.http.Strict-Transport-Security = "max-age=63072000; preload";
   }
 
   synthetic {""};


### PR DESCRIPTION
This commit sets the `preload` flag for the `Strict-Transport-Security` HTTP header. This signals to browsers that the domain should be added to the HSTS preload list that is shipped with most modern browsers.