### PR TITLE
Add AWS Elastic IPs to the purge_ip_whitelist for assets

### DIFF
--- a/spec/test-outputs/assets-production.out.vcl
+++ b/spec/test-outputs/assets-production.out.vcl
@@ -140,6 +140,9 @@ acl purge_ip_whitelist {
   "31.210.241.100";   # Carrenza mirrors
 
   "31.210.245.86";    # Carrenza Production
+  "18.202.136.43";    # AWS Production
+  "34.246.209.74";    # AWS Production
+  "34.253.57.8";      # AWS Production
 
   "23.235.32.0"/20;   # Fastly cache node
   "43.249.72.0"/22;   # Fastly cache node

--- a/spec/test-outputs/assets-staging.out.vcl
+++ b/spec/test-outputs/assets-staging.out.vcl
@@ -140,6 +140,9 @@ acl purge_ip_whitelist {
   "31.210.241.100";   # Carrenza mirrors
 
   "31.210.245.70";    # Carrenza Staging
+  "18.203.108.248";   # AWS Staging
+  "18.202.183.143";   # AWS Staging
+  "18.203.90.80";     # AWS Staging
 
   "23.235.32.0"/20;   # Fastly cache node
   "43.249.72.0"/22;   # Fastly cache node

--- a/vcl_templates/assets.vcl.erb
+++ b/vcl_templates/assets.vcl.erb
@@ -156,8 +156,14 @@ acl purge_ip_whitelist {
   "31.210.241.100";   # Carrenza mirrors
 <% if environment == 'staging' %>
   "31.210.245.70";    # Carrenza Staging
+  "18.203.108.248";   # AWS Staging
+  "18.202.183.143";   # AWS Staging
+  "18.203.90.80";     # AWS Staging
 <% elsif environment == 'production' %>
   "31.210.245.86";    # Carrenza Production
+  "18.202.136.43";    # AWS Production
+  "34.246.209.74";    # AWS Production
+  "34.253.57.8";      # AWS Production
 <% end %>
   "23.235.32.0"/20;   # Fastly cache node
   "43.249.72.0"/22;   # Fastly cache node


### PR DESCRIPTION
Context
Documentation suggests that a manual purge should be done from a cache machine
and this is not possible from AWS as the egress ips are not in the whitelist
(Doc Link: https://docs.publishing.service.gov.uk/manual/cache-flush.html)

Decision
Add the Elastic IPs used for cache in AWS to the VCL config.