### PR TITLE
Allow bypassing basic authorisation if allowed IP address

### DIFF
--- a/spec/test-outputs/www-integration.out.vcl
+++ b/spec/test-outputs/www-integration.out.vcl
@@ -123,6 +123,10 @@ acl purge_ip_whitelist {
 }
 
 
+acl allowed_ip_addresses {
+  
+}
+
 
 sub vcl_recv {
 

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -147,7 +147,7 @@ acl purge_ip_whitelist {
   "203.57.145.0"/24;  # Fastly cache node
 }
 
-<% if environment == 'staging' %>
+<% if %w(staging integration).include?(environment) %>
 acl allowed_ip_addresses {
   <% config.fetch('allowed_ip_addresses', []).each do |ip_address| %>
   "<%= ip_address %>";
@@ -175,9 +175,11 @@ sub vcl_recv {
   }
 
   <% if config['basic_authentication'] %>
-  # Check whether the basic auth credentials are correct in integration
-  if (req.http.Authorization != "Basic <%= config['basic_authentication'] %>") {
-    error 401 "Unauthorized";
+  if (! (client.ip ~ allowed_ip_addresses)) {
+    # Check whether the basic auth credentials are correct in integration
+    if (req.http.Authorization != "Basic <%= config['basic_authentication'] %>") {
+      error 401 "Unauthorized";
+    }
   }
   <% end %>
 


### PR DESCRIPTION
We have a problem where backend apps in integration can't access other integration services via the Internet because they require authentication. Instead of requesting the apps pass in the username/password we can allow access based on their IP address and request basic authorization from everyone else.

[Zendesk Ticket](https://govuk.zendesk.com/agent/tickets/3682605)