### PR TITLE
Set ABTest cookies to secure

### DIFF
--- a/spec/test-outputs/www-integration.out.vcl
+++ b/spec/test-outputs/www-integration.out.vcl
@@ -588,7 +588,7 @@ sub vcl_deliver {
     && req.http.User-Agent !~ "^GOV\.UK Crawler Worker"
     && req.http.Cookie !~ "ABTest-Example") {
     # Set a fairly short cookie expiry because this is just an A/B test demo.
-    add resp.http.Set-Cookie = "ABTest-Example=" req.http.GOVUK-ABTest-Example "; expires=" now + 1d;
+    add resp.http.Set-Cookie = "ABTest-Example=" req.http.GOVUK-ABTest-Example "; secure; expires=" now + 1d;
   }
 
   # Begin dynamic section
@@ -596,43 +596,43 @@ sub vcl_deliver {
   if (table.lookup(active_ab_tests, "ViewDrivingLicence") == "true") {
     if (req.http.Cookie !~ "ABTest-ViewDrivingLicence" || req.url ~ "[\?\&]ABTest-ViewDrivingLicence" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
       set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "ViewDrivingLicence"))));
-      add resp.http.Set-Cookie = "ABTest-ViewDrivingLicence=" req.http.GOVUK-ABTest-ViewDrivingLicence "; expires=" var.expiry "; path=/";
+      add resp.http.Set-Cookie = "ABTest-ViewDrivingLicence=" req.http.GOVUK-ABTest-ViewDrivingLicence "; secure; expires=" var.expiry "; path=/";
     }
   }
   if (table.lookup(active_ab_tests, "RelatedLinksAATest") == "true") {
     if (req.http.Cookie !~ "ABTest-RelatedLinksAATest" || req.url ~ "[\?\&]ABTest-RelatedLinksAATest" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
       set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "RelatedLinksAATest"))));
-      add resp.http.Set-Cookie = "ABTest-RelatedLinksAATest=" req.http.GOVUK-ABTest-RelatedLinksAATest "; expires=" var.expiry "; path=/";
+      add resp.http.Set-Cookie = "ABTest-RelatedLinksAATest=" req.http.GOVUK-ABTest-RelatedLinksAATest "; secure; expires=" var.expiry "; path=/";
     }
   }
   if (table.lookup(active_ab_tests, "RelatedLinksABTest1") == "true") {
     if (req.http.Cookie !~ "ABTest-RelatedLinksABTest1" || req.url ~ "[\?\&]ABTest-RelatedLinksABTest1" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
       set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "RelatedLinksABTest1"))));
-      add resp.http.Set-Cookie = "ABTest-RelatedLinksABTest1=" req.http.GOVUK-ABTest-RelatedLinksABTest1 "; expires=" var.expiry "; path=/";
+      add resp.http.Set-Cookie = "ABTest-RelatedLinksABTest1=" req.http.GOVUK-ABTest-RelatedLinksABTest1 "; secure; expires=" var.expiry "; path=/";
     }
   }
   if (table.lookup(active_ab_tests, "RelatedLinksABTest2") == "true") {
     if (req.http.Cookie !~ "ABTest-RelatedLinksABTest2" || req.url ~ "[\?\&]ABTest-RelatedLinksABTest2" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
       set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "RelatedLinksABTest2"))));
-      add resp.http.Set-Cookie = "ABTest-RelatedLinksABTest2=" req.http.GOVUK-ABTest-RelatedLinksABTest2 "; expires=" var.expiry "; path=/";
+      add resp.http.Set-Cookie = "ABTest-RelatedLinksABTest2=" req.http.GOVUK-ABTest-RelatedLinksABTest2 "; secure; expires=" var.expiry "; path=/";
     }
   }
   if (table.lookup(active_ab_tests, "RelatedLinksABTest3") == "true") {
     if (req.http.Cookie !~ "ABTest-RelatedLinksABTest3" || req.url ~ "[\?\&]ABTest-RelatedLinksABTest3" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
       set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "RelatedLinksABTest3"))));
-      add resp.http.Set-Cookie = "ABTest-RelatedLinksABTest3=" req.http.GOVUK-ABTest-RelatedLinksABTest3 "; expires=" var.expiry "; path=/";
+      add resp.http.Set-Cookie = "ABTest-RelatedLinksABTest3=" req.http.GOVUK-ABTest-RelatedLinksABTest3 "; secure; expires=" var.expiry "; path=/";
     }
   }
   if (table.lookup(active_ab_tests, "RelatedLinksABTest4") == "true") {
     if (req.http.Cookie !~ "ABTest-RelatedLinksABTest4" || req.url ~ "[\?\&]ABTest-RelatedLinksABTest4" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
       set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "RelatedLinksABTest4"))));
-      add resp.http.Set-Cookie = "ABTest-RelatedLinksABTest4=" req.http.GOVUK-ABTest-RelatedLinksABTest4 "; expires=" var.expiry "; path=/";
+      add resp.http.Set-Cookie = "ABTest-RelatedLinksABTest4=" req.http.GOVUK-ABTest-RelatedLinksABTest4 "; secure; expires=" var.expiry "; path=/";
     }
   }
   if (table.lookup(active_ab_tests, "FinderAnswerABTest") == "true") {
     if (req.http.Cookie !~ "ABTest-FinderAnswerABTest" || req.url ~ "[\?\&]ABTest-FinderAnswerABTest" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
       set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "FinderAnswerABTest"))));
-      add resp.http.Set-Cookie = "ABTest-FinderAnswerABTest=" req.http.GOVUK-ABTest-FinderAnswerABTest "; expires=" var.expiry "; path=/";
+      add resp.http.Set-Cookie = "ABTest-FinderAnswerABTest=" req.http.GOVUK-ABTest-FinderAnswerABTest "; secure; expires=" var.expiry "; path=/";
     }
   }
   # End dynamic section

--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -593,7 +593,7 @@ sub vcl_deliver {
     && req.http.User-Agent !~ "^GOV\.UK Crawler Worker"
     && req.http.Cookie !~ "ABTest-Example") {
     # Set a fairly short cookie expiry because this is just an A/B test demo.
-    add resp.http.Set-Cookie = "ABTest-Example=" req.http.GOVUK-ABTest-Example "; expires=" now + 1d;
+    add resp.http.Set-Cookie = "ABTest-Example=" req.http.GOVUK-ABTest-Example "; secure; expires=" now + 1d;
   }
 
   # Begin dynamic section
@@ -601,43 +601,43 @@ sub vcl_deliver {
   if (table.lookup(active_ab_tests, "ViewDrivingLicence") == "true") {
     if (req.http.Cookie !~ "ABTest-ViewDrivingLicence" || req.url ~ "[\?\&]ABTest-ViewDrivingLicence" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
       set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "ViewDrivingLicence"))));
-      add resp.http.Set-Cookie = "ABTest-ViewDrivingLicence=" req.http.GOVUK-ABTest-ViewDrivingLicence "; expires=" var.expiry "; path=/";
+      add resp.http.Set-Cookie = "ABTest-ViewDrivingLicence=" req.http.GOVUK-ABTest-ViewDrivingLicence "; secure; expires=" var.expiry "; path=/";
     }
   }
   if (table.lookup(active_ab_tests, "RelatedLinksAATest") == "true") {
     if (req.http.Cookie !~ "ABTest-RelatedLinksAATest" || req.url ~ "[\?\&]ABTest-RelatedLinksAATest" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
       set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "RelatedLinksAATest"))));
-      add resp.http.Set-Cookie = "ABTest-RelatedLinksAATest=" req.http.GOVUK-ABTest-RelatedLinksAATest "; expires=" var.expiry "; path=/";
+      add resp.http.Set-Cookie = "ABTest-RelatedLinksAATest=" req.http.GOVUK-ABTest-RelatedLinksAATest "; secure; expires=" var.expiry "; path=/";
     }
   }
   if (table.lookup(active_ab_tests, "RelatedLinksABTest1") == "true") {
     if (req.http.Cookie !~ "ABTest-RelatedLinksABTest1" || req.url ~ "[\?\&]ABTest-RelatedLinksABTest1" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
       set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "RelatedLinksABTest1"))));
-      add resp.http.Set-Cookie = "ABTest-RelatedLinksABTest1=" req.http.GOVUK-ABTest-RelatedLinksABTest1 "; expires=" var.expiry "; path=/";
+      add resp.http.Set-Cookie = "ABTest-RelatedLinksABTest1=" req.http.GOVUK-ABTest-RelatedLinksABTest1 "; secure; expires=" var.expiry "; path=/";
     }
   }
   if (table.lookup(active_ab_tests, "RelatedLinksABTest2") == "true") {
     if (req.http.Cookie !~ "ABTest-RelatedLinksABTest2" || req.url ~ "[\?\&]ABTest-RelatedLinksABTest2" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
       set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "RelatedLinksABTest2"))));
-      add resp.http.Set-Cookie = "ABTest-RelatedLinksABTest2=" req.http.GOVUK-ABTest-RelatedLinksABTest2 "; expires=" var.expiry "; path=/";
+      add resp.http.Set-Cookie = "ABTest-RelatedLinksABTest2=" req.http.GOVUK-ABTest-RelatedLinksABTest2 "; secure; expires=" var.expiry "; path=/";
     }
   }
   if (table.lookup(active_ab_tests, "RelatedLinksABTest3") == "true") {
     if (req.http.Cookie !~ "ABTest-RelatedLinksABTest3" || req.url ~ "[\?\&]ABTest-RelatedLinksABTest3" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
       set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "RelatedLinksABTest3"))));
-      add resp.http.Set-Cookie = "ABTest-RelatedLinksABTest3=" req.http.GOVUK-ABTest-RelatedLinksABTest3 "; expires=" var.expiry "; path=/";
+      add resp.http.Set-Cookie = "ABTest-RelatedLinksABTest3=" req.http.GOVUK-ABTest-RelatedLinksABTest3 "; secure; expires=" var.expiry "; path=/";
     }
   }
   if (table.lookup(active_ab_tests, "RelatedLinksABTest4") == "true") {
     if (req.http.Cookie !~ "ABTest-RelatedLinksABTest4" || req.url ~ "[\?\&]ABTest-RelatedLinksABTest4" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
       set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "RelatedLinksABTest4"))));
-      add resp.http.Set-Cookie = "ABTest-RelatedLinksABTest4=" req.http.GOVUK-ABTest-RelatedLinksABTest4 "; expires=" var.expiry "; path=/";
+      add resp.http.Set-Cookie = "ABTest-RelatedLinksABTest4=" req.http.GOVUK-ABTest-RelatedLinksABTest4 "; secure; expires=" var.expiry "; path=/";
     }
   }
   if (table.lookup(active_ab_tests, "FinderAnswerABTest") == "true") {
     if (req.http.Cookie !~ "ABTest-FinderAnswerABTest" || req.url ~ "[\?\&]ABTest-FinderAnswerABTest" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
       set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "FinderAnswerABTest"))));
-      add resp.http.Set-Cookie = "ABTest-FinderAnswerABTest=" req.http.GOVUK-ABTest-FinderAnswerABTest "; expires=" var.expiry "; path=/";
+      add resp.http.Set-Cookie = "ABTest-FinderAnswerABTest=" req.http.GOVUK-ABTest-FinderAnswerABTest "; secure; expires=" var.expiry "; path=/";
     }
   }
   # End dynamic section

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -602,7 +602,7 @@ sub vcl_deliver {
     && req.http.User-Agent !~ "^GOV\.UK Crawler Worker"
     && req.http.Cookie !~ "ABTest-Example") {
     # Set a fairly short cookie expiry because this is just an A/B test demo.
-    add resp.http.Set-Cookie = "ABTest-Example=" req.http.GOVUK-ABTest-Example "; expires=" now + 1d;
+    add resp.http.Set-Cookie = "ABTest-Example=" req.http.GOVUK-ABTest-Example "; secure; expires=" now + 1d;
   }
 
   # Begin dynamic section
@@ -610,43 +610,43 @@ sub vcl_deliver {
   if (table.lookup(active_ab_tests, "ViewDrivingLicence") == "true") {
     if (req.http.Cookie !~ "ABTest-ViewDrivingLicence" || req.url ~ "[\?\&]ABTest-ViewDrivingLicence" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
       set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "ViewDrivingLicence"))));
-      add resp.http.Set-Cookie = "ABTest-ViewDrivingLicence=" req.http.GOVUK-ABTest-ViewDrivingLicence "; expires=" var.expiry "; path=/";
+      add resp.http.Set-Cookie = "ABTest-ViewDrivingLicence=" req.http.GOVUK-ABTest-ViewDrivingLicence "; secure; expires=" var.expiry "; path=/";
     }
   }
   if (table.lookup(active_ab_tests, "RelatedLinksAATest") == "true") {
     if (req.http.Cookie !~ "ABTest-RelatedLinksAATest" || req.url ~ "[\?\&]ABTest-RelatedLinksAATest" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
       set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "RelatedLinksAATest"))));
-      add resp.http.Set-Cookie = "ABTest-RelatedLinksAATest=" req.http.GOVUK-ABTest-RelatedLinksAATest "; expires=" var.expiry "; path=/";
+      add resp.http.Set-Cookie = "ABTest-RelatedLinksAATest=" req.http.GOVUK-ABTest-RelatedLinksAATest "; secure; expires=" var.expiry "; path=/";
     }
   }
   if (table.lookup(active_ab_tests, "RelatedLinksABTest1") == "true") {
     if (req.http.Cookie !~ "ABTest-RelatedLinksABTest1" || req.url ~ "[\?\&]ABTest-RelatedLinksABTest1" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
       set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "RelatedLinksABTest1"))));
-      add resp.http.Set-Cookie = "ABTest-RelatedLinksABTest1=" req.http.GOVUK-ABTest-RelatedLinksABTest1 "; expires=" var.expiry "; path=/";
+      add resp.http.Set-Cookie = "ABTest-RelatedLinksABTest1=" req.http.GOVUK-ABTest-RelatedLinksABTest1 "; secure; expires=" var.expiry "; path=/";
     }
   }
   if (table.lookup(active_ab_tests, "RelatedLinksABTest2") == "true") {
     if (req.http.Cookie !~ "ABTest-RelatedLinksABTest2" || req.url ~ "[\?\&]ABTest-RelatedLinksABTest2" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
       set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "RelatedLinksABTest2"))));
-      add resp.http.Set-Cookie = "ABTest-RelatedLinksABTest2=" req.http.GOVUK-ABTest-RelatedLinksABTest2 "; expires=" var.expiry "; path=/";
+      add resp.http.Set-Cookie = "ABTest-RelatedLinksABTest2=" req.http.GOVUK-ABTest-RelatedLinksABTest2 "; secure; expires=" var.expiry "; path=/";
     }
   }
   if (table.lookup(active_ab_tests, "RelatedLinksABTest3") == "true") {
     if (req.http.Cookie !~ "ABTest-RelatedLinksABTest3" || req.url ~ "[\?\&]ABTest-RelatedLinksABTest3" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
       set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "RelatedLinksABTest3"))));
-      add resp.http.Set-Cookie = "ABTest-RelatedLinksABTest3=" req.http.GOVUK-ABTest-RelatedLinksABTest3 "; expires=" var.expiry "; path=/";
+      add resp.http.Set-Cookie = "ABTest-RelatedLinksABTest3=" req.http.GOVUK-ABTest-RelatedLinksABTest3 "; secure; expires=" var.expiry "; path=/";
     }
   }
   if (table.lookup(active_ab_tests, "RelatedLinksABTest4") == "true") {
     if (req.http.Cookie !~ "ABTest-RelatedLinksABTest4" || req.url ~ "[\?\&]ABTest-RelatedLinksABTest4" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
       set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "RelatedLinksABTest4"))));
-      add resp.http.Set-Cookie = "ABTest-RelatedLinksABTest4=" req.http.GOVUK-ABTest-RelatedLinksABTest4 "; expires=" var.expiry "; path=/";
+      add resp.http.Set-Cookie = "ABTest-RelatedLinksABTest4=" req.http.GOVUK-ABTest-RelatedLinksABTest4 "; secure; expires=" var.expiry "; path=/";
     }
   }
   if (table.lookup(active_ab_tests, "FinderAnswerABTest") == "true") {
     if (req.http.Cookie !~ "ABTest-FinderAnswerABTest" || req.url ~ "[\?\&]ABTest-FinderAnswerABTest" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
       set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "FinderAnswerABTest"))));
-      add resp.http.Set-Cookie = "ABTest-FinderAnswerABTest=" req.http.GOVUK-ABTest-FinderAnswerABTest "; expires=" var.expiry "; path=/";
+      add resp.http.Set-Cookie = "ABTest-FinderAnswerABTest=" req.http.GOVUK-ABTest-FinderAnswerABTest "; secure; expires=" var.expiry "; path=/";
     }
   }
   # End dynamic section

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -353,7 +353,7 @@ sub vcl_deliver {
     && req.http.User-Agent !~ "^GOV\.UK Crawler Worker"
     && req.http.Cookie !~ "ABTest-Example") {
     # Set a fairly short cookie expiry because this is just an A/B test demo.
-    add resp.http.Set-Cookie = "ABTest-Example=" req.http.GOVUK-ABTest-Example "; expires=" now + 1d;
+    add resp.http.Set-Cookie = "ABTest-Example=" req.http.GOVUK-ABTest-Example "; secure; expires=" now + 1d;
   }
 
   # Begin dynamic section
@@ -365,7 +365,7 @@ sub vcl_deliver {
   if (table.lookup(active_ab_tests, "<%= test %>") == "true") {
     if (req.http.Cookie !~ "ABTest-<%= test %>" || req.url ~ "[\?\&]ABTest-<%= test %>" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
       set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "<%= test %>"))));
-      add resp.http.Set-Cookie = "ABTest-<%= test %>=" req.http.GOVUK-ABTest-<%= test %> "; expires=" var.expiry "; path=/";
+      add resp.http.Set-Cookie = "ABTest-<%= test %>=" req.http.GOVUK-ABTest-<%= test %> "; secure; expires=" var.expiry "; path=/";
     }
   }
 <% end # unless -%>


### PR DESCRIPTION
All cookies on GOV.UK should be secure and not setting ABTest cookies as secure looks to have been an oversight when AB tests were added https://github.com/alphagov/govuk-cdn-config/pull/13