### PR TITLE
Disable related links AB2 test

### DIFF
--- a/configs/dictionaries/active_ab_tests.yaml
+++ b/configs/dictionaries/active_ab_tests.yaml
@@ -6,5 +6,5 @@
 Example: true
 RelatedLinksAATest: false
 RelatedLinksABTest1: false
-RelatedLinksABTest2: true
+RelatedLinksABTest2: false
 ViewDrivingLicence: false


### PR DESCRIPTION
We have now collected the necessary data for this test, so it can be disabled.