### PR TITLE
Optimize mirror vcl

### DIFF
--- a/spec/test-outputs/mirror-production.out.vcl
+++ b/spec/test-outputs/mirror-production.out.vcl
@@ -146,11 +146,6 @@ sub vcl_recv {
     error 403 "Forbidden";
   }
 
-  # Check whether the remote IP address is in the list of blocked IPs
-  if (table.lookup(ip_address_blacklist, client.ip)) {
-    error 403 "Forbidden";
-  }
-
   # Force SSL.
   if (!req.http.Fastly-SSL) {
      error 801 "Force SSL";
@@ -165,25 +160,28 @@ sub vcl_recv {
   set req.grace = 24h;
 
   #################### Start of default mirror backend ########################
-  set req.backend = F_mirrorS3;
-  set req.http.host = "bar";
-  set req.http.Fastly-Backend-Name = "mirrorS3";
+  if (req.restarts < 1) {
+    set req.http.original-url = req.url;
 
-  # Requests to home page, rewrite to index.html
-  if (req.url ~ "^/?([\?#].*)?$") {
-    set req.url = regsub(req.url, "^/?([\?#].*)?$", "/index.html\1");
+    set req.backend = F_mirrorS3;
+    set req.http.host = "bar";
+    set req.http.Fastly-Backend-Name = "mirrorS3";
+
+    # Requests to home page, rewrite to index.html
+    if (req.url ~ "^/?([\?#].*)?$") {
+      set req.url = regsub(req.url, "^/?([\?#].*)?$", "/index.html\1");
+    }
+
+    # Replace multiple /
+    set req.url = regsuball(req.url, "([^:])//+", "\1/");
+
+    # Requests without document extension, rewrite adding .html
+    if (req.url !~ "^([^#\?\s]+)\.(atom|chm|css|csv|diff|doc|docx|dot|dxf|eps|gif|gml|html|ico|ics|jpeg|jpg|JPG|js|json|kml|odp|ods|odt|pdf|PDF|png|ppt|pptx|ps|rdf|rtf|sch|txt|wsdl|xls|xlsm|xlsx|xlt|xml|xsd|xslt|zip)([\?#]+.*)?$") {
+      set req.url = regsub(req.url, "^([^#\?\s]+)([\?#]+.*)?$", "\1.html\2");
+    }
+    # Add bucket directory prefix to all the requests
+    set req.url = "/foo_" req.url;
   }
-
-  # Replace multiple /
-  set req.url = regsuball(req.url, "([^:])//+", "\1/");
-
-  # Requests without document extension, rewrite adding .html
-  if (req.url !~ "^([^#\?\s]+)\.(atom|chm|css|csv|diff|doc|docx|dot|dxf|eps|gif|gml|html|ico|ics|jpeg|jpg|JPG|js|json|kml|odp|ods|odt|pdf|PDF|png|ppt|pptx|ps|rdf|rtf|sch|txt|wsdl|xls|xlsm|xlsx|xlt|xml|xsd|xslt|zip)([\?#]+.*)?$") {
-    set req.url = regsub(req.url, "^([^#\?\s]+)([\?#]+.*)?$", "\1.html\2");
-  }
-  # Add bucket directory prefix to all the requests
-  set req.url = "/foo_" req.url;
-
   #################### End of default mirror backend ##########################
 
   # Serve stale if it exists.
@@ -194,6 +192,8 @@ sub vcl_recv {
 
   # Common config when failover to mirror buckets
   if (req.restarts > 1) {
+    set req.url = req.http.original-url;
+
     # Don't serve from stale for mirrors
     set req.grace = 0s;
     set req.http.Fastly-Failover = "1";
@@ -213,7 +213,7 @@ sub vcl_recv {
   }
 
   # Failover to s3 mirror replica
-  if (req.restarts > 1) {
+  if (req.restarts == 2) {
     set req.backend = F_mirrorS3Replica;
     set req.http.host = "s3-mirror-replica.aws.com";
     set req.http.Fastly-Backend-Name = "mirrorS3Replica";
@@ -232,7 +232,7 @@ sub vcl_recv {
     set req.url = "/gcs-mirror" req.url;
 
     set req.http.Date = now;
-    set req.http.Authorization = "AWS gcs-mirror-access-id:"  digest.hmac_sha1_base64("gcs-mirror-secret-key", "GET" LF LF LF now LF "/gcs-mirror" req.url.path);
+    set req.http.Authorization = "AWS gcs-mirror-access-id:" digest.hmac_sha1_base64("gcs-mirror-secret-key", "GET" LF LF LF now LF "/gcs-bucket" req.url.path);
   }
 
   # Unspoofable original client address.
@@ -249,106 +249,6 @@ sub vcl_recv {
   if (req.request != "HEAD" && req.request != "GET" && req.request != "FASTLYPURGE") {
     return(pass);
   }
-
-    # Begin dynamic section
-if (table.lookup(active_ab_tests, "Example") == "true") {
-  if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
-    set req.http.GOVUK-ABTest-Example = "A";
-  } else if (req.url ~ "[\?\&]ABTest-Example=A(&|$)") {
-    # Some users, such as remote testers, will be given a URL with a query string
-    # to place them into a specific bucket.
-    set req.http.GOVUK-ABTest-Example = "A";
-  } else if (req.url ~ "[\?\&]ABTest-Example=B(&|$)") {
-    # Some users, such as remote testers, will be given a URL with a query string
-    # to place them into a specific bucket.
-    set req.http.GOVUK-ABTest-Example = "B";
-  } else if (req.http.Cookie ~ "ABTest-Example") {
-    # Set the value of the header to whatever decision was previously made
-    set req.http.GOVUK-ABTest-Example = req.http.Cookie:ABTest-Example;
-  } else {
-    declare local var.denominator_Example INTEGER;
-    declare local var.denominator_Example_A INTEGER;
-    declare local var.nominator_Example_A INTEGER;
-    set var.nominator_Example_A = std.atoi(table.lookup(example_percentages, "A"));
-    set var.denominator_Example += var.nominator_Example_A;
-    declare local var.denominator_Example_B INTEGER;
-    declare local var.nominator_Example_B INTEGER;
-    set var.nominator_Example_B = std.atoi(table.lookup(example_percentages, "B"));
-    set var.denominator_Example += var.nominator_Example_B;
-    set var.denominator_Example_A = var.denominator_Example;
-    if (randombool(var.nominator_Example_A, var.denominator_Example_A)) {
-      set req.http.GOVUK-ABTest-Example = "A";
-    } else {
-      set req.http.GOVUK-ABTest-Example = "B";
-    }
-  }
-}
-if (table.lookup(active_ab_tests, "ViewDrivingLicence") == "true") {
-  if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
-    set req.http.GOVUK-ABTest-ViewDrivingLicence = "A";
-  } else if (req.url ~ "[\?\&]ABTest-ViewDrivingLicence=A(&|$)") {
-    # Some users, such as remote testers, will be given a URL with a query string
-    # to place them into a specific bucket.
-    set req.http.GOVUK-ABTest-ViewDrivingLicence = "A";
-  } else if (req.url ~ "[\?\&]ABTest-ViewDrivingLicence=B(&|$)") {
-    # Some users, such as remote testers, will be given a URL with a query string
-    # to place them into a specific bucket.
-    set req.http.GOVUK-ABTest-ViewDrivingLicence = "B";
-  } else if (req.http.Cookie ~ "ABTest-ViewDrivingLicence") {
-    # Set the value of the header to whatever decision was previously made
-    set req.http.GOVUK-ABTest-ViewDrivingLicence = req.http.Cookie:ABTest-ViewDrivingLicence;
-  } else {
-    declare local var.denominator_ViewDrivingLicence INTEGER;
-    declare local var.denominator_ViewDrivingLicence_A INTEGER;
-    declare local var.nominator_ViewDrivingLicence_A INTEGER;
-    set var.nominator_ViewDrivingLicence_A = std.atoi(table.lookup(viewdrivinglicence_percentages, "A"));
-    set var.denominator_ViewDrivingLicence += var.nominator_ViewDrivingLicence_A;
-    declare local var.denominator_ViewDrivingLicence_B INTEGER;
-    declare local var.nominator_ViewDrivingLicence_B INTEGER;
-    set var.nominator_ViewDrivingLicence_B = std.atoi(table.lookup(viewdrivinglicence_percentages, "B"));
-    set var.denominator_ViewDrivingLicence += var.nominator_ViewDrivingLicence_B;
-    set var.denominator_ViewDrivingLicence_A = var.denominator_ViewDrivingLicence;
-    if (randombool(var.nominator_ViewDrivingLicence_A, var.denominator_ViewDrivingLicence_A)) {
-      set req.http.GOVUK-ABTest-ViewDrivingLicence = "A";
-    } else {
-      set req.http.GOVUK-ABTest-ViewDrivingLicence = "B";
-    }
-  }
-}
-if (table.lookup(active_ab_tests, "FinderAnswerABTest") == "true") {
-  if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
-    set req.http.GOVUK-ABTest-FinderAnswerABTest = "A";
-  } else if (req.url ~ "[\?\&]ABTest-FinderAnswerABTest=A(&|$)") {
-    # Some users, such as remote testers, will be given a URL with a query string
-    # to place them into a specific bucket.
-    set req.http.GOVUK-ABTest-FinderAnswerABTest = "A";
-  } else if (req.url ~ "[\?\&]ABTest-FinderAnswerABTest=B(&|$)") {
-    # Some users, such as remote testers, will be given a URL with a query string
-    # to place them into a specific bucket.
-    set req.http.GOVUK-ABTest-FinderAnswerABTest = "B";
-  } else if (req.http.Cookie ~ "ABTest-FinderAnswerABTest") {
-    # Set the value of the header to whatever decision was previously made
-    set req.http.GOVUK-ABTest-FinderAnswerABTest = req.http.Cookie:ABTest-FinderAnswerABTest;
-  } else {
-    declare local var.denominator_FinderAnswerABTest INTEGER;
-    declare local var.denominator_FinderAnswerABTest_A INTEGER;
-    declare local var.nominator_FinderAnswerABTest_A INTEGER;
-    set var.nominator_FinderAnswerABTest_A = std.atoi(table.lookup(finderanswerabtest_percentages, "A"));
-    set var.denominator_FinderAnswerABTest += var.nominator_FinderAnswerABTest_A;
-    declare local var.denominator_FinderAnswerABTest_B INTEGER;
-    declare local var.nominator_FinderAnswerABTest_B INTEGER;
-    set var.nominator_FinderAnswerABTest_B = std.atoi(table.lookup(finderanswerabtest_percentages, "B"));
-    set var.denominator_FinderAnswerABTest += var.nominator_FinderAnswerABTest_B;
-    set var.denominator_FinderAnswerABTest_A = var.denominator_FinderAnswerABTest;
-    if (randombool(var.nominator_FinderAnswerABTest_A, var.denominator_FinderAnswerABTest_A)) {
-      set req.http.GOVUK-ABTest-FinderAnswerABTest = "A";
-    } else {
-      set req.http.GOVUK-ABTest-FinderAnswerABTest = "B";
-    }
-  }
-}
-# End dynamic section
-
 
   return(lookup);
 }

--- a/spec/test-outputs/mirror-staging.out.vcl
+++ b/spec/test-outputs/mirror-staging.out.vcl
@@ -146,11 +146,6 @@ sub vcl_recv {
     error 403 "Forbidden";
   }
 
-  # Check whether the remote IP address is in the list of blocked IPs
-  if (table.lookup(ip_address_blacklist, client.ip)) {
-    error 403 "Forbidden";
-  }
-
   # Force SSL.
   if (!req.http.Fastly-SSL) {
      error 801 "Force SSL";
@@ -165,25 +160,28 @@ sub vcl_recv {
   set req.grace = 24h;
 
   #################### Start of default mirror backend ########################
-  set req.backend = F_mirrorS3;
-  set req.http.host = "bar";
-  set req.http.Fastly-Backend-Name = "mirrorS3";
+  if (req.restarts < 1) {
+    set req.http.original-url = req.url;
 
-  # Requests to home page, rewrite to index.html
-  if (req.url ~ "^/?([\?#].*)?$") {
-    set req.url = regsub(req.url, "^/?([\?#].*)?$", "/index.html\1");
+    set req.backend = F_mirrorS3;
+    set req.http.host = "bar";
+    set req.http.Fastly-Backend-Name = "mirrorS3";
+
+    # Requests to home page, rewrite to index.html
+    if (req.url ~ "^/?([\?#].*)?$") {
+      set req.url = regsub(req.url, "^/?([\?#].*)?$", "/index.html\1");
+    }
+
+    # Replace multiple /
+    set req.url = regsuball(req.url, "([^:])//+", "\1/");
+
+    # Requests without document extension, rewrite adding .html
+    if (req.url !~ "^([^#\?\s]+)\.(atom|chm|css|csv|diff|doc|docx|dot|dxf|eps|gif|gml|html|ico|ics|jpeg|jpg|JPG|js|json|kml|odp|ods|odt|pdf|PDF|png|ppt|pptx|ps|rdf|rtf|sch|txt|wsdl|xls|xlsm|xlsx|xlt|xml|xsd|xslt|zip)([\?#]+.*)?$") {
+      set req.url = regsub(req.url, "^([^#\?\s]+)([\?#]+.*)?$", "\1.html\2");
+    }
+    # Add bucket directory prefix to all the requests
+    set req.url = "/foo_" req.url;
   }
-
-  # Replace multiple /
-  set req.url = regsuball(req.url, "([^:])//+", "\1/");
-
-  # Requests without document extension, rewrite adding .html
-  if (req.url !~ "^([^#\?\s]+)\.(atom|chm|css|csv|diff|doc|docx|dot|dxf|eps|gif|gml|html|ico|ics|jpeg|jpg|JPG|js|json|kml|odp|ods|odt|pdf|PDF|png|ppt|pptx|ps|rdf|rtf|sch|txt|wsdl|xls|xlsm|xlsx|xlt|xml|xsd|xslt|zip)([\?#]+.*)?$") {
-    set req.url = regsub(req.url, "^([^#\?\s]+)([\?#]+.*)?$", "\1.html\2");
-  }
-  # Add bucket directory prefix to all the requests
-  set req.url = "/foo_" req.url;
-
   #################### End of default mirror backend ##########################
 
   # Serve stale if it exists.
@@ -194,6 +192,8 @@ sub vcl_recv {
 
   # Common config when failover to mirror buckets
   if (req.restarts > 1) {
+    set req.url = req.http.original-url;
+
     # Don't serve from stale for mirrors
     set req.grace = 0s;
     set req.http.Fastly-Failover = "1";
@@ -213,7 +213,7 @@ sub vcl_recv {
   }
 
   # Failover to s3 mirror replica
-  if (req.restarts > 1) {
+  if (req.restarts == 2) {
     set req.backend = F_mirrorS3Replica;
     set req.http.host = "s3-mirror-replica.aws.com";
     set req.http.Fastly-Backend-Name = "mirrorS3Replica";
@@ -232,7 +232,7 @@ sub vcl_recv {
     set req.url = "/gcs-mirror" req.url;
 
     set req.http.Date = now;
-    set req.http.Authorization = "AWS gcs-mirror-access-id:"  digest.hmac_sha1_base64("gcs-mirror-secret-key", "GET" LF LF LF now LF "/gcs-mirror" req.url.path);
+    set req.http.Authorization = "AWS gcs-mirror-access-id:" digest.hmac_sha1_base64("gcs-mirror-secret-key", "GET" LF LF LF now LF "/gcs-bucket" req.url.path);
   }
 
   # Unspoofable original client address.
@@ -249,106 +249,6 @@ sub vcl_recv {
   if (req.request != "HEAD" && req.request != "GET" && req.request != "FASTLYPURGE") {
     return(pass);
   }
-
-    # Begin dynamic section
-if (table.lookup(active_ab_tests, "Example") == "true") {
-  if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
-    set req.http.GOVUK-ABTest-Example = "A";
-  } else if (req.url ~ "[\?\&]ABTest-Example=A(&|$)") {
-    # Some users, such as remote testers, will be given a URL with a query string
-    # to place them into a specific bucket.
-    set req.http.GOVUK-ABTest-Example = "A";
-  } else if (req.url ~ "[\?\&]ABTest-Example=B(&|$)") {
-    # Some users, such as remote testers, will be given a URL with a query string
-    # to place them into a specific bucket.
-    set req.http.GOVUK-ABTest-Example = "B";
-  } else if (req.http.Cookie ~ "ABTest-Example") {
-    # Set the value of the header to whatever decision was previously made
-    set req.http.GOVUK-ABTest-Example = req.http.Cookie:ABTest-Example;
-  } else {
-    declare local var.denominator_Example INTEGER;
-    declare local var.denominator_Example_A INTEGER;
-    declare local var.nominator_Example_A INTEGER;
-    set var.nominator_Example_A = std.atoi(table.lookup(example_percentages, "A"));
-    set var.denominator_Example += var.nominator_Example_A;
-    declare local var.denominator_Example_B INTEGER;
-    declare local var.nominator_Example_B INTEGER;
-    set var.nominator_Example_B = std.atoi(table.lookup(example_percentages, "B"));
-    set var.denominator_Example += var.nominator_Example_B;
-    set var.denominator_Example_A = var.denominator_Example;
-    if (randombool(var.nominator_Example_A, var.denominator_Example_A)) {
-      set req.http.GOVUK-ABTest-Example = "A";
-    } else {
-      set req.http.GOVUK-ABTest-Example = "B";
-    }
-  }
-}
-if (table.lookup(active_ab_tests, "ViewDrivingLicence") == "true") {
-  if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
-    set req.http.GOVUK-ABTest-ViewDrivingLicence = "A";
-  } else if (req.url ~ "[\?\&]ABTest-ViewDrivingLicence=A(&|$)") {
-    # Some users, such as remote testers, will be given a URL with a query string
-    # to place them into a specific bucket.
-    set req.http.GOVUK-ABTest-ViewDrivingLicence = "A";
-  } else if (req.url ~ "[\?\&]ABTest-ViewDrivingLicence=B(&|$)") {
-    # Some users, such as remote testers, will be given a URL with a query string
-    # to place them into a specific bucket.
-    set req.http.GOVUK-ABTest-ViewDrivingLicence = "B";
-  } else if (req.http.Cookie ~ "ABTest-ViewDrivingLicence") {
-    # Set the value of the header to whatever decision was previously made
-    set req.http.GOVUK-ABTest-ViewDrivingLicence = req.http.Cookie:ABTest-ViewDrivingLicence;
-  } else {
-    declare local var.denominator_ViewDrivingLicence INTEGER;
-    declare local var.denominator_ViewDrivingLicence_A INTEGER;
-    declare local var.nominator_ViewDrivingLicence_A INTEGER;
-    set var.nominator_ViewDrivingLicence_A = std.atoi(table.lookup(viewdrivinglicence_percentages, "A"));
-    set var.denominator_ViewDrivingLicence += var.nominator_ViewDrivingLicence_A;
-    declare local var.denominator_ViewDrivingLicence_B INTEGER;
-    declare local var.nominator_ViewDrivingLicence_B INTEGER;
-    set var.nominator_ViewDrivingLicence_B = std.atoi(table.lookup(viewdrivinglicence_percentages, "B"));
-    set var.denominator_ViewDrivingLicence += var.nominator_ViewDrivingLicence_B;
-    set var.denominator_ViewDrivingLicence_A = var.denominator_ViewDrivingLicence;
-    if (randombool(var.nominator_ViewDrivingLicence_A, var.denominator_ViewDrivingLicence_A)) {
-      set req.http.GOVUK-ABTest-ViewDrivingLicence = "A";
-    } else {
-      set req.http.GOVUK-ABTest-ViewDrivingLicence = "B";
-    }
-  }
-}
-if (table.lookup(active_ab_tests, "FinderAnswerABTest") == "true") {
-  if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
-    set req.http.GOVUK-ABTest-FinderAnswerABTest = "A";
-  } else if (req.url ~ "[\?\&]ABTest-FinderAnswerABTest=A(&|$)") {
-    # Some users, such as remote testers, will be given a URL with a query string
-    # to place them into a specific bucket.
-    set req.http.GOVUK-ABTest-FinderAnswerABTest = "A";
-  } else if (req.url ~ "[\?\&]ABTest-FinderAnswerABTest=B(&|$)") {
-    # Some users, such as remote testers, will be given a URL with a query string
-    # to place them into a specific bucket.
-    set req.http.GOVUK-ABTest-FinderAnswerABTest = "B";
-  } else if (req.http.Cookie ~ "ABTest-FinderAnswerABTest") {
-    # Set the value of the header to whatever decision was previously made
-    set req.http.GOVUK-ABTest-FinderAnswerABTest = req.http.Cookie:ABTest-FinderAnswerABTest;
-  } else {
-    declare local var.denominator_FinderAnswerABTest INTEGER;
-    declare local var.denominator_FinderAnswerABTest_A INTEGER;
-    declare local var.nominator_FinderAnswerABTest_A INTEGER;
-    set var.nominator_FinderAnswerABTest_A = std.atoi(table.lookup(finderanswerabtest_percentages, "A"));
-    set var.denominator_FinderAnswerABTest += var.nominator_FinderAnswerABTest_A;
-    declare local var.denominator_FinderAnswerABTest_B INTEGER;
-    declare local var.nominator_FinderAnswerABTest_B INTEGER;
-    set var.nominator_FinderAnswerABTest_B = std.atoi(table.lookup(finderanswerabtest_percentages, "B"));
-    set var.denominator_FinderAnswerABTest += var.nominator_FinderAnswerABTest_B;
-    set var.denominator_FinderAnswerABTest_A = var.denominator_FinderAnswerABTest;
-    if (randombool(var.nominator_FinderAnswerABTest_A, var.denominator_FinderAnswerABTest_A)) {
-      set req.http.GOVUK-ABTest-FinderAnswerABTest = "A";
-    } else {
-      set req.http.GOVUK-ABTest-FinderAnswerABTest = "B";
-    }
-  }
-}
-# End dynamic section
-
 
   return(lookup);
 }

--- a/spec/vcl_generation_spec.rb
+++ b/spec/vcl_generation_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe "VCL generation" do
     "gcs_mirror_prefix" => "gcs-mirror",
     "gcs_mirror_access_id" => "gcs-mirror-access-id",
     "gcs_mirror_secret_key" => "gcs-mirror-secret-key",
+    "gcs_mirror_bucket_name" => "gcs-bucket",
     "default_ttl" => "5000",
     "apt_hostname" => "foo",
     "origin_domain_suffix" => "boo",

--- a/vcl_templates/mirror.vcl.erb
+++ b/vcl_templates/mirror.vcl.erb
@@ -162,11 +162,6 @@ sub vcl_recv {
     error 403 "Forbidden";
   }
 
-  # Check whether the remote IP address is in the list of blocked IPs
-  if (table.lookup(ip_address_blacklist, client.ip)) {
-    error 403 "Forbidden";
-  }
-
   # Force SSL.
   if (!req.http.Fastly-SSL) {
      error 801 "Force SSL";
@@ -181,25 +176,28 @@ sub vcl_recv {
   set req.grace = 24h;
 
   #################### Start of default mirror backend ########################
-  set req.backend = F_mirrorS3;
-  set req.http.host = "<%= config.fetch('s3_mirror_hostname') %>";
-  set req.http.Fastly-Backend-Name = "mirrorS3";
+  if (req.restarts < 1) {
+    set req.http.original-url = req.url;
 
-  # Requests to home page, rewrite to index.html
-  if (req.url ~ "^/?([\?#].*)?$") {
-    set req.url = regsub(req.url, "^/?([\?#].*)?$", "/index.html\1");
+    set req.backend = F_mirrorS3;
+    set req.http.host = "<%= config.fetch('s3_mirror_hostname') %>";
+    set req.http.Fastly-Backend-Name = "mirrorS3";
+
+    # Requests to home page, rewrite to index.html
+    if (req.url ~ "^/?([\?#].*)?$") {
+      set req.url = regsub(req.url, "^/?([\?#].*)?$", "/index.html\1");
+    }
+
+    # Replace multiple /
+    set req.url = regsuball(req.url, "([^:])//+", "\1/");
+
+    # Requests without document extension, rewrite adding .html
+    if (req.url !~ "^([^#\?\s]+)\.(atom|chm|css|csv|diff|doc|docx|dot|dxf|eps|gif|gml|html|ico|ics|jpeg|jpg|JPG|js|json|kml|odp|ods|odt|pdf|PDF|png|ppt|pptx|ps|rdf|rtf|sch|txt|wsdl|xls|xlsm|xlsx|xlt|xml|xsd|xslt|zip)([\?#]+.*)?$") {
+      set req.url = regsub(req.url, "^([^#\?\s]+)([\?#]+.*)?$", "\1.html\2");
+    }
+    # Add bucket directory prefix to all the requests
+    set req.url = "/<%= config.fetch('s3_mirror_prefix') %>" req.url;
   }
-
-  # Replace multiple /
-  set req.url = regsuball(req.url, "([^:])//+", "\1/");
-
-  # Requests without document extension, rewrite adding .html
-  if (req.url !~ "^([^#\?\s]+)\.(atom|chm|css|csv|diff|doc|docx|dot|dxf|eps|gif|gml|html|ico|ics|jpeg|jpg|JPG|js|json|kml|odp|ods|odt|pdf|PDF|png|ppt|pptx|ps|rdf|rtf|sch|txt|wsdl|xls|xlsm|xlsx|xlt|xml|xsd|xslt|zip)([\?#]+.*)?$") {
-    set req.url = regsub(req.url, "^([^#\?\s]+)([\?#]+.*)?$", "\1.html\2");
-  }
-  # Add bucket directory prefix to all the requests
-  set req.url = "/<%= config.fetch('s3_mirror_prefix') %>" req.url;
-
   #################### End of default mirror backend ##########################
 
   # Serve stale if it exists.
@@ -210,6 +208,8 @@ sub vcl_recv {
 
   # Common config when failover to mirror buckets
   if (req.restarts > 1) {
+    set req.url = req.http.original-url;
+
     # Don't serve from stale for mirrors
     set req.grace = 0s;
     set req.http.Fastly-Failover = "1";
@@ -229,7 +229,7 @@ sub vcl_recv {
   }
 
   # Failover to s3 mirror replica
-  if (req.restarts > 1) {
+  if (req.restarts == 2) {
     set req.backend = F_mirrorS3Replica;
     set req.http.host = "<%= config.fetch('s3_mirror_replica_hostname') %>";
     set req.http.Fastly-Backend-Name = "mirrorS3Replica";
@@ -248,7 +248,7 @@ sub vcl_recv {
     set req.url = "/<%= config.fetch('gcs_mirror_prefix') %>" req.url;
 
     set req.http.Date = now;
-    set req.http.Authorization = "AWS <%= config.fetch('gcs_mirror_access_id') %>:"  digest.hmac_sha1_base64("<%= config.fetch('gcs_mirror_secret_key') %>", "GET" LF LF LF now LF "/<%= config.fetch('gcs_mirror_prefix') %>" req.url.path);
+    set req.http.Authorization = "AWS <%= config.fetch('gcs_mirror_access_id') %>:" digest.hmac_sha1_base64("<%= config.fetch('gcs_mirror_secret_key') %>", "GET" LF LF LF now LF "/<%= config.fetch('gcs_mirror_bucket_name') %>" req.url.path);
   }
 
   # Unspoofable original client address.
@@ -265,9 +265,6 @@ sub vcl_recv {
   if (req.request != "HEAD" && req.request != "GET" && req.request != "FASTLYPURGE") {
     return(pass);
   }
-
-  <% template_path = File.join(File.dirname(__FILE__), "vcl_templates/_multivariate_tests.vcl.erb") -%>
-  <%= ERB.new(File.new(template_path).read, nil, "-", "_erbout2").result(binding) %>
 
   return(lookup);
 }


### PR DESCRIPTION
# Context

There is no need for:
1. blacklisting IPs because only few IPs are allowed to connect to this
fastly service by default
2. AB tests because no such tests are needed on the mirror fastly service

# Decisions
1. remove blacklist ips section
2. remove import of AB tests