### PR TITLE
Disable related links AB3 test

### DIFF
--- a/configs/dictionaries/active_ab_tests.yaml
+++ b/configs/dictionaries/active_ab_tests.yaml
@@ -7,5 +7,5 @@ Example: true
 RelatedLinksAATest: false
 RelatedLinksABTest1: false
 RelatedLinksABTest2: false
-RelatedLinksABTest3: true
+RelatedLinksABTest3: false
 ViewDrivingLicence: false


### PR DESCRIPTION
We have now collected the necessary data for this test, so it can be disabled.