### PR TITLE
Disable Related Links v4 A/B test

### DIFF
--- a/configs/dictionaries/active_ab_tests.yaml
+++ b/configs/dictionaries/active_ab_tests.yaml
@@ -8,6 +8,6 @@ RelatedLinksAATest: false
 RelatedLinksABTest1: false
 RelatedLinksABTest2: false
 RelatedLinksABTest3: false
-RelatedLinksABTest4: true
+RelatedLinksABTest4: false
 ViewDrivingLicence: false
 FinderAnswerABTest: true


### PR DESCRIPTION
We have now collected the necessary data for this test, so it can be disabled.