### PR TITLE
Add AWS NAT Gateway Elastic IPs to purge whitelist

### DIFF
--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -107,6 +107,9 @@ acl purge_ip_whitelist {
   "31.210.241.100";   # Carrenza mirrors
 
   "31.210.245.86";    # Carrenza Production
+  "34.246.209.74";    # AWS NAT GW1
+  "34.253.57.8";      # AWS NAT GW2
+  "18.202.136.43";    # AWS NAT GW3
 
   "23.235.32.0"/20;   # Fastly cache node
   "43.249.72.0"/22;   # Fastly cache node

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -107,6 +107,9 @@ acl purge_ip_whitelist {
   "31.210.241.100";   # Carrenza mirrors
 
   "31.210.245.70";    # Carrenza Staging
+  "18.202.183.143";   # AWS NAT GW1
+  "18.203.90.80";     # AWS NAT GW2
+  "18.203.108.248";   # AWS NAT GW3
 
   "23.235.32.0"/20;   # Fastly cache node
   "43.249.72.0"/22;   # Fastly cache node

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -122,8 +122,14 @@ acl purge_ip_whitelist {
   "31.210.241.100";   # Carrenza mirrors
 <% if environment == 'staging' %>
   "31.210.245.70";    # Carrenza Staging
+  "18.202.183.143";   # AWS NAT GW1
+  "18.203.90.80";     # AWS NAT GW2
+  "18.203.108.248";   # AWS NAT GW3
 <% elsif environment == 'production' %>
   "31.210.245.86";    # Carrenza Production
+  "34.246.209.74";    # AWS NAT GW1
+  "34.253.57.8";      # AWS NAT GW2
+  "18.202.136.43";    # AWS NAT GW3
 <% end %>
   "23.235.32.0"/20;   # Fastly cache node
   "43.249.72.0"/22;   # Fastly cache node


### PR DESCRIPTION
After migration of the cache clearing service, we do require the
backends in AWS to be able to purge entries in Fastly cache

solo: @schmie