### PR TITLE
Restore ability to purge URLs by Fastly web UI

### DIFF
--- a/spec/test-outputs/apt-integration.out.vcl
+++ b/spec/test-outputs/apt-integration.out.vcl
@@ -25,9 +25,9 @@ backend F_apt {
 sub vcl_recv {
 #FASTLY recv
 
-    # Prevent third parties from flushing CDN caches with FASTLYPURGE
+    # Require authentication for FASTLYPURGE requests
     if (req.request == "FASTLYPURGE") {
-      error 403 "Forbiddden";
+      set req.http.Fastly-Purge-Requires-Auth = "1";
     }
 
     # Unspoofable original client address

--- a/spec/test-outputs/apt-production.out.vcl
+++ b/spec/test-outputs/apt-production.out.vcl
@@ -25,9 +25,9 @@ backend F_apt {
 sub vcl_recv {
 #FASTLY recv
 
-    # Prevent third parties from flushing CDN caches with FASTLYPURGE
+    # Require authentication for FASTLYPURGE requests
     if (req.request == "FASTLYPURGE") {
-      error 403 "Forbiddden";
+      set req.http.Fastly-Purge-Requires-Auth = "1";
     }
 
     # Unspoofable original client address

--- a/spec/test-outputs/apt-staging.out.vcl
+++ b/spec/test-outputs/apt-staging.out.vcl
@@ -25,9 +25,9 @@ backend F_apt {
 sub vcl_recv {
 #FASTLY recv
 
-    # Prevent third parties from flushing CDN caches with FASTLYPURGE
+    # Require authentication for FASTLYPURGE requests
     if (req.request == "FASTLYPURGE") {
-      error 403 "Forbiddden";
+      set req.http.Fastly-Purge-Requires-Auth = "1";
     }
 
     # Unspoofable original client address

--- a/spec/test-outputs/assets-integration.out.vcl
+++ b/spec/test-outputs/assets-integration.out.vcl
@@ -157,9 +157,9 @@ acl purge_ip_whitelist {
 
 sub vcl_recv {
 
-  # Allow FASTLYPURGE from IPs defined in the ACL only, else return a HTTP 403
+  # Require authentication for FASTLYPURGE requests unless from IP in ACL
   if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_whitelist) {
-    error 403 "Forbidden";
+    set req.http.Fastly-Purge-Requires-Auth = "1";
   }
 
   # Force SSL.

--- a/spec/test-outputs/assets-production.out.vcl
+++ b/spec/test-outputs/assets-production.out.vcl
@@ -162,9 +162,9 @@ acl purge_ip_whitelist {
 
 sub vcl_recv {
 
-  # Allow FASTLYPURGE from IPs defined in the ACL only, else return a HTTP 403
+  # Require authentication for FASTLYPURGE requests unless from IP in ACL
   if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_whitelist) {
-    error 403 "Forbidden";
+    set req.http.Fastly-Purge-Requires-Auth = "1";
   }
 
   # Force SSL.

--- a/spec/test-outputs/assets-staging.out.vcl
+++ b/spec/test-outputs/assets-staging.out.vcl
@@ -162,9 +162,9 @@ acl purge_ip_whitelist {
 
 sub vcl_recv {
 
-  # Allow FASTLYPURGE from IPs defined in the ACL only, else return a HTTP 403
+  # Require authentication for FASTLYPURGE requests unless from IP in ACL
   if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_whitelist) {
-    error 403 "Forbidden";
+    set req.http.Fastly-Purge-Requires-Auth = "1";
   }
 
   # Force SSL.

--- a/spec/test-outputs/performanceplatform-integration.out.vcl
+++ b/spec/test-outputs/performanceplatform-integration.out.vcl
@@ -61,12 +61,9 @@ acl purge_ip_whitelist {
 
 sub vcl_recv {
 
-  # Allow FASTLYPURGE from IPs defined in the ACL only, else return a HTTP 403
-  if (req.request == "FASTLYPURGE") {
-    if (client.ip ~ purge_ip_whitelist) {
-      return (lookup);
-    }
-    error 403 "Forbidden";
+  # Require authentication for FASTLYPURGE requests unless from IP in ACL
+  if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_whitelist) {
+    set req.http.Fastly-Purge-Requires-Auth = "1";
   }
 
   # Force SSL.

--- a/spec/test-outputs/performanceplatform-production.out.vcl
+++ b/spec/test-outputs/performanceplatform-production.out.vcl
@@ -61,12 +61,9 @@ acl purge_ip_whitelist {
 
 sub vcl_recv {
 
-  # Allow FASTLYPURGE from IPs defined in the ACL only, else return a HTTP 403
-  if (req.request == "FASTLYPURGE") {
-    if (client.ip ~ purge_ip_whitelist) {
-      return (lookup);
-    }
-    error 403 "Forbidden";
+  # Require authentication for FASTLYPURGE requests unless from IP in ACL
+  if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_whitelist) {
+    set req.http.Fastly-Purge-Requires-Auth = "1";
   }
 
   # Force SSL.

--- a/spec/test-outputs/performanceplatform-staging.out.vcl
+++ b/spec/test-outputs/performanceplatform-staging.out.vcl
@@ -61,12 +61,9 @@ acl purge_ip_whitelist {
 
 sub vcl_recv {
 
-  # Allow FASTLYPURGE from IPs defined in the ACL only, else return a HTTP 403
-  if (req.request == "FASTLYPURGE") {
-    if (client.ip ~ purge_ip_whitelist) {
-      return (lookup);
-    }
-    error 403 "Forbidden";
+  # Require authentication for FASTLYPURGE requests unless from IP in ACL
+  if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_whitelist) {
+    set req.http.Fastly-Purge-Requires-Auth = "1";
   }
 
   # Force SSL.

--- a/spec/test-outputs/www-integration.out.vcl
+++ b/spec/test-outputs/www-integration.out.vcl
@@ -126,12 +126,9 @@ acl purge_ip_whitelist {
 
 sub vcl_recv {
 
-  # Allow FASTLYPURGE from IPs defined in the ACL only, else return a HTTP 403
-  if (req.request == "FASTLYPURGE") {
-    if (client.ip ~ purge_ip_whitelist) {
-      return (lookup);
-    }
-    error 403 "Forbidden";
+  # Require authentication for FASTLYPURGE requests unless from IP in ACL
+  if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_whitelist) {
+    set req.http.Fastly-Purge-Requires-Auth = "1";
   }
 
   

--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -131,12 +131,9 @@ acl purge_ip_whitelist {
 
 sub vcl_recv {
 
-  # Allow FASTLYPURGE from IPs defined in the ACL only, else return a HTTP 403
-  if (req.request == "FASTLYPURGE") {
-    if (client.ip ~ purge_ip_whitelist) {
-      return (lookup);
-    }
-    error 403 "Forbidden";
+  # Require authentication for FASTLYPURGE requests unless from IP in ACL
+  if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_whitelist) {
+    set req.http.Fastly-Purge-Requires-Auth = "1";
   }
 
   

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -135,12 +135,9 @@ acl allowed_ip_addresses {
 
 sub vcl_recv {
 
-  # Allow FASTLYPURGE from IPs defined in the ACL only, else return a HTTP 403
-  if (req.request == "FASTLYPURGE") {
-    if (client.ip ~ purge_ip_whitelist) {
-      return (lookup);
-    }
-    error 403 "Forbidden";
+  # Require authentication for FASTLYPURGE requests unless from IP in ACL
+  if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_whitelist) {
+    set req.http.Fastly-Purge-Requires-Auth = "1";
   }
 
   

--- a/vcl_templates/apt.vcl.erb
+++ b/vcl_templates/apt.vcl.erb
@@ -25,9 +25,9 @@ backend F_apt {
 sub vcl_recv {
 #FASTLY recv
 
-    # Prevent third parties from flushing CDN caches with FASTLYPURGE
+    # Require authentication for FASTLYPURGE requests
     if (req.request == "FASTLYPURGE") {
-      error 403 "Forbiddden";
+      set req.http.Fastly-Purge-Requires-Auth = "1";
     }
 
     # Unspoofable original client address

--- a/vcl_templates/assets.vcl.erb
+++ b/vcl_templates/assets.vcl.erb
@@ -183,9 +183,9 @@ acl purge_ip_whitelist {
 
 sub vcl_recv {
 
-  # Allow FASTLYPURGE from IPs defined in the ACL only, else return a HTTP 403
+  # Require authentication for FASTLYPURGE requests unless from IP in ACL
   if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_whitelist) {
-    error 403 "Forbidden";
+    set req.http.Fastly-Purge-Requires-Auth = "1";
   }
 
   # Force SSL.

--- a/vcl_templates/bouncer.vcl.erb
+++ b/vcl_templates/bouncer.vcl.erb
@@ -62,12 +62,9 @@ acl purge_ip_whitelist {
 
 sub vcl_recv {
 
-  # Allow FASTLYPURGE from IPs defined in the ACL only, else return a HTTP 403
-  if (req.request == "FASTLYPURGE") {
-    if (client.ip ~ purge_ip_whitelist) {
-      return (lookup);
-    }
-    error 403 "Forbidden";
+  # Require authentication for FASTLYPURGE requests unless from IP in ACL
+  if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_whitelist) {
+    set req.http.Fastly-Purge-Requires-Auth = "1";
   }
 
   # Serve a 404 Not Found response if request URL matches "/autodiscover/autodiscover.xml"

--- a/vcl_templates/performanceplatform.vcl.erb
+++ b/vcl_templates/performanceplatform.vcl.erb
@@ -66,12 +66,9 @@ acl purge_ip_whitelist {
 
 sub vcl_recv {
 
-  # Allow FASTLYPURGE from IPs defined in the ACL only, else return a HTTP 403
-  if (req.request == "FASTLYPURGE") {
-    if (client.ip ~ purge_ip_whitelist) {
-      return (lookup);
-    }
-    error 403 "Forbidden";
+  # Require authentication for FASTLYPURGE requests unless from IP in ACL
+  if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_whitelist) {
+    set req.http.Fastly-Purge-Requires-Auth = "1";
   }
 
   # Force SSL.

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -157,12 +157,9 @@ acl allowed_ip_addresses {
 
 sub vcl_recv {
 
-  # Allow FASTLYPURGE from IPs defined in the ACL only, else return a HTTP 403
-  if (req.request == "FASTLYPURGE") {
-    if (client.ip ~ purge_ip_whitelist) {
-      return (lookup);
-    }
-    error 403 "Forbidden";
+  # Require authentication for FASTLYPURGE requests unless from IP in ACL
+  if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_whitelist) {
+    set req.http.Fastly-Purge-Requires-Auth = "1";
   }
 
   <% if environment == 'staging' %>


### PR DESCRIPTION
After a discussion with Fastly Support we learnt that we don't have the
ability to purge individual URLs from Fastly via the web UI because of
our VCL configuration. We actually return a 403 as the requests are not
in the allowed list.

Fastly support suggested that we change our return of error 403 to
instead set a head a header that authentication is required. Without a
valid token to authenticate these will deny the request and return a
message that authentication is needed.