### PR TITLE
Re-enable FinderAnswerABTest

### DIFF
--- a/configs/dictionaries/active_ab_tests.yaml
+++ b/configs/dictionaries/active_ab_tests.yaml
@@ -10,4 +10,4 @@ RelatedLinksABTest2: false
 RelatedLinksABTest3: false
 RelatedLinksABTest4: false
 ViewDrivingLicence: false
-FinderAnswerABTest: false
+FinderAnswerABTest: true


### PR DESCRIPTION
Trello: https://trello.com/c/VYMcypuO
Reverts: #147

The search improvements made as a result of the incident on 8th April have been stable for a day,
so we think it’s safe to turn the test back on.