### PR TITLE
[DO NOT MERGE, testing in staging] new www fastly service vcl to use new mirror buckets

### DIFF
--- a/deploy-service.sh
+++ b/deploy-service.sh
@@ -2,7 +2,7 @@
 set -eu
 
 rm -rf govuk-cdn-config-secrets
-git clone git@github.com:alphagov/govuk-cdn-config-secrets.git -b add_www_staging_values
+git clone git@github.com:alphagov/govuk-cdn-config-secrets.git
 
 cp govuk-cdn-config-secrets/fastly/fastly.yaml .
 

--- a/deploy-service.sh
+++ b/deploy-service.sh
@@ -2,7 +2,7 @@
 set -eu
 
 rm -rf govuk-cdn-config-secrets
-git clone git@github.com:alphagov/govuk-cdn-config-secrets.git
+git clone git@github.com:alphagov/govuk-cdn-config-secrets.git -b add_www_staging_values
 
 cp govuk-cdn-config-secrets/fastly/fastly.yaml .
 

--- a/spec/test-outputs/assets-integration.out.vcl
+++ b/spec/test-outputs/assets-integration.out.vcl
@@ -61,78 +61,6 @@ backend F_awsorigin {
       }
 }
 
-# Mirror backend for provider 0
-backend F_mirror1 {
-    .connect_timeout = 1s;
-    .dynamic = true;
-    .port = "443";
-    .host = "foo";
-    .first_byte_timeout = 15s;
-    .max_connections = 200;
-    .between_bytes_timeout = 10s;
-    .share_key = "123";
-
-    .ssl = true;
-    .ssl_check_cert = always;
-    .min_tls_version = "1.2";
-    .ssl_cert_hostname = "foo";
-    .ssl_sni_hostname = "foo";
-
-    .probe = {
-        .request =
-            "HEAD /__canary__ HTTP/1.1"
-            "Host: foo"
-            "User-Agent: Fastly healthcheck (git version: )"
-            "Connection: close";
-        .threshold = 1;
-        .window = 2;
-        .timeout = 5s;
-        .initial = 1;
-        .expected_response = 200;
-        .interval = 10s;
-    }
-}
-# Mirror backend for S3
-backend F_mirrorS3 {
-    .connect_timeout = 1s;
-    .dynamic = true;
-    .port = "443";
-    .host = "bar";
-    .first_byte_timeout = 15s;
-    .max_connections = 200;
-    .between_bytes_timeout = 10s;
-    .share_key = "123";
-
-    .ssl = true;
-    .ssl_check_cert = always;
-    .min_tls_version = "1.2";
-    .ssl_cert_hostname = "bar";
-    .ssl_sni_hostname = "bar";
-
-    .probe = {
-        .request =
-            "HEAD / HTTP/1.1"
-            "Host: bar"
-            "User-Agent: Fastly healthcheck (git version: )"
-            "Connection: close";
-        .threshold = 1;
-        .window = 2;
-        .timeout = 5s;
-        .initial = 1;
-        .expected_response = 200;
-        .interval = 10s;
-    }
-}
-
-backend sick_force_grace {
-  .host = "127.0.0.1";
-  .port = "1";
-  .probe = {
-    .request = "invalid";
-    .interval = 365d;
-    .initial = 0;
-  }
-}
 
 
 acl purge_ip_whitelist {
@@ -191,35 +119,7 @@ sub vcl_recv {
       set req.http.host = "foo";
   }
 
-  # Serve stale if it exists.
-  if (req.restarts > 0) {
-    set req.backend = sick_force_grace;
-    set req.http.Fastly-Backend-Name = "stale";
-  }
-
-  # Failover to mirror.
-  if (req.restarts > 1) {
-    # Don't serve from stale for mirrors
-    set req.grace = 0s;
-    set req.http.Fastly-Failover = "1";
-
-    set req.backend = F_mirror1;
-    set req.http.Fastly-Backend-Name = "mirror1";
-    set req.http.host = "foo";
-  }
-
-  # FIXME: Prefer a fallback director if we move to Varnish 3
-  if (req.restarts > 2) {
-    set req.backend = F_mirrorS3;
-    set req.http.host = "bar";
-    set req.http.Fastly-Backend-Name = "mirrorS3";
-
-    # Replace multiple /
-    set req.url = regsuball(req.url, "([^:])//+", "\1/");
-
-    # Rewrite adding bucket directory prefix
-    set req.url = "/foo_" req.url;
-  }
+  
 
   # Unspoofable original client address.
   set req.http.True-Client-IP = req.http.Fastly-Client-IP;
@@ -320,6 +220,17 @@ sub vcl_error {
     set obj.status = 200;
     synthetic {""};
     return(deliver);
+  }
+
+  # Serve stale from error subroutine as recommended in:
+  # https://docs.fastly.com/guides/performance-tuning/serving-stale-content
+  # The use of `req.restarts == 0` condition is to enforce the restriction
+  # of serving stale only when the backend is the origin.
+  if ((req.restarts == 0) && (obj.status >= 500 && obj.status < 600)) {
+    /* deliver stale object if it is available */
+    if (stale.exists) {
+      return(deliver_stale);
+    }
   }
 
   # Assume we've hit vcl_error() because the backend is unavailable

--- a/spec/test-outputs/mirror-integration.out.vcl
+++ b/spec/test-outputs/mirror-integration.out.vcl
@@ -284,7 +284,7 @@ sub vcl_fetch {
   # a 301 status code. All errors from the mirrors are set to 503 as they
   # cannot know whether or not a page actually exists (e.g. /search is a valid
   # URL but the mirror cannot return it).
-  if (beresp.status != 200 && beresp.http.Fastly-Backend-Name ~ "mirror") {
+  if (beresp.status != 200 && beresp.http.Fastly-Backend-Name ~ "^mirror") {
     set beresp.status = 503;
   }
 
@@ -292,7 +292,7 @@ sub vcl_fetch {
     set req.http.Fastly-Cachetype = "ERROR";
     set beresp.ttl = 1s;
     set beresp.grace = 5s;
-    if (beresp.http.Fastly-Backend-Name ~ "mirrorS3") {
+    if (beresp.http.Fastly-Backend-Name ~ "^mirror") {
       error 503 "Error page";
     }
     return (deliver);
@@ -304,8 +304,8 @@ sub vcl_fetch {
     # apply the default ttl
     set beresp.ttl = 5000s;
 
-    # S3 does not set cache headers by default. Override TTL and add cache-control with 15 minutes
-    if (beresp.http.Fastly-Backend-Name ~ "mirrorS3") {
+    # Mirror buckets do not set cache headers by default. Override TTL and add cache-control with 15 minutes
+    if (beresp.http.Fastly-Backend-Name ~ "^mirror") {
       set beresp.ttl = 900s;
       set beresp.http.Cache-Control = "max-age=900";
     }

--- a/spec/test-outputs/mirror-production.out.vcl
+++ b/spec/test-outputs/mirror-production.out.vcl
@@ -289,7 +289,7 @@ sub vcl_fetch {
   # a 301 status code. All errors from the mirrors are set to 503 as they
   # cannot know whether or not a page actually exists (e.g. /search is a valid
   # URL but the mirror cannot return it).
-  if (beresp.status != 200 && beresp.http.Fastly-Backend-Name ~ "mirror") {
+  if (beresp.status != 200 && beresp.http.Fastly-Backend-Name ~ "^mirror") {
     set beresp.status = 503;
   }
 
@@ -297,7 +297,7 @@ sub vcl_fetch {
     set req.http.Fastly-Cachetype = "ERROR";
     set beresp.ttl = 1s;
     set beresp.grace = 5s;
-    if (beresp.http.Fastly-Backend-Name ~ "mirrorS3") {
+    if (beresp.http.Fastly-Backend-Name ~ "^mirror") {
       error 503 "Error page";
     }
     return (deliver);
@@ -309,8 +309,8 @@ sub vcl_fetch {
     # apply the default ttl
     set beresp.ttl = 5000s;
 
-    # S3 does not set cache headers by default. Override TTL and add cache-control with 15 minutes
-    if (beresp.http.Fastly-Backend-Name ~ "mirrorS3") {
+    # Mirror buckets do not set cache headers by default. Override TTL and add cache-control with 15 minutes
+    if (beresp.http.Fastly-Backend-Name ~ "^mirror") {
       set beresp.ttl = 900s;
       set beresp.http.Cache-Control = "max-age=900";
     }

--- a/spec/test-outputs/mirror-staging.out.vcl
+++ b/spec/test-outputs/mirror-staging.out.vcl
@@ -289,7 +289,7 @@ sub vcl_fetch {
   # a 301 status code. All errors from the mirrors are set to 503 as they
   # cannot know whether or not a page actually exists (e.g. /search is a valid
   # URL but the mirror cannot return it).
-  if (beresp.status != 200 && beresp.http.Fastly-Backend-Name ~ "mirror") {
+  if (beresp.status != 200 && beresp.http.Fastly-Backend-Name ~ "^mirror") {
     set beresp.status = 503;
   }
 
@@ -297,7 +297,7 @@ sub vcl_fetch {
     set req.http.Fastly-Cachetype = "ERROR";
     set beresp.ttl = 1s;
     set beresp.grace = 5s;
-    if (beresp.http.Fastly-Backend-Name ~ "mirrorS3") {
+    if (beresp.http.Fastly-Backend-Name ~ "^mirror") {
       error 503 "Error page";
     }
     return (deliver);
@@ -309,8 +309,8 @@ sub vcl_fetch {
     # apply the default ttl
     set beresp.ttl = 5000s;
 
-    # S3 does not set cache headers by default. Override TTL and add cache-control with 15 minutes
-    if (beresp.http.Fastly-Backend-Name ~ "mirrorS3") {
+    # Mirror buckets do not set cache headers by default. Override TTL and add cache-control with 15 minutes
+    if (beresp.http.Fastly-Backend-Name ~ "^mirror") {
       set beresp.ttl = 900s;
       set beresp.http.Cache-Control = "max-age=900";
     }

--- a/spec/test-outputs/www-integration.out.vcl
+++ b/spec/test-outputs/www-integration.out.vcl
@@ -222,7 +222,7 @@ sub vcl_fetch {
   if ((beresp.status >= 500 && beresp.status <= 599) && req.restarts < 3 && (req.request == "GET" || req.request == "HEAD") && !beresp.http.No-Fallback) {
     set beresp.saintmode = 5s;
 
-    if ((req.restarts == 0) && stale.exists ) {
+    if (stale.exists) {
      set req.http.Fastly-Backend-Name = "stale";
      set beresp.http.Fastly-Backend-Name = "stale";
      return(deliver_stale);

--- a/spec/test-outputs/www-integration.out.vcl
+++ b/spec/test-outputs/www-integration.out.vcl
@@ -236,7 +236,7 @@ sub vcl_fetch {
 
   set beresp.http.Fastly-Backend-Name = req.http.Fastly-Backend-Name;
 
-  if ((beresp.status >= 500 && beresp.status <= 599) && req.restarts < 3 && (req.request == "GET" || req.request == "HEAD") && !beresp.http.No-Fallback) {
+  if ((beresp.status >= 500 && beresp.status <= 599) && req.restarts < 4 && (req.request == "GET" || req.request == "HEAD") && !beresp.http.No-Fallback) {
     set beresp.saintmode = 5s;
     return (restart);
   }

--- a/spec/test-outputs/www-integration.out.vcl
+++ b/spec/test-outputs/www-integration.out.vcl
@@ -88,9 +88,13 @@ sub vcl_recv {
 
   # Default backend, these details will be overwritten if other backends are
   # chosen
-  set req.http.original-url = req.url;
   set req.backend = F_origin;
   set req.http.Fastly-Backend-Name = "origin";
+
+  # Save original request url because req.url changes after restarts.
+  if (req.restarts < 1) {
+    set req.http.original-url = req.url;
+  }
 
   
 

--- a/spec/test-outputs/www-integration.out.vcl
+++ b/spec/test-outputs/www-integration.out.vcl
@@ -222,8 +222,8 @@ sub vcl_fetch {
   if ((beresp.status >= 500 && beresp.status <= 599) && req.restarts < 3 && (req.request == "GET" || req.request == "HEAD") && !beresp.http.No-Fallback) {
     set beresp.saintmode = 5s;
 
-    if req.restarts == 0 && stale.exists {
-     set beresp.http.Fastly-Backend-Name = "stale"
+    if ((req.restarts == 0) && stale.exists ) {
+     set beresp.http.Fastly-Backend-Name = "stale";
      return(deliver_stale);
     }
 

--- a/spec/test-outputs/www-integration.out.vcl
+++ b/spec/test-outputs/www-integration.out.vcl
@@ -267,7 +267,7 @@ sub vcl_fetch {
   # a 301 status code. All errors from the mirrors are set to 503 as they
   # cannot know whether or not a page actually exists (e.g. /search is a valid
   # URL but the mirror cannot return it).
-  if (beresp.status != 200 && beresp.http.Fastly-Backend-Name ~ "mirror") {
+  if (beresp.status != 200 && beresp.http.Fastly-Backend-Name ~ "^mirror") {
     set beresp.status = 503;
   }
 
@@ -275,7 +275,7 @@ sub vcl_fetch {
     set req.http.Fastly-Cachetype = "ERROR";
     set beresp.ttl = 1s;
     set beresp.grace = 5s;
-    if (beresp.http.Fastly-Backend-Name ~ "mirrorS3") {
+    if (beresp.http.Fastly-Backend-Name ~ "^mirror") {
       error 503 "Error page";
     }
     return (deliver);
@@ -287,8 +287,8 @@ sub vcl_fetch {
     # apply the default ttl
     set beresp.ttl = 5000s;
 
-    # S3 does not set cache headers by default. Override TTL and add cache-control with 15 minutes
-    if (beresp.http.Fastly-Backend-Name ~ "mirrorS3") {
+    # Mirror buckets do not set cache headers by default. Override TTL and add cache-control with 15 minutes
+    if (beresp.http.Fastly-Backend-Name ~ "^mirror") {
       set beresp.ttl = 900s;
       set beresp.http.Cache-Control = "max-age=900";
     }

--- a/spec/test-outputs/www-integration.out.vcl
+++ b/spec/test-outputs/www-integration.out.vcl
@@ -385,9 +385,10 @@ sub vcl_error {
   
 
   # Assume we've hit vcl_error() because the backend is unavailable
-  # for the first two retries. By restarting, vcl_recv() will try
-  # serving from stale before failing over to the mirrors.
-  if (req.restarts < 3) {
+  # for the first 3 retries: origin, mirrorS3, mirrorS3Replica.
+  # By restarting, vcl_recv() will try serving from stale before
+  # failing over to the mirrors.
+  if (req.restarts < 4) {
     return (restart);
   }
 

--- a/spec/test-outputs/www-integration.out.vcl
+++ b/spec/test-outputs/www-integration.out.vcl
@@ -91,11 +91,6 @@ sub vcl_recv {
   set req.backend = F_origin;
   set req.http.Fastly-Backend-Name = "origin";
 
-  # Save original request url because req.url changes after restarts.
-  if (req.restarts < 1) {
-    set req.http.original-url = req.url;
-  }
-
   
 
   # Unspoofable original client address.

--- a/spec/test-outputs/www-integration.out.vcl
+++ b/spec/test-outputs/www-integration.out.vcl
@@ -223,6 +223,7 @@ sub vcl_fetch {
     set beresp.saintmode = 5s;
 
     if ((req.restarts == 0) && stale.exists ) {
+     set req.http.Fastly-Backend-Name = "stale"
      set beresp.http.Fastly-Backend-Name = "stale";
      return(deliver_stale);
     }

--- a/spec/test-outputs/www-integration.out.vcl
+++ b/spec/test-outputs/www-integration.out.vcl
@@ -223,7 +223,7 @@ sub vcl_fetch {
     set beresp.saintmode = 5s;
 
     if ((req.restarts == 0) && stale.exists ) {
-     set req.http.Fastly-Backend-Name = "stale"
+     set req.http.Fastly-Backend-Name = "stale";
      set beresp.http.Fastly-Backend-Name = "stale";
      return(deliver_stale);
     }

--- a/spec/test-outputs/www-integration.out.vcl
+++ b/spec/test-outputs/www-integration.out.vcl
@@ -28,68 +28,8 @@ backend F_origin {
         .interval = 10s;
     }
 }
-# Mirror backend for provider 0
-backend F_mirror1 {
-    .connect_timeout = 1s;
-    .dynamic = true;
-    .port = "443";
-    .host = "foo";
-    .first_byte_timeout = 15s;
-    .max_connections = 200;
-    .between_bytes_timeout = 10s;
-    .share_key = "123";
 
-    .ssl = true;
-    .ssl_check_cert = always;
-    .min_tls_version = "1.2";
-    .ssl_cert_hostname = "foo";
-    .ssl_sni_hostname = "foo";
 
-    .probe = {
-        .request =
-            "HEAD / HTTP/1.1"
-            "Host: foo"
-            "User-Agent: Fastly healthcheck (git version: )"
-            "Connection: close";
-        .threshold = 1;
-        .window = 2;
-        .timeout = 5s;
-        .initial = 1;
-        .expected_response = 200;
-        .interval = 10s;
-    }
-}
-# Mirror backend for S3
-backend F_mirrorS3 {
-    .connect_timeout = 1s;
-    .dynamic = true;
-    .port = "443";
-    .host = "bar";
-    .first_byte_timeout = 15s;
-    .max_connections = 200;
-    .between_bytes_timeout = 10s;
-    .share_key = "123";
-
-    .ssl = true;
-    .ssl_check_cert = always;
-    .min_tls_version = "1.2";
-    .ssl_cert_hostname = "bar";
-    .ssl_sni_hostname = "bar";
-
-    .probe = {
-        .request =
-            "HEAD / HTTP/1.1"
-            "Host: bar"
-            "User-Agent: Fastly healthcheck (git version: )"
-            "Connection: close";
-        .threshold = 1;
-        .window = 2;
-        .timeout = 5s;
-        .initial = 1;
-        .expected_response = 200;
-        .interval = 10s;
-    }
-}
 
 backend sick_force_grace {
   .host = "127.0.0.1";
@@ -158,8 +98,11 @@ sub vcl_recv {
   set req.grace = 24h;
 
   # Default backend.
-  set req.backend = F_origin;
-  set req.http.Fastly-Backend-Name = "origin";
+  if (req.restarts < 1) {
+    set req.http.original-url = req.url;
+    set req.backend = F_origin;
+    set req.http.Fastly-Backend-Name = "origin";
+  }
 
   # Serve stale if it exists.
   if (req.restarts > 0) {
@@ -167,38 +110,7 @@ sub vcl_recv {
     set req.http.Fastly-Backend-Name = "stale";
   }
 
-  # Failover to mirror.
-  if (req.restarts > 1) {
-    # Don't serve from stale for mirrors
-    set req.grace = 0s;
-    set req.http.Fastly-Failover = "1";
-
-    set req.backend = F_mirror1;
-    set req.http.host = "foo";
-    set req.http.Fastly-Backend-Name = "mirror1";
-  }
-
-  # FIXME: Prefer a fallback director if we move to Varnish 3
-  if (req.restarts > 2) {
-    set req.backend = F_mirrorS3;
-    set req.http.host = "bar";
-    set req.http.Fastly-Backend-Name = "mirrorS3";
-
-    # Requests to home page, rewrite to index.html
-    if (req.url ~ "^/?([\?#].*)?$") {
-      set req.url = regsub(req.url, "^/?([\?#].*)?$", "/index.html\1");
-    }
-
-    # Replace multiple /
-    set req.url = regsuball(req.url, "([^:])//+", "\1/");
-
-    # Requests without document extension, rewrite adding .html
-    if (req.url !~ "^([^#\?\s]+)\.(atom|chm|css|csv|diff|doc|docx|dot|dxf|eps|gif|gml|html|ico|ics|jpeg|jpg|JPG|js|json|kml|odp|ods|odt|pdf|PDF|png|ppt|pptx|ps|rdf|rtf|sch|txt|wsdl|xls|xlsm|xlsx|xlt|xml|xsd|xslt|zip)([\?#]+.*)?$") {
-      set req.url = regsub(req.url, "^([^#\?\s]+)([\?#]+.*)?$", "\1.html\2");
-    }
-    # Add bucket directory prefix to all the requests
-    set req.url = "/foo_" req.url;
-  }
+  
 
   # Unspoofable original client address.
   set req.http.True-Client-IP = req.http.Fastly-Client-IP;

--- a/spec/test-outputs/www-integration.out.vcl
+++ b/spec/test-outputs/www-integration.out.vcl
@@ -370,7 +370,7 @@ sub vcl_error {
   # https://docs.fastly.com/guides/performance-tuning/serving-stale-content
   # The use of `req.restarts == 0` condition is to enforce the restriction
   # of serving stale only when the backend is the origin.
-  if (req.restarts == 0) && (obj.status >= 500 && obj.status < 600) {
+  if ((req.restarts == 0) && (obj.status >= 500 && obj.status < 600)) {
     /* deliver stale object if it is available */
     if (stale.exists) {
       return(deliver_stale);

--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -522,7 +522,7 @@ sub vcl_error {
   # https://docs.fastly.com/guides/performance-tuning/serving-stale-content
   # The use of `req.restarts == 0` condition is to enforce the restriction
   # of serving stale only when the backend is the origin.
-  if (req.restarts == 0) && (obj.status >= 500 && obj.status < 600) {
+  if ((req.restarts == 0) && (obj.status >= 500 && obj.status < 600)) {
     /* deliver stale object if it is available */
     if (stale.exists) {
       return(deliver_stale);

--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -375,7 +375,7 @@ sub vcl_fetch {
     set beresp.saintmode = 5s;
 
     if ((req.restarts == 0) && stale.exists ) {
-     set req.http.Fastly-Backend-Name = "stale"
+     set req.http.Fastly-Backend-Name = "stale";
      set beresp.http.Fastly-Backend-Name = "stale";
      return(deliver_stale);
     }

--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -419,7 +419,7 @@ sub vcl_fetch {
   # a 301 status code. All errors from the mirrors are set to 503 as they
   # cannot know whether or not a page actually exists (e.g. /search is a valid
   # URL but the mirror cannot return it).
-  if (beresp.status != 200 && beresp.http.Fastly-Backend-Name ~ "mirror") {
+  if (beresp.status != 200 && beresp.http.Fastly-Backend-Name ~ "^mirror") {
     set beresp.status = 503;
   }
 
@@ -427,7 +427,7 @@ sub vcl_fetch {
     set req.http.Fastly-Cachetype = "ERROR";
     set beresp.ttl = 1s;
     set beresp.grace = 5s;
-    if (beresp.http.Fastly-Backend-Name ~ "mirrorS3") {
+    if (beresp.http.Fastly-Backend-Name ~ "^mirror") {
       error 503 "Error page";
     }
     return (deliver);
@@ -439,8 +439,8 @@ sub vcl_fetch {
     # apply the default ttl
     set beresp.ttl = 5000s;
 
-    # S3 does not set cache headers by default. Override TTL and add cache-control with 15 minutes
-    if (beresp.http.Fastly-Backend-Name ~ "mirrorS3") {
+    # Mirror buckets do not set cache headers by default. Override TTL and add cache-control with 15 minutes
+    if (beresp.http.Fastly-Backend-Name ~ "^mirror") {
       set beresp.ttl = 900s;
       set beresp.http.Cache-Control = "max-age=900";
     }

--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -537,9 +537,10 @@ sub vcl_error {
   
 
   # Assume we've hit vcl_error() because the backend is unavailable
-  # for the first two retries. By restarting, vcl_recv() will try
-  # serving from stale before failing over to the mirrors.
-  if (req.restarts < 3) {
+  # for the first 3 retries: origin, mirrorS3, mirrorS3Replica.
+  # By restarting, vcl_recv() will try serving from stale before
+  # failing over to the mirrors.
+  if (req.restarts < 4) {
     return (restart);
   }
 

--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -185,9 +185,13 @@ sub vcl_recv {
 
   # Default backend, these details will be overwritten if other backends are
   # chosen
-  set req.http.original-url = req.url;
   set req.backend = F_origin;
   set req.http.Fastly-Backend-Name = "origin";
+
+  # Save original request url because req.url changes after restarts.
+  if (req.restarts < 1) {
+    set req.http.original-url = req.url;
+  }
 
   
   # Common config when failover to mirror buckets

--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -374,7 +374,7 @@ sub vcl_fetch {
   if ((beresp.status >= 500 && beresp.status <= 599) && req.restarts < 3 && (req.request == "GET" || req.request == "HEAD") && !beresp.http.No-Fallback) {
     set beresp.saintmode = 5s;
 
-    if ((req.restarts == 0) && stale.exists ) {
+    if (stale.exists) {
      set req.http.Fastly-Backend-Name = "stale";
      set beresp.http.Fastly-Backend-Name = "stale";
      return(deliver_stale);

--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -188,12 +188,13 @@ sub vcl_recv {
   set req.backend = F_origin;
   set req.http.Fastly-Backend-Name = "origin";
 
+  
+
   # Save original request url because req.url changes after restarts.
   if (req.restarts < 1) {
     set req.http.original-url = req.url;
   }
 
-  
   # Common config when failover to mirror buckets
   if (req.restarts > 0) {
     set req.url = req.http.original-url;

--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -126,6 +126,29 @@ backend F_mirrorGCS {
     }
 }
 
+director mirrors_director fallback {
+  {
+    .backend = F_mirrorS3;
+  }{
+    .backend = F_mirrorS3Replica;
+  }{
+    .backend = F_mirrorGCS;
+  }
+}
+
+
+# This backend is permanently sick on purpose so that the vcl_error
+# can use this backend to force serving stale objects if the origin
+# is sick, see: https://book.varnish-software.com/3.0/Saving_a_request.html
+backend sick_force_grace {
+  .host = "127.0.0.1";
+  .port = "1";
+  .probe = {
+    .request = "invalid";
+    .interval = 365d;
+    .initial = 0;
+  }
+}
 
 acl purge_ip_whitelist {
   "37.26.93.252";     # Skyscape mirrors
@@ -184,15 +207,21 @@ sub vcl_recv {
   set req.grace = 24h;
 
   # Default backend.
-  if (req.restarts < 1) {
+  if (req.restarts == 0) {
     set req.http.original-url = req.url;
     set req.backend = F_origin;
     set req.http.Fastly-Backend-Name = "origin";
   }
 
-  
-  # Common config when failover to mirror buckets
+  # Serve stale if it exists.
   if (req.restarts > 0) {
+    set req.backend = sick_force_grace;
+    set req.http.Fastly-Backend-Name = "stale";
+  }
+
+  
+  # Failover to mirror buckets
+  if (req.restarts > 1) {
     set req.url = req.http.original-url;
 
     # Don't serve from stale for mirrors
@@ -211,39 +240,32 @@ sub vcl_recv {
     if (req.url !~ "^([^#\?\s]+)\.(atom|chm|css|csv|diff|doc|docx|dot|dxf|eps|gif|gml|html|ico|ics|jpeg|jpg|JPG|js|json|kml|odp|ods|odt|pdf|PDF|png|ppt|pptx|ps|rdf|rtf|sch|txt|wsdl|xls|xlsm|xlsx|xlt|xml|xsd|xslt|zip)([\?#]+.*)?$") {
       set req.url = regsub(req.url, "^([^#\?\s]+)([\?#]+.*)?$", "\1.html\2");
     }
-  }
 
-  # Failover to primary s3 mirror.
-  if (req.restarts == 1) {
-      set req.backend = F_mirrorS3;
+    # get healthy mirror from fallback director
+    set req.backend = mirrors_director;
+
+    if (req.backend == F_mirrorS3){
       set req.http.host = "bar";
       set req.http.Fastly-Backend-Name = "mirrorS3";
 
       # Add bucket directory prefix to all the requests
       set req.url = "/foo_" req.url;
-  }
+    } else if (req.backend == F_mirrorS3Replica){
+      set req.http.host = "s3-mirror-replica.aws.com";
+      set req.http.Fastly-Backend-Name = "mirrorS3Replica";
 
-  # Failover to replica s3 mirror.
-  if (req.restarts == 2) {
-    set req.backend = F_mirrorS3Replica;
-    set req.http.host = "s3-mirror-replica.aws.com";
-    set req.http.Fastly-Backend-Name = "mirrorS3Replica";
+      # Add bucket directory prefix to all the requests
+      set req.url = "/s3-mirror-replica" req.url;
+    } else {
+      set req.http.host = "gcs-mirror.google.com";
+      set req.http.Fastly-Backend-Name = "mirrorGCS";
 
-    # Add bucket directory prefix to all the requests
-    set req.url = "/s3-mirror-replica" req.url;
-  }
+      # Add bucket directory prefix to all the requests
+      set req.url = "/gcs-mirror" req.url;
 
-  # Failover to GCS mirror.
-  if (req.restarts > 2) {
-    set req.backend = F_mirrorGCS;
-    set req.http.host = "gcs-mirror.google.com";
-    set req.http.Fastly-Backend-Name = "mirrorGCS";
-
-    # Add bucket directory prefix to all the requests
-    set req.url = "/gcs-mirror" req.url;
-
-    set req.http.Date = now;
-    set req.http.Authorization = "AWS gcs-mirror-access-id:" digest.hmac_sha1_base64("gcs-mirror-secret-key", "GET" LF LF LF now LF "/gcs-bucket" req.url.path);
+      set req.http.Date = now;
+      set req.http.Authorization = "AWS gcs-mirror-access-id:" digest.hmac_sha1_base64("gcs-mirror-secret-key", "GET" LF LF LF now LF "/gcs-bucket" req.url.path);
+    }
   }
   
 
@@ -373,13 +395,6 @@ sub vcl_fetch {
 
   if ((beresp.status >= 500 && beresp.status <= 599) && req.restarts < 3 && (req.request == "GET" || req.request == "HEAD") && !beresp.http.No-Fallback) {
     set beresp.saintmode = 5s;
-
-    if (stale.exists) {
-     set req.http.Fastly-Backend-Name = "stale";
-     set beresp.http.Fastly-Backend-Name = "stale";
-     return(deliver_stale);
-    }
-
     return (restart);
   }
 
@@ -527,9 +542,8 @@ sub vcl_error {
   
 
   # Assume we've hit vcl_error() because the backend is unavailable
-  # for the first 3 retries: origin, mirrorS3, mirrorS3Replica.
-  # By restarting, vcl_recv() will try serving from stale before
-  # failing over to the mirrors.
+  # for the first two retries. By restarting, vcl_recv() will try
+  # serving from stale before failing over to the mirrors.
   if (req.restarts < 3) {
     return (restart);
   }

--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -375,6 +375,7 @@ sub vcl_fetch {
     set beresp.saintmode = 5s;
 
     if ((req.restarts == 0) && stale.exists ) {
+     set req.http.Fastly-Backend-Name = "stale"
      set beresp.http.Fastly-Backend-Name = "stale";
      return(deliver_stale);
     }

--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -374,8 +374,8 @@ sub vcl_fetch {
   if ((beresp.status >= 500 && beresp.status <= 599) && req.restarts < 3 && (req.request == "GET" || req.request == "HEAD") && !beresp.http.No-Fallback) {
     set beresp.saintmode = 5s;
 
-    if req.restarts == 0 && stale.exists {
-     set beresp.http.Fastly-Backend-Name = "stale"
+    if ((req.restarts == 0) && stale.exists ) {
+     set beresp.http.Fastly-Backend-Name = "stale";
      return(deliver_stale);
     }
 

--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -388,7 +388,7 @@ sub vcl_fetch {
 
   set beresp.http.Fastly-Backend-Name = req.http.Fastly-Backend-Name;
 
-  if ((beresp.status >= 500 && beresp.status <= 599) && req.restarts < 3 && (req.request == "GET" || req.request == "HEAD") && !beresp.http.No-Fallback) {
+  if ((beresp.status >= 500 && beresp.status <= 599) && req.restarts < 4 && (req.request == "GET" || req.request == "HEAD") && !beresp.http.No-Fallback) {
     set beresp.saintmode = 5s;
     return (restart);
   }

--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -126,29 +126,6 @@ backend F_mirrorGCS {
     }
 }
 
-director mirrors_director fallback {
-  {
-    .backend = F_mirrorS3;
-  }{
-    .backend = F_mirrorS3Replica;
-  }{
-    .backend = F_mirrorGCS;
-  }
-}
-
-
-# This backend is permanently sick on purpose so that the vcl_error
-# can use this backend to force serving stale objects if the origin
-# is sick, see: https://book.varnish-software.com/3.0/Saving_a_request.html
-backend sick_force_grace {
-  .host = "127.0.0.1";
-  .port = "1";
-  .probe = {
-    .request = "invalid";
-    .interval = 365d;
-    .initial = 0;
-  }
-}
 
 acl purge_ip_whitelist {
   "37.26.93.252";     # Skyscape mirrors
@@ -206,22 +183,15 @@ sub vcl_recv {
   # Serve from stale for 24 hours if origin is sick
   set req.grace = 24h;
 
-  # Default backend.
-  if (req.restarts == 0) {
-    set req.http.original-url = req.url;
-    set req.backend = F_origin;
-    set req.http.Fastly-Backend-Name = "origin";
-  }
-
-  # Serve stale if it exists.
-  if (req.restarts > 0) {
-    set req.backend = sick_force_grace;
-    set req.http.Fastly-Backend-Name = "stale";
-  }
+  # Default backend, these details will be overwritten if other backends are
+  # chosen
+  set req.http.original-url = req.url;
+  set req.backend = F_origin;
+  set req.http.Fastly-Backend-Name = "origin";
 
   
-  # Failover to mirror buckets
-  if (req.restarts > 1) {
+  # Common config when failover to mirror buckets
+  if (req.restarts > 0) {
     set req.url = req.http.original-url;
 
     # Don't serve from stale for mirrors
@@ -240,32 +210,39 @@ sub vcl_recv {
     if (req.url !~ "^([^#\?\s]+)\.(atom|chm|css|csv|diff|doc|docx|dot|dxf|eps|gif|gml|html|ico|ics|jpeg|jpg|JPG|js|json|kml|odp|ods|odt|pdf|PDF|png|ppt|pptx|ps|rdf|rtf|sch|txt|wsdl|xls|xlsm|xlsx|xlt|xml|xsd|xslt|zip)([\?#]+.*)?$") {
       set req.url = regsub(req.url, "^([^#\?\s]+)([\?#]+.*)?$", "\1.html\2");
     }
+  }
 
-    # get healthy mirror from fallback director
-    set req.backend = mirrors_director;
-
-    if (req.backend == F_mirrorS3){
+  # Failover to primary s3 mirror.
+  if (req.restarts == 1) {
+      set req.backend = F_mirrorS3;
       set req.http.host = "bar";
       set req.http.Fastly-Backend-Name = "mirrorS3";
 
       # Add bucket directory prefix to all the requests
       set req.url = "/foo_" req.url;
-    } else if (req.backend == F_mirrorS3Replica){
-      set req.http.host = "s3-mirror-replica.aws.com";
-      set req.http.Fastly-Backend-Name = "mirrorS3Replica";
+  }
 
-      # Add bucket directory prefix to all the requests
-      set req.url = "/s3-mirror-replica" req.url;
-    } else {
-      set req.http.host = "gcs-mirror.google.com";
-      set req.http.Fastly-Backend-Name = "mirrorGCS";
+  # Failover to replica s3 mirror.
+  if (req.restarts == 2) {
+    set req.backend = F_mirrorS3Replica;
+    set req.http.host = "s3-mirror-replica.aws.com";
+    set req.http.Fastly-Backend-Name = "mirrorS3Replica";
 
-      # Add bucket directory prefix to all the requests
-      set req.url = "/gcs-mirror" req.url;
+    # Add bucket directory prefix to all the requests
+    set req.url = "/s3-mirror-replica" req.url;
+  }
 
-      set req.http.Date = now;
-      set req.http.Authorization = "AWS gcs-mirror-access-id:" digest.hmac_sha1_base64("gcs-mirror-secret-key", "GET" LF LF LF now LF "/gcs-bucket" req.url.path);
-    }
+  # Failover to GCS mirror.
+  if (req.restarts > 2) {
+    set req.backend = F_mirrorGCS;
+    set req.http.host = "gcs-mirror.google.com";
+    set req.http.Fastly-Backend-Name = "mirrorGCS";
+
+    # Add bucket directory prefix to all the requests
+    set req.url = "/gcs-mirror" req.url;
+
+    set req.http.Date = now;
+    set req.http.Authorization = "AWS gcs-mirror-access-id:" digest.hmac_sha1_base64("gcs-mirror-secret-key", "GET" LF LF LF now LF "/gcs-bucket" req.url.path);
   }
   
 
@@ -540,6 +517,17 @@ sub vcl_error {
   }
 
   
+
+  # Serve stale from error subroutine as recommended in:
+  # https://docs.fastly.com/guides/performance-tuning/serving-stale-content
+  # The use of `req.restarts == 0` condition is to enforce the restriction
+  # of serving stale only when the backend is the origin.
+  if (req.restarts == 0) && (obj.status >= 500 && obj.status < 600) {
+    /* deliver stale object if it is available */
+    if (stale.exists) {
+      return(deliver_stale);
+    }
+  }
 
   # Assume we've hit vcl_error() because the backend is unavailable
   # for the first two retries. By restarting, vcl_recv() will try

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -383,7 +383,7 @@ sub vcl_fetch {
   if ((beresp.status >= 500 && beresp.status <= 599) && req.restarts < 3 && (req.request == "GET" || req.request == "HEAD") && !beresp.http.No-Fallback) {
     set beresp.saintmode = 5s;
 
-    if ((req.restarts == 0) && stale.exists ) {
+    if (stale.exists) {
      set req.http.Fastly-Backend-Name = "stale";
      set beresp.http.Fastly-Backend-Name = "stale";
      return(deliver_stale);

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -127,17 +127,6 @@ backend F_mirrorGCS {
 }
 
 
-backend sick_force_grace {
-  .host = "127.0.0.1";
-  .port = "1";
-  .probe = {
-    .request = "invalid";
-    .interval = 365d;
-    .initial = 0;
-  }
-}
-
-
 acl purge_ip_whitelist {
   "37.26.93.252";     # Skyscape mirrors
   "31.210.241.100";   # Carrenza mirrors
@@ -210,15 +199,9 @@ sub vcl_recv {
     set req.http.Fastly-Backend-Name = "origin";
   }
 
-  # Serve stale if it exists.
-  if (req.restarts > 0) {
-    set req.backend = sick_force_grace;
-    set req.http.Fastly-Backend-Name = "stale";
-  }
-
   
   # Common config when failover to mirror buckets
-  if (req.restarts > 1) {
+  if (req.restarts > 0) {
     set req.url = req.http.original-url;
 
     # Don't serve from stale for mirrors
@@ -240,7 +223,7 @@ sub vcl_recv {
   }
 
   # Failover to primary s3 mirror.
-  if (req.restarts == 2) {
+  if (req.restarts == 1) {
       set req.backend = F_mirrorS3;
       set req.http.host = "bar";
       set req.http.Fastly-Backend-Name = "mirrorS3";
@@ -250,7 +233,7 @@ sub vcl_recv {
   }
 
   # Failover to replica s3 mirror.
-  if (req.restarts == 3) {
+  if (req.restarts == 2) {
     set req.backend = F_mirrorS3Replica;
     set req.http.host = "s3-mirror-replica.aws.com";
     set req.http.Fastly-Backend-Name = "mirrorS3Replica";
@@ -260,7 +243,7 @@ sub vcl_recv {
   }
 
   # Failover to GCS mirror.
-  if (req.restarts > 3) {
+  if (req.restarts > 2) {
     set req.backend = F_mirrorGCS;
     set req.http.host = "gcs-mirror.google.com";
     set req.http.Fastly-Backend-Name = "mirrorGCS";
@@ -397,8 +380,14 @@ sub vcl_fetch {
 
   set beresp.http.Fastly-Backend-Name = req.http.Fastly-Backend-Name;
 
-  if ((beresp.status >= 500 && beresp.status <= 599) && req.restarts < 4 && (req.request == "GET" || req.request == "HEAD") && !beresp.http.No-Fallback) {
+  if ((beresp.status >= 500 && beresp.status <= 599) && req.restarts < 3 && (req.request == "GET" || req.request == "HEAD") && !beresp.http.No-Fallback) {
     set beresp.saintmode = 5s;
+
+    if req.restarts == 0 && stale.exists {
+     set beresp.http.Fastly-Backend-Name = "stale"
+     return(deliver_stale);
+    }
+
     return (restart);
   }
 
@@ -549,7 +538,7 @@ sub vcl_error {
   # for the first 3 retries: origin, mirrorS3, mirrorS3Replica.
   # By restarting, vcl_recv() will try serving from stale before
   # failing over to the mirrors.
-  if (req.restarts < 4) {
+  if (req.restarts < 3) {
     return (restart);
   }
 

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -384,7 +384,7 @@ sub vcl_fetch {
     set beresp.saintmode = 5s;
 
     if ((req.restarts == 0) && stale.exists ) {
-     set req.http.Fastly-Backend-Name = "stale"
+     set req.http.Fastly-Backend-Name = "stale";
      set beresp.http.Fastly-Backend-Name = "stale";
      return(deliver_stale);
     }

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -197,12 +197,13 @@ sub vcl_recv {
   set req.backend = F_origin;
   set req.http.Fastly-Backend-Name = "origin";
 
+  
+
   # Save original request url because req.url changes after restarts.
   if (req.restarts < 1) {
     set req.http.original-url = req.url;
   }
 
-  
   # Common config when failover to mirror buckets
   if (req.restarts > 0) {
     set req.url = req.http.original-url;

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -28,37 +28,8 @@ backend F_origin {
         .interval = 10s;
     }
 }
-# Mirror backend for provider 0
-backend F_mirror1 {
-    .connect_timeout = 1s;
-    .dynamic = true;
-    .port = "443";
-    .host = "foo";
-    .first_byte_timeout = 15s;
-    .max_connections = 200;
-    .between_bytes_timeout = 10s;
-    .share_key = "123";
 
-    .ssl = true;
-    .ssl_check_cert = always;
-    .min_tls_version = "1.2";
-    .ssl_cert_hostname = "foo";
-    .ssl_sni_hostname = "foo";
 
-    .probe = {
-        .request =
-            "HEAD / HTTP/1.1"
-            "Host: foo"
-            "User-Agent: Fastly healthcheck (git version: )"
-            "Connection: close";
-        .threshold = 1;
-        .window = 2;
-        .timeout = 5s;
-        .initial = 1;
-        .expected_response = 200;
-        .interval = 10s;
-    }
-}
 # Mirror backend for S3
 backend F_mirrorS3 {
     .connect_timeout = 1s;
@@ -90,6 +61,71 @@ backend F_mirrorS3 {
         .interval = 10s;
     }
 }
+
+# Mirror backend for S3 replica
+backend F_mirrorS3Replica {
+    .connect_timeout = 1s;
+    .dynamic = true;
+    .port = "443";
+    .host = "s3-mirror-replica.aws.com";
+    .first_byte_timeout = 15s;
+    .max_connections = 200;
+    .between_bytes_timeout = 10s;
+    .share_key = "123";
+
+    .ssl = true;
+    .ssl_check_cert = always;
+    .min_tls_version = "1.2";
+    .ssl_cert_hostname = "s3-mirror-replica.aws.com";
+    .ssl_sni_hostname = "s3-mirror-replica.aws.com";
+
+    .probe = {
+        .request =
+            "HEAD / HTTP/1.1"
+            "Host: s3-mirror-replica.aws.com"
+            "User-Agent: Fastly healthcheck (git version: )"
+            "Connection: close";
+        .threshold = 1;
+        .window = 2;
+        .timeout = 5s;
+        .initial = 1;
+        .expected_response = 200;
+        .interval = 10s;
+    }
+}
+
+# Mirror backend for GCS
+backend F_mirrorGCS {
+    .connect_timeout = 1s;
+    .dynamic = true;
+    .port = "443";
+    .host = "gcs-mirror.google.com";
+    .first_byte_timeout = 15s;
+    .max_connections = 200;
+    .between_bytes_timeout = 10s;
+    .share_key = "123";
+
+    .ssl = true;
+    .ssl_check_cert = always;
+    .min_tls_version = "1.2";
+    .ssl_cert_hostname = "gcs-mirror.google.com";
+    .ssl_sni_hostname = "gcs-mirror.google.com";
+
+    .probe = {
+        .request =
+            "HEAD / HTTP/1.1"
+            "Host: gcs-mirror.google.com"
+            "User-Agent: Fastly healthcheck (git version: )"
+            "Connection: close";
+        .threshold = 1;
+        .window = 2;
+        .timeout = 5s;
+        .initial = 1;
+        .expected_response = 403;
+        .interval = 10s;
+    }
+}
+
 
 backend sick_force_grace {
   .host = "127.0.0.1";
@@ -168,8 +204,11 @@ sub vcl_recv {
   set req.grace = 24h;
 
   # Default backend.
-  set req.backend = F_origin;
-  set req.http.Fastly-Backend-Name = "origin";
+  if (req.restarts < 1) {
+    set req.http.original-url = req.url;
+    set req.backend = F_origin;
+    set req.http.Fastly-Backend-Name = "origin";
+  }
 
   # Serve stale if it exists.
   if (req.restarts > 0) {
@@ -177,22 +216,14 @@ sub vcl_recv {
     set req.http.Fastly-Backend-Name = "stale";
   }
 
-  # Failover to mirror.
+  
+  # Common config when failover to mirror buckets
   if (req.restarts > 1) {
+    set req.url = req.http.original-url;
+
     # Don't serve from stale for mirrors
     set req.grace = 0s;
     set req.http.Fastly-Failover = "1";
-
-    set req.backend = F_mirror1;
-    set req.http.host = "foo";
-    set req.http.Fastly-Backend-Name = "mirror1";
-  }
-
-  # FIXME: Prefer a fallback director if we move to Varnish 3
-  if (req.restarts > 2) {
-    set req.backend = F_mirrorS3;
-    set req.http.host = "bar";
-    set req.http.Fastly-Backend-Name = "mirrorS3";
 
     # Requests to home page, rewrite to index.html
     if (req.url ~ "^/?([\?#].*)?$") {
@@ -206,9 +237,41 @@ sub vcl_recv {
     if (req.url !~ "^([^#\?\s]+)\.(atom|chm|css|csv|diff|doc|docx|dot|dxf|eps|gif|gml|html|ico|ics|jpeg|jpg|JPG|js|json|kml|odp|ods|odt|pdf|PDF|png|ppt|pptx|ps|rdf|rtf|sch|txt|wsdl|xls|xlsm|xlsx|xlt|xml|xsd|xslt|zip)([\?#]+.*)?$") {
       set req.url = regsub(req.url, "^([^#\?\s]+)([\?#]+.*)?$", "\1.html\2");
     }
-    # Add bucket directory prefix to all the requests
-    set req.url = "/foo_" req.url;
   }
+
+  # Failover to primary s3 mirror.
+  if (req.restarts == 2) {
+      set req.backend = F_mirrorS3;
+      set req.http.host = "bar";
+      set req.http.Fastly-Backend-Name = "mirrorS3";
+
+      # Add bucket directory prefix to all the requests
+      set req.url = "/foo_" req.url;
+  }
+
+  # Failover to replica s3 mirror.
+  if (req.restarts == 3) {
+    set req.backend = F_mirrorS3Replica;
+    set req.http.host = "s3-mirror-replica.aws.com";
+    set req.http.Fastly-Backend-Name = "mirrorS3Replica";
+
+    # Add bucket directory prefix to all the requests
+    set req.url = "/s3-mirror-replica" req.url;
+  }
+
+  # Failover to GCS mirror.
+  if (req.restarts > 3) {
+    set req.backend = F_mirrorGCS;
+    set req.http.host = "gcs-mirror.google.com";
+    set req.http.Fastly-Backend-Name = "mirrorGCS";
+
+    # Add bucket directory prefix to all the requests
+    set req.url = "/gcs-mirror" req.url;
+
+    set req.http.Date = now;
+    set req.http.Authorization = "AWS gcs-mirror-access-id:" digest.hmac_sha1_base64("gcs-mirror-secret-key", "GET" LF LF LF now LF "/gcs-bucket" req.url.path);
+  }
+  
 
   # Unspoofable original client address.
   set req.http.True-Client-IP = req.http.Fastly-Client-IP;

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -531,7 +531,7 @@ sub vcl_error {
   # https://docs.fastly.com/guides/performance-tuning/serving-stale-content
   # The use of `req.restarts == 0` condition is to enforce the restriction
   # of serving stale only when the backend is the origin.
-  if (req.restarts == 0) && (obj.status >= 500 && obj.status < 600) {
+  if ((req.restarts == 0) && (obj.status >= 500 && obj.status < 600)) {
     /* deliver stale object if it is available */
     if (stale.exists) {
       return(deliver_stale);

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -383,8 +383,8 @@ sub vcl_fetch {
   if ((beresp.status >= 500 && beresp.status <= 599) && req.restarts < 3 && (req.request == "GET" || req.request == "HEAD") && !beresp.http.No-Fallback) {
     set beresp.saintmode = 5s;
 
-    if req.restarts == 0 && stale.exists {
-     set beresp.http.Fastly-Backend-Name = "stale"
+    if ((req.restarts == 0) && stale.exists ) {
+     set beresp.http.Fastly-Backend-Name = "stale";
      return(deliver_stale);
     }
 

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -397,7 +397,7 @@ sub vcl_fetch {
 
   set beresp.http.Fastly-Backend-Name = req.http.Fastly-Backend-Name;
 
-  if ((beresp.status >= 500 && beresp.status <= 599) && req.restarts < 3 && (req.request == "GET" || req.request == "HEAD") && !beresp.http.No-Fallback) {
+  if ((beresp.status >= 500 && beresp.status <= 599) && req.restarts < 4 && (req.request == "GET" || req.request == "HEAD") && !beresp.http.No-Fallback) {
     set beresp.saintmode = 5s;
     return (restart);
   }

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -428,7 +428,7 @@ sub vcl_fetch {
   # a 301 status code. All errors from the mirrors are set to 503 as they
   # cannot know whether or not a page actually exists (e.g. /search is a valid
   # URL but the mirror cannot return it).
-  if (beresp.status != 200 && beresp.http.Fastly-Backend-Name ~ "mirror") {
+  if (beresp.status != 200 && beresp.http.Fastly-Backend-Name ~ "^mirror") {
     set beresp.status = 503;
   }
 
@@ -436,7 +436,7 @@ sub vcl_fetch {
     set req.http.Fastly-Cachetype = "ERROR";
     set beresp.ttl = 1s;
     set beresp.grace = 5s;
-    if (beresp.http.Fastly-Backend-Name ~ "mirrorS3") {
+    if (beresp.http.Fastly-Backend-Name ~ "^mirror") {
       error 503 "Error page";
     }
     return (deliver);
@@ -448,8 +448,8 @@ sub vcl_fetch {
     # apply the default ttl
     set beresp.ttl = 5000s;
 
-    # S3 does not set cache headers by default. Override TTL and add cache-control with 15 minutes
-    if (beresp.http.Fastly-Backend-Name ~ "mirrorS3") {
+    # Mirror buckets do not set cache headers by default. Override TTL and add cache-control with 15 minutes
+    if (beresp.http.Fastly-Backend-Name ~ "^mirror") {
       set beresp.ttl = 900s;
       set beresp.http.Cache-Control = "max-age=900";
     }

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -384,6 +384,7 @@ sub vcl_fetch {
     set beresp.saintmode = 5s;
 
     if ((req.restarts == 0) && stale.exists ) {
+     set req.http.Fastly-Backend-Name = "stale"
      set beresp.http.Fastly-Backend-Name = "stale";
      return(deliver_stale);
     }

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -194,9 +194,13 @@ sub vcl_recv {
 
   # Default backend, these details will be overwritten if other backends are
   # chosen
-  set req.http.original-url = req.url;
   set req.backend = F_origin;
   set req.http.Fastly-Backend-Name = "origin";
+
+  # Save original request url because req.url changes after restarts.
+  if (req.restarts < 1) {
+    set req.http.original-url = req.url;
+  }
 
   
   # Common config when failover to mirror buckets

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -546,9 +546,10 @@ sub vcl_error {
   
 
   # Assume we've hit vcl_error() because the backend is unavailable
-  # for the first two retries. By restarting, vcl_recv() will try
-  # serving from stale before failing over to the mirrors.
-  if (req.restarts < 3) {
+  # for the first 3 retries: origin, mirrorS3, mirrorS3Replica.
+  # By restarting, vcl_recv() will try serving from stale before
+  # failing over to the mirrors.
+  if (req.restarts < 4) {
     return (restart);
   }
 

--- a/vcl_templates/assets.vcl.erb
+++ b/vcl_templates/assets.vcl.erb
@@ -71,40 +71,7 @@ backend F_awsorigin {
       }
 }
 
-# Mirror backend for provider 0
-backend F_mirror1 {
-    .connect_timeout = 1s;
-    .dynamic = true;
-    .port = "<%= config.fetch('provider1_mirror_port', 443) %>";
-    .host = "<%= config.fetch('provider1_mirror_hostname') %>";
-    .first_byte_timeout = 15s;
-    .max_connections = 200;
-    .between_bytes_timeout = 10s;
-    .share_key = "<%= config.fetch('service_id') %>";
-
-    .ssl = true;
-    .ssl_check_cert = <%= config['disable_tls_validation'] ? 'never' : 'always' %>;
-    .min_tls_version = "<%= config.fetch('min_tls_version', '1.2') %>";
-    <%- if config['ssl_ciphers'] -%>
-    .ssl_ciphers = "<%= config['ssl_ciphers'] -%>";
-    <%- end -%>
-    .ssl_cert_hostname = "<%= config.fetch('ssl_cert_hostname', config.fetch('provider1_mirror_hostname')) %>";
-    .ssl_sni_hostname = "<%= config.fetch('ssl_sni_hostname', config.fetch('provider1_mirror_hostname')) %>";
-
-    .probe = {
-        .request =
-            "HEAD /__canary__ HTTP/1.1"
-            "Host: <%= config.fetch('provider1_mirror_hostname') %>"
-            "User-Agent: Fastly healthcheck (git version: <%= config['git_version'] %>)"
-            "Connection: close";
-        .threshold = 1;
-        .window = 2;
-        .timeout = 5s;
-        .initial = 1;
-        .expected_response = 200;
-        .interval = 10s;
-    }
-}
+<% if %w(staging production).include?(environment) %>
 # Mirror backend for S3
 backend F_mirrorS3 {
     .connect_timeout = 1s;
@@ -140,16 +107,76 @@ backend F_mirrorS3 {
     }
 }
 
-backend sick_force_grace {
-  .host = "127.0.0.1";
-  .port = "1";
-  .probe = {
-    .request = "invalid";
-    .interval = 365d;
-    .initial = 0;
-  }
+# Mirror backend for S3 replica
+backend F_mirrorS3Replica {
+    .connect_timeout = 1s;
+    .dynamic = true;
+    .port = "<%= config.fetch('s3_mirror_replica_port', 443) %>";
+    .host = "<%= config.fetch('s3_mirror_replica_hostname') %>";
+    .first_byte_timeout = 15s;
+    .max_connections = 200;
+    .between_bytes_timeout = 10s;
+    .share_key = "<%= config.fetch('service_id') %>";
+
+    .ssl = true;
+    .ssl_check_cert = <%= config['disable_tls_validation'] ? 'never' : 'always' %>;
+    .min_tls_version = "<%= config.fetch('min_tls_version', '1.2') %>";
+    <%- if config['ssl_ciphers'] -%>
+    .ssl_ciphers = "<%= config['ssl_ciphers'] -%>";
+    <%- end -%>
+    .ssl_cert_hostname = "<%= config.fetch('ssl_cert_hostname', config.fetch('s3_mirror_replica_hostname')) %>";
+    .ssl_sni_hostname = "<%= config.fetch('ssl_sni_hostname', config.fetch('s3_mirror_replica_hostname')) %>";
+
+    .probe = {
+        .request =
+            "HEAD <%= config.fetch('s3_mirror_replica_probe_request', '/') %> HTTP/1.1"
+            "Host: <%= config.fetch('s3_mirror_replica_hostname') %>"
+            "User-Agent: Fastly healthcheck (git version: <%= config['git_version'] %>)"
+            "Connection: close";
+        .threshold = 1;
+        .window = 2;
+        .timeout = 5s;
+        .initial = 1;
+        .expected_response = 200;
+        .interval = 10s;
+    }
 }
 
+# Mirror backend for GCS
+backend F_mirrorGCS {
+    .connect_timeout = 1s;
+    .dynamic = true;
+    .port = "<%= config.fetch('gcs_mirror_port', 443) %>";
+    .host = "<%= config.fetch('gcs_mirror_hostname') %>";
+    .first_byte_timeout = 15s;
+    .max_connections = 200;
+    .between_bytes_timeout = 10s;
+    .share_key = "<%= config.fetch('service_id') %>";
+
+    .ssl = true;
+    .ssl_check_cert = <%= config['disable_tls_validation'] ? 'never' : 'always' %>;
+    .min_tls_version = "<%= config.fetch('min_tls_version', '1.2') %>";
+    <%- if config['ssl_ciphers'] -%>
+    .ssl_ciphers = "<%= config['ssl_ciphers'] -%>";
+    <%- end -%>
+    .ssl_cert_hostname = "<%= config.fetch('ssl_cert_hostname', config.fetch('gcs_mirror_hostname')) %>";
+    .ssl_sni_hostname = "<%= config.fetch('ssl_sni_hostname', config.fetch('gcs_mirror_hostname')) %>";
+
+    .probe = {
+        .request =
+            "HEAD <%= config.fetch('gcs_mirror_probe_request', '/') %> HTTP/1.1"
+            "Host: <%= config.fetch('gcs_mirror_hostname') %>"
+            "User-Agent: Fastly healthcheck (git version: <%= config['git_version'] %>)"
+            "Connection: close";
+        .threshold = 1;
+        .window = 2;
+        .timeout = 5s;
+        .initial = 1;
+        .expected_response = 403;
+        .interval = 10s;
+    }
+}
+<% end %>
 
 acl purge_ip_whitelist {
   "37.26.93.252";     # Skyscape mirrors
@@ -217,35 +244,58 @@ sub vcl_recv {
       set req.http.host = "<%= config.fetch('carrenza_origin_hostname') %>";
   }
 
-  # Serve stale if it exists.
-  if (req.restarts > 0) {
-    set req.backend = sick_force_grace;
-    set req.http.Fastly-Backend-Name = "stale";
+  <% if %w(staging production).include?(environment) %>
+
+  # Save original request url because req.url changes after restarts.
+  if (req.restarts < 1) {
+    set req.http.original-url = req.url;
   }
 
-  # Failover to mirror.
-  if (req.restarts > 1) {
+  # Common config when failover to mirror buckets
+  if (req.restarts > 0) {
+    set req.url = req.http.original-url;
+
     # Don't serve from stale for mirrors
     set req.grace = 0s;
     set req.http.Fastly-Failover = "1";
 
-    set req.backend = F_mirror1;
-    set req.http.Fastly-Backend-Name = "mirror1";
-    set req.http.host = "<%= config.fetch('provider1_mirror_hostname') %>";
-  }
-
-  # FIXME: Prefer a fallback director if we move to Varnish 3
-  if (req.restarts > 2) {
-    set req.backend = F_mirrorS3;
-    set req.http.host = "<%= config.fetch('s3_mirror_hostname') %>";
-    set req.http.Fastly-Backend-Name = "mirrorS3";
-
     # Replace multiple /
     set req.url = regsuball(req.url, "([^:])//+", "\1/");
-
-    # Rewrite adding bucket directory prefix
-    set req.url = "/<%= config.fetch('s3_mirror_prefix') %>" req.url;
   }
+
+  # Failover to primary s3 mirror.
+  if (req.restarts == 1) {
+      set req.backend = F_mirrorS3;
+      set req.http.host = "<%= config.fetch('s3_mirror_hostname') %>";
+      set req.http.Fastly-Backend-Name = "mirrorS3";
+
+      # Add bucket directory prefix to all the requests
+      set req.url = "/<%= config.fetch('s3_mirror_prefix') %>" req.url;
+  }
+
+  # Failover to replica s3 mirror.
+  if (req.restarts == 2) {
+    set req.backend = F_mirrorS3Replica;
+    set req.http.host = "<%= config.fetch('s3_mirror_replica_hostname') %>";
+    set req.http.Fastly-Backend-Name = "mirrorS3Replica";
+
+    # Add bucket directory prefix to all the requests
+    set req.url = "/<%= config.fetch('s3_mirror_replica_prefix') %>" req.url;
+  }
+
+  # Failover to GCS mirror.
+  if (req.restarts > 2) {
+    set req.backend = F_mirrorGCS;
+    set req.http.host = "<%= config.fetch('gcs_mirror_hostname') %>";
+    set req.http.Fastly-Backend-Name = "mirrorGCS";
+
+    # Add bucket directory prefix to all the requests
+    set req.url = "/<%= config.fetch('gcs_mirror_prefix') %>" req.url;
+
+    set req.http.Date = now;
+    set req.http.Authorization = "AWS <%= config.fetch('gcs_mirror_access_id') %>:" digest.hmac_sha1_base64("<%= config.fetch('gcs_mirror_secret_key') %>", "GET" LF LF LF now LF "/<%= config.fetch('gcs_mirror_bucket_name') %>" req.url.path);
+  }
+  <% end %>
 
   # Unspoofable original client address.
   set req.http.True-Client-IP = req.http.Fastly-Client-IP;
@@ -346,6 +396,17 @@ sub vcl_error {
     set obj.status = 200;
     synthetic {""};
     return(deliver);
+  }
+
+  # Serve stale from error subroutine as recommended in:
+  # https://docs.fastly.com/guides/performance-tuning/serving-stale-content
+  # The use of `req.restarts == 0` condition is to enforce the restriction
+  # of serving stale only when the backend is the origin.
+  if ((req.restarts == 0) && (obj.status >= 500 && obj.status < 600)) {
+    /* deliver stale object if it is available */
+    if (stale.exists) {
+      return(deliver_stale);
+    }
   }
 
   # Assume we've hit vcl_error() because the backend is unavailable

--- a/vcl_templates/mirror.vcl.erb
+++ b/vcl_templates/mirror.vcl.erb
@@ -305,7 +305,7 @@ sub vcl_fetch {
   # a 301 status code. All errors from the mirrors are set to 503 as they
   # cannot know whether or not a page actually exists (e.g. /search is a valid
   # URL but the mirror cannot return it).
-  if (beresp.status != 200 && beresp.http.Fastly-Backend-Name ~ "mirror") {
+  if (beresp.status != 200 && beresp.http.Fastly-Backend-Name ~ "^mirror") {
     set beresp.status = 503;
   }
 
@@ -313,7 +313,7 @@ sub vcl_fetch {
     set req.http.Fastly-Cachetype = "ERROR";
     set beresp.ttl = 1s;
     set beresp.grace = 5s;
-    if (beresp.http.Fastly-Backend-Name ~ "mirrorS3") {
+    if (beresp.http.Fastly-Backend-Name ~ "^mirror") {
       error 503 "Error page";
     }
     return (deliver);
@@ -325,8 +325,8 @@ sub vcl_fetch {
     # apply the default ttl
     set beresp.ttl = <%= config.fetch('default_ttl') %>s;
 
-    # S3 does not set cache headers by default. Override TTL and add cache-control with 15 minutes
-    if (beresp.http.Fastly-Backend-Name ~ "mirrorS3") {
+    # Mirror buckets do not set cache headers by default. Override TTL and add cache-control with 15 minutes
+    if (beresp.http.Fastly-Backend-Name ~ "^mirror") {
       set beresp.ttl = 900s;
       set beresp.http.Cache-Control = "max-age=900";
     }

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -479,7 +479,7 @@ sub vcl_error {
   # https://docs.fastly.com/guides/performance-tuning/serving-stale-content
   # The use of `req.restarts == 0` condition is to enforce the restriction
   # of serving stale only when the backend is the origin.
-  if (req.restarts == 0) && (obj.status >= 500 && obj.status < 600) {
+  if ((req.restarts == 0) && (obj.status >= 500 && obj.status < 600)) {
     /* deliver stale object if it is available */
     if (stale.exists) {
       return(deliver_stale);

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -324,7 +324,7 @@ sub vcl_fetch {
     set beresp.saintmode = 5s;
 
     if ((req.restarts == 0) && stale.exists ) {
-     set req.http.Fastly-Backend-Name = "stale"
+     set req.http.Fastly-Backend-Name = "stale";
      set beresp.http.Fastly-Backend-Name = "stale";
      return(deliver_stale);
     }

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -368,7 +368,7 @@ sub vcl_fetch {
   # a 301 status code. All errors from the mirrors are set to 503 as they
   # cannot know whether or not a page actually exists (e.g. /search is a valid
   # URL but the mirror cannot return it).
-  if (beresp.status != 200 && beresp.http.Fastly-Backend-Name ~ "mirror") {
+  if (beresp.status != 200 && beresp.http.Fastly-Backend-Name ~ "^mirror") {
     set beresp.status = 503;
   }
 
@@ -376,7 +376,7 @@ sub vcl_fetch {
     set req.http.Fastly-Cachetype = "ERROR";
     set beresp.ttl = 1s;
     set beresp.grace = 5s;
-    if (beresp.http.Fastly-Backend-Name ~ "mirrorS3") {
+    if (beresp.http.Fastly-Backend-Name ~ "^mirror") {
       error 503 "Error page";
     }
     return (deliver);
@@ -388,8 +388,8 @@ sub vcl_fetch {
     # apply the default ttl
     set beresp.ttl = <%= config.fetch('default_ttl') %>s;
 
-    # S3 does not set cache headers by default. Override TTL and add cache-control with 15 minutes
-    if (beresp.http.Fastly-Backend-Name ~ "mirrorS3") {
+    # Mirror buckets do not set cache headers by default. Override TTL and add cache-control with 15 minutes
+    if (beresp.http.Fastly-Backend-Name ~ "^mirror") {
       set beresp.ttl = 900s;
       set beresp.http.Cache-Control = "max-age=900";
     }

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -143,7 +143,30 @@ backend F_mirrorGCS {
         .interval = 10s;
     }
 }
+
+director mirrors_director fallback {
+  {
+    .backend = F_mirrorS3;
+  }{
+    .backend = F_mirrorS3Replica;
+  }{
+    .backend = F_mirrorGCS;
+  }
+}
 <% end %>
+
+# This backend is permanently sick on purpose so that the vcl_error
+# can use this backend to force serving stale objects if the origin
+# is sick, see: https://book.varnish-software.com/3.0/Saving_a_request.html
+backend sick_force_grace {
+  .host = "127.0.0.1";
+  .port = "1";
+  .probe = {
+    .request = "invalid";
+    .interval = 365d;
+    .initial = 0;
+  }
+}
 
 acl purge_ip_whitelist {
   "37.26.93.252";     # Skyscape mirrors
@@ -225,15 +248,21 @@ sub vcl_recv {
   set req.grace = 24h;
 
   # Default backend.
-  if (req.restarts < 1) {
+  if (req.restarts == 0) {
     set req.http.original-url = req.url;
     set req.backend = F_origin;
     set req.http.Fastly-Backend-Name = "origin";
   }
 
-  <% if %w(staging production).include?(environment) %>
-  # Common config when failover to mirror buckets
+  # Serve stale if it exists.
   if (req.restarts > 0) {
+    set req.backend = sick_force_grace;
+    set req.http.Fastly-Backend-Name = "stale";
+  }
+
+  <% if %w(staging production).include?(environment) %>
+  # Failover to mirror buckets
+  if (req.restarts > 1) {
     set req.url = req.http.original-url;
 
     # Don't serve from stale for mirrors
@@ -252,39 +281,32 @@ sub vcl_recv {
     if (req.url !~ "^([^#\?\s]+)\.(atom|chm|css|csv|diff|doc|docx|dot|dxf|eps|gif|gml|html|ico|ics|jpeg|jpg|JPG|js|json|kml|odp|ods|odt|pdf|PDF|png|ppt|pptx|ps|rdf|rtf|sch|txt|wsdl|xls|xlsm|xlsx|xlt|xml|xsd|xslt|zip)([\?#]+.*)?$") {
       set req.url = regsub(req.url, "^([^#\?\s]+)([\?#]+.*)?$", "\1.html\2");
     }
-  }
 
-  # Failover to primary s3 mirror.
-  if (req.restarts == 1) {
-      set req.backend = F_mirrorS3;
+    # get healthy mirror from fallback director
+    set req.backend = mirrors_director;
+
+    if (req.backend == F_mirrorS3){
       set req.http.host = "<%= config.fetch('s3_mirror_hostname') %>";
       set req.http.Fastly-Backend-Name = "mirrorS3";
 
       # Add bucket directory prefix to all the requests
       set req.url = "/<%= config.fetch('s3_mirror_prefix') %>" req.url;
-  }
+    } else if (req.backend == F_mirrorS3Replica){
+      set req.http.host = "<%= config.fetch('s3_mirror_replica_hostname') %>";
+      set req.http.Fastly-Backend-Name = "mirrorS3Replica";
 
-  # Failover to replica s3 mirror.
-  if (req.restarts == 2) {
-    set req.backend = F_mirrorS3Replica;
-    set req.http.host = "<%= config.fetch('s3_mirror_replica_hostname') %>";
-    set req.http.Fastly-Backend-Name = "mirrorS3Replica";
+      # Add bucket directory prefix to all the requests
+      set req.url = "/<%= config.fetch('s3_mirror_replica_prefix') %>" req.url;
+    } else {
+      set req.http.host = "<%= config.fetch('gcs_mirror_hostname') %>";
+      set req.http.Fastly-Backend-Name = "mirrorGCS";
 
-    # Add bucket directory prefix to all the requests
-    set req.url = "/<%= config.fetch('s3_mirror_replica_prefix') %>" req.url;
-  }
+      # Add bucket directory prefix to all the requests
+      set req.url = "/<%= config.fetch('gcs_mirror_prefix') %>" req.url;
 
-  # Failover to GCS mirror.
-  if (req.restarts > 2) {
-    set req.backend = F_mirrorGCS;
-    set req.http.host = "<%= config.fetch('gcs_mirror_hostname') %>";
-    set req.http.Fastly-Backend-Name = "mirrorGCS";
-
-    # Add bucket directory prefix to all the requests
-    set req.url = "/<%= config.fetch('gcs_mirror_prefix') %>" req.url;
-
-    set req.http.Date = now;
-    set req.http.Authorization = "AWS <%= config.fetch('gcs_mirror_access_id') %>:" digest.hmac_sha1_base64("<%= config.fetch('gcs_mirror_secret_key') %>", "GET" LF LF LF now LF "/<%= config.fetch('gcs_mirror_bucket_name') %>" req.url.path);
+      set req.http.Date = now;
+      set req.http.Authorization = "AWS <%= config.fetch('gcs_mirror_access_id') %>:" digest.hmac_sha1_base64("<%= config.fetch('gcs_mirror_secret_key') %>", "GET" LF LF LF now LF "/<%= config.fetch('gcs_mirror_bucket_name') %>" req.url.path);
+    }
   }
   <% end %>
 
@@ -322,13 +344,6 @@ sub vcl_fetch {
 
   if ((beresp.status >= 500 && beresp.status <= 599) && req.restarts < 3 && (req.request == "GET" || req.request == "HEAD") && !beresp.http.No-Fallback) {
     set beresp.saintmode = 5s;
-
-    if (stale.exists) {
-     set req.http.Fastly-Backend-Name = "stale";
-     set beresp.http.Fastly-Backend-Name = "stale";
-     return(deliver_stale);
-    }
-
     return (restart);
   }
 
@@ -484,9 +499,8 @@ sub vcl_error {
   <% end %>
 
   # Assume we've hit vcl_error() because the backend is unavailable
-  # for the first 3 retries: origin, mirrorS3, mirrorS3Replica.
-  # By restarting, vcl_recv() will try serving from stale before
-  # failing over to the mirrors.
+  # for the first two retries. By restarting, vcl_recv() will try
+  # serving from stale before failing over to the mirrors.
   if (req.restarts < 3) {
     return (restart);
   }

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -324,7 +324,7 @@ sub vcl_fetch {
     set beresp.saintmode = 5s;
 
     if ((req.restarts == 0) && stale.exists ) {
-     set beresp.http.Fastly-Backend-Name = "stale"
+     set beresp.http.Fastly-Backend-Name = "stale";
      return(deliver_stale);
     }
 

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -323,7 +323,7 @@ sub vcl_fetch {
   if ((beresp.status >= 500 && beresp.status <= 599) && req.restarts < 3 && (req.request == "GET" || req.request == "HEAD") && !beresp.http.No-Fallback) {
     set beresp.saintmode = 5s;
 
-    if req.restarts == 0 && stale.exists {
+    if ((req.restarts == 0) && stale.exists ) {
      set beresp.http.Fastly-Backend-Name = "stale"
      return(deliver_stale);
     }

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -494,9 +494,10 @@ sub vcl_error {
   <% end %>
 
   # Assume we've hit vcl_error() because the backend is unavailable
-  # for the first two retries. By restarting, vcl_recv() will try
-  # serving from stale before failing over to the mirrors.
-  if (req.restarts < 3) {
+  # for the first 3 retries: origin, mirrorS3, mirrorS3Replica.
+  # By restarting, vcl_recv() will try serving from stale before
+  # failing over to the mirrors.
+  if (req.restarts < 4) {
     return (restart);
   }
 

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -323,7 +323,7 @@ sub vcl_fetch {
   if ((beresp.status >= 500 && beresp.status <= 599) && req.restarts < 3 && (req.request == "GET" || req.request == "HEAD") && !beresp.http.No-Fallback) {
     set beresp.saintmode = 5s;
 
-    if ((req.restarts == 0) && stale.exists ) {
+    if (stale.exists) {
      set req.http.Fastly-Backend-Name = "stale";
      set beresp.http.Fastly-Backend-Name = "stale";
      return(deliver_stale);

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -226,9 +226,13 @@ sub vcl_recv {
 
   # Default backend, these details will be overwritten if other backends are
   # chosen
-  set req.http.original-url = req.url;
   set req.backend = F_origin;
   set req.http.Fastly-Backend-Name = "origin";
+
+  # Save original request url because req.url changes after restarts.
+  if (req.restarts < 1) {
+    set req.http.original-url = req.url;
+  }
 
   <% if %w(staging production).include?(environment) %>
   # Common config when failover to mirror buckets

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -143,30 +143,7 @@ backend F_mirrorGCS {
         .interval = 10s;
     }
 }
-
-director mirrors_director fallback {
-  {
-    .backend = F_mirrorS3;
-  }{
-    .backend = F_mirrorS3Replica;
-  }{
-    .backend = F_mirrorGCS;
-  }
-}
 <% end %>
-
-# This backend is permanently sick on purpose so that the vcl_error
-# can use this backend to force serving stale objects if the origin
-# is sick, see: https://book.varnish-software.com/3.0/Saving_a_request.html
-backend sick_force_grace {
-  .host = "127.0.0.1";
-  .port = "1";
-  .probe = {
-    .request = "invalid";
-    .interval = 365d;
-    .initial = 0;
-  }
-}
 
 acl purge_ip_whitelist {
   "37.26.93.252";     # Skyscape mirrors
@@ -247,22 +224,15 @@ sub vcl_recv {
   # Serve from stale for 24 hours if origin is sick
   set req.grace = 24h;
 
-  # Default backend.
-  if (req.restarts == 0) {
-    set req.http.original-url = req.url;
-    set req.backend = F_origin;
-    set req.http.Fastly-Backend-Name = "origin";
-  }
-
-  # Serve stale if it exists.
-  if (req.restarts > 0) {
-    set req.backend = sick_force_grace;
-    set req.http.Fastly-Backend-Name = "stale";
-  }
+  # Default backend, these details will be overwritten if other backends are
+  # chosen
+  set req.http.original-url = req.url;
+  set req.backend = F_origin;
+  set req.http.Fastly-Backend-Name = "origin";
 
   <% if %w(staging production).include?(environment) %>
-  # Failover to mirror buckets
-  if (req.restarts > 1) {
+  # Common config when failover to mirror buckets
+  if (req.restarts > 0) {
     set req.url = req.http.original-url;
 
     # Don't serve from stale for mirrors
@@ -281,32 +251,39 @@ sub vcl_recv {
     if (req.url !~ "^([^#\?\s]+)\.(atom|chm|css|csv|diff|doc|docx|dot|dxf|eps|gif|gml|html|ico|ics|jpeg|jpg|JPG|js|json|kml|odp|ods|odt|pdf|PDF|png|ppt|pptx|ps|rdf|rtf|sch|txt|wsdl|xls|xlsm|xlsx|xlt|xml|xsd|xslt|zip)([\?#]+.*)?$") {
       set req.url = regsub(req.url, "^([^#\?\s]+)([\?#]+.*)?$", "\1.html\2");
     }
+  }
 
-    # get healthy mirror from fallback director
-    set req.backend = mirrors_director;
-
-    if (req.backend == F_mirrorS3){
+  # Failover to primary s3 mirror.
+  if (req.restarts == 1) {
+      set req.backend = F_mirrorS3;
       set req.http.host = "<%= config.fetch('s3_mirror_hostname') %>";
       set req.http.Fastly-Backend-Name = "mirrorS3";
 
       # Add bucket directory prefix to all the requests
       set req.url = "/<%= config.fetch('s3_mirror_prefix') %>" req.url;
-    } else if (req.backend == F_mirrorS3Replica){
-      set req.http.host = "<%= config.fetch('s3_mirror_replica_hostname') %>";
-      set req.http.Fastly-Backend-Name = "mirrorS3Replica";
+  }
 
-      # Add bucket directory prefix to all the requests
-      set req.url = "/<%= config.fetch('s3_mirror_replica_prefix') %>" req.url;
-    } else {
-      set req.http.host = "<%= config.fetch('gcs_mirror_hostname') %>";
-      set req.http.Fastly-Backend-Name = "mirrorGCS";
+  # Failover to replica s3 mirror.
+  if (req.restarts == 2) {
+    set req.backend = F_mirrorS3Replica;
+    set req.http.host = "<%= config.fetch('s3_mirror_replica_hostname') %>";
+    set req.http.Fastly-Backend-Name = "mirrorS3Replica";
 
-      # Add bucket directory prefix to all the requests
-      set req.url = "/<%= config.fetch('gcs_mirror_prefix') %>" req.url;
+    # Add bucket directory prefix to all the requests
+    set req.url = "/<%= config.fetch('s3_mirror_replica_prefix') %>" req.url;
+  }
 
-      set req.http.Date = now;
-      set req.http.Authorization = "AWS <%= config.fetch('gcs_mirror_access_id') %>:" digest.hmac_sha1_base64("<%= config.fetch('gcs_mirror_secret_key') %>", "GET" LF LF LF now LF "/<%= config.fetch('gcs_mirror_bucket_name') %>" req.url.path);
-    }
+  # Failover to GCS mirror.
+  if (req.restarts > 2) {
+    set req.backend = F_mirrorGCS;
+    set req.http.host = "<%= config.fetch('gcs_mirror_hostname') %>";
+    set req.http.Fastly-Backend-Name = "mirrorGCS";
+
+    # Add bucket directory prefix to all the requests
+    set req.url = "/<%= config.fetch('gcs_mirror_prefix') %>" req.url;
+
+    set req.http.Date = now;
+    set req.http.Authorization = "AWS <%= config.fetch('gcs_mirror_access_id') %>:" digest.hmac_sha1_base64("<%= config.fetch('gcs_mirror_secret_key') %>", "GET" LF LF LF now LF "/<%= config.fetch('gcs_mirror_bucket_name') %>" req.url.path);
   }
   <% end %>
 
@@ -497,6 +474,17 @@ sub vcl_error {
     return (deliver);
   }
   <% end %>
+
+  # Serve stale from error subroutine as recommended in:
+  # https://docs.fastly.com/guides/performance-tuning/serving-stale-content
+  # The use of `req.restarts == 0` condition is to enforce the restriction
+  # of serving stale only when the backend is the origin.
+  if (req.restarts == 0) && (obj.status >= 500 && obj.status < 600) {
+    /* deliver stale object if it is available */
+    if (stale.exists) {
+      return(deliver_stale);
+    }
+  }
 
   # Assume we've hit vcl_error() because the backend is unavailable
   # for the first two retries. By restarting, vcl_recv() will try

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -229,12 +229,13 @@ sub vcl_recv {
   set req.backend = F_origin;
   set req.http.Fastly-Backend-Name = "origin";
 
+  <% if %w(staging production).include?(environment) %>
+
   # Save original request url because req.url changes after restarts.
   if (req.restarts < 1) {
     set req.http.original-url = req.url;
   }
 
-  <% if %w(staging production).include?(environment) %>
   # Common config when failover to mirror buckets
   if (req.restarts > 0) {
     set req.url = req.http.original-url;

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -337,7 +337,7 @@ sub vcl_fetch {
 
   set beresp.http.Fastly-Backend-Name = req.http.Fastly-Backend-Name;
 
-  if ((beresp.status >= 500 && beresp.status <= 599) && req.restarts < 3 && (req.request == "GET" || req.request == "HEAD") && !beresp.http.No-Fallback) {
+  if ((beresp.status >= 500 && beresp.status <= 599) && req.restarts < 4 && (req.request == "GET" || req.request == "HEAD") && !beresp.http.No-Fallback) {
     set beresp.saintmode = 5s;
     return (restart);
   }

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -324,6 +324,7 @@ sub vcl_fetch {
     set beresp.saintmode = 5s;
 
     if ((req.restarts == 0) && stale.exists ) {
+     set req.http.Fastly-Backend-Name = "stale"
      set beresp.http.Fastly-Backend-Name = "stale";
      return(deliver_stale);
     }

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -145,17 +145,6 @@ backend F_mirrorGCS {
 }
 <% end %>
 
-backend sick_force_grace {
-  .host = "127.0.0.1";
-  .port = "1";
-  .probe = {
-    .request = "invalid";
-    .interval = 365d;
-    .initial = 0;
-  }
-}
-
-
 acl purge_ip_whitelist {
   "37.26.93.252";     # Skyscape mirrors
   "31.210.241.100";   # Carrenza mirrors
@@ -242,15 +231,9 @@ sub vcl_recv {
     set req.http.Fastly-Backend-Name = "origin";
   }
 
-  # Serve stale if it exists.
-  if (req.restarts > 0) {
-    set req.backend = sick_force_grace;
-    set req.http.Fastly-Backend-Name = "stale";
-  }
-
   <% if %w(staging production).include?(environment) %>
   # Common config when failover to mirror buckets
-  if (req.restarts > 1) {
+  if (req.restarts > 0) {
     set req.url = req.http.original-url;
 
     # Don't serve from stale for mirrors
@@ -272,7 +255,7 @@ sub vcl_recv {
   }
 
   # Failover to primary s3 mirror.
-  if (req.restarts == 2) {
+  if (req.restarts == 1) {
       set req.backend = F_mirrorS3;
       set req.http.host = "<%= config.fetch('s3_mirror_hostname') %>";
       set req.http.Fastly-Backend-Name = "mirrorS3";
@@ -282,7 +265,7 @@ sub vcl_recv {
   }
 
   # Failover to replica s3 mirror.
-  if (req.restarts == 3) {
+  if (req.restarts == 2) {
     set req.backend = F_mirrorS3Replica;
     set req.http.host = "<%= config.fetch('s3_mirror_replica_hostname') %>";
     set req.http.Fastly-Backend-Name = "mirrorS3Replica";
@@ -292,7 +275,7 @@ sub vcl_recv {
   }
 
   # Failover to GCS mirror.
-  if (req.restarts > 3) {
+  if (req.restarts > 2) {
     set req.backend = F_mirrorGCS;
     set req.http.host = "<%= config.fetch('gcs_mirror_hostname') %>";
     set req.http.Fastly-Backend-Name = "mirrorGCS";
@@ -337,8 +320,14 @@ sub vcl_fetch {
 
   set beresp.http.Fastly-Backend-Name = req.http.Fastly-Backend-Name;
 
-  if ((beresp.status >= 500 && beresp.status <= 599) && req.restarts < 4 && (req.request == "GET" || req.request == "HEAD") && !beresp.http.No-Fallback) {
+  if ((beresp.status >= 500 && beresp.status <= 599) && req.restarts < 3 && (req.request == "GET" || req.request == "HEAD") && !beresp.http.No-Fallback) {
     set beresp.saintmode = 5s;
+
+    if req.restarts == 0 && stale.exists {
+     set beresp.http.Fastly-Backend-Name = "stale"
+     return(deliver_stale);
+    }
+
     return (restart);
   }
 
@@ -497,7 +486,7 @@ sub vcl_error {
   # for the first 3 retries: origin, mirrorS3, mirrorS3Replica.
   # By restarting, vcl_recv() will try serving from stale before
   # failing over to the mirrors.
-  if (req.restarts < 4) {
+  if (req.restarts < 3) {
     return (restart);
   }
 

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -37,40 +37,8 @@ backend F_origin {
         .interval = 10s;
     }
 }
-# Mirror backend for provider 0
-backend F_mirror1 {
-    .connect_timeout = 1s;
-    .dynamic = true;
-    .port = "<%= config.fetch('provider1_mirror_port', 443) %>";
-    .host = "<%= config.fetch('provider1_mirror_hostname') %>";
-    .first_byte_timeout = 15s;
-    .max_connections = 200;
-    .between_bytes_timeout = 10s;
-    .share_key = "<%= config.fetch('service_id') %>";
 
-    .ssl = true;
-    .ssl_check_cert = <%= config['disable_tls_validation'] ? 'never' : 'always' %>;
-    .min_tls_version = "<%= config.fetch('min_tls_version', '1.2') %>";
-    <%- if config['ssl_ciphers'] -%>
-    .ssl_ciphers = "<%= config['ssl_ciphers'] -%>";
-    <%- end -%>
-    .ssl_cert_hostname = "<%= config.fetch('ssl_cert_hostname', config.fetch('provider1_mirror_hostname')) %>";
-    .ssl_sni_hostname = "<%= config.fetch('ssl_sni_hostname', config.fetch('provider1_mirror_hostname')) %>";
-
-    .probe = {
-        .request =
-            "HEAD / HTTP/1.1"
-            "Host: <%= config.fetch('provider1_mirror_hostname') %>"
-            "User-Agent: Fastly healthcheck (git version: <%= config['git_version'] %>)"
-            "Connection: close";
-        .threshold = 1;
-        .window = 2;
-        .timeout = 5s;
-        .initial = 1;
-        .expected_response = 200;
-        .interval = 10s;
-    }
-}
+<% if %w(staging production).include?(environment) %>
 # Mirror backend for S3
 backend F_mirrorS3 {
     .connect_timeout = 1s;
@@ -105,6 +73,77 @@ backend F_mirrorS3 {
         .interval = 10s;
     }
 }
+
+# Mirror backend for S3 replica
+backend F_mirrorS3Replica {
+    .connect_timeout = 1s;
+    .dynamic = true;
+    .port = "<%= config.fetch('s3_mirror_replica_port', 443) %>";
+    .host = "<%= config.fetch('s3_mirror_replica_hostname') %>";
+    .first_byte_timeout = 15s;
+    .max_connections = 200;
+    .between_bytes_timeout = 10s;
+    .share_key = "<%= config.fetch('service_id') %>";
+
+    .ssl = true;
+    .ssl_check_cert = <%= config['disable_tls_validation'] ? 'never' : 'always' %>;
+    .min_tls_version = "<%= config.fetch('min_tls_version', '1.2') %>";
+    <%- if config['ssl_ciphers'] -%>
+    .ssl_ciphers = "<%= config['ssl_ciphers'] -%>";
+    <%- end -%>
+    .ssl_cert_hostname = "<%= config.fetch('ssl_cert_hostname', config.fetch('s3_mirror_replica_hostname')) %>";
+    .ssl_sni_hostname = "<%= config.fetch('ssl_sni_hostname', config.fetch('s3_mirror_replica_hostname')) %>";
+
+    .probe = {
+        .request =
+            "HEAD <%= config.fetch('s3_mirror_replica_probe_request', '/') %> HTTP/1.1"
+            "Host: <%= config.fetch('s3_mirror_replica_hostname') %>"
+            "User-Agent: Fastly healthcheck (git version: <%= config['git_version'] %>)"
+            "Connection: close";
+        .threshold = 1;
+        .window = 2;
+        .timeout = 5s;
+        .initial = 1;
+        .expected_response = 200;
+        .interval = 10s;
+    }
+}
+
+# Mirror backend for GCS
+backend F_mirrorGCS {
+    .connect_timeout = 1s;
+    .dynamic = true;
+    .port = "<%= config.fetch('gcs_mirror_port', 443) %>";
+    .host = "<%= config.fetch('gcs_mirror_hostname') %>";
+    .first_byte_timeout = 15s;
+    .max_connections = 200;
+    .between_bytes_timeout = 10s;
+    .share_key = "<%= config.fetch('service_id') %>";
+
+    .ssl = true;
+    .ssl_check_cert = <%= config['disable_tls_validation'] ? 'never' : 'always' %>;
+    .min_tls_version = "<%= config.fetch('min_tls_version', '1.2') %>";
+    <%- if config['ssl_ciphers'] -%>
+    .ssl_ciphers = "<%= config['ssl_ciphers'] -%>";
+    <%- end -%>
+    .ssl_cert_hostname = "<%= config.fetch('ssl_cert_hostname', config.fetch('gcs_mirror_hostname')) %>";
+    .ssl_sni_hostname = "<%= config.fetch('ssl_sni_hostname', config.fetch('gcs_mirror_hostname')) %>";
+
+    .probe = {
+        .request =
+            "HEAD <%= config.fetch('gcs_mirror_probe_request', '/') %> HTTP/1.1"
+            "Host: <%= config.fetch('gcs_mirror_hostname') %>"
+            "User-Agent: Fastly healthcheck (git version: <%= config['git_version'] %>)"
+            "Connection: close";
+        .threshold = 1;
+        .window = 2;
+        .timeout = 5s;
+        .initial = 1;
+        .expected_response = 403;
+        .interval = 10s;
+    }
+}
+<% end %>
 
 backend sick_force_grace {
   .host = "127.0.0.1";
@@ -197,8 +236,11 @@ sub vcl_recv {
   set req.grace = 24h;
 
   # Default backend.
-  set req.backend = F_origin;
-  set req.http.Fastly-Backend-Name = "origin";
+  if (req.restarts < 1) {
+    set req.http.original-url = req.url;
+    set req.backend = F_origin;
+    set req.http.Fastly-Backend-Name = "origin";
+  }
 
   # Serve stale if it exists.
   if (req.restarts > 0) {
@@ -206,22 +248,14 @@ sub vcl_recv {
     set req.http.Fastly-Backend-Name = "stale";
   }
 
-  # Failover to mirror.
+  <% if %w(staging production).include?(environment) %>
+  # Common config when failover to mirror buckets
   if (req.restarts > 1) {
+    set req.url = req.http.original-url;
+
     # Don't serve from stale for mirrors
     set req.grace = 0s;
     set req.http.Fastly-Failover = "1";
-
-    set req.backend = F_mirror1;
-    set req.http.host = "<%= config.fetch('provider1_mirror_hostname') %>";
-    set req.http.Fastly-Backend-Name = "mirror1";
-  }
-
-  # FIXME: Prefer a fallback director if we move to Varnish 3
-  if (req.restarts > 2) {
-    set req.backend = F_mirrorS3;
-    set req.http.host = "<%= config.fetch('s3_mirror_hostname') %>";
-    set req.http.Fastly-Backend-Name = "mirrorS3";
 
     # Requests to home page, rewrite to index.html
     if (req.url ~ "^/?([\?#].*)?$") {
@@ -235,9 +269,41 @@ sub vcl_recv {
     if (req.url !~ "^([^#\?\s]+)\.(atom|chm|css|csv|diff|doc|docx|dot|dxf|eps|gif|gml|html|ico|ics|jpeg|jpg|JPG|js|json|kml|odp|ods|odt|pdf|PDF|png|ppt|pptx|ps|rdf|rtf|sch|txt|wsdl|xls|xlsm|xlsx|xlt|xml|xsd|xslt|zip)([\?#]+.*)?$") {
       set req.url = regsub(req.url, "^([^#\?\s]+)([\?#]+.*)?$", "\1.html\2");
     }
-    # Add bucket directory prefix to all the requests
-    set req.url = "/<%= config.fetch('s3_mirror_prefix') %>" req.url;
   }
+
+  # Failover to primary s3 mirror.
+  if (req.restarts == 2) {
+      set req.backend = F_mirrorS3;
+      set req.http.host = "<%= config.fetch('s3_mirror_hostname') %>";
+      set req.http.Fastly-Backend-Name = "mirrorS3";
+
+      # Add bucket directory prefix to all the requests
+      set req.url = "/<%= config.fetch('s3_mirror_prefix') %>" req.url;
+  }
+
+  # Failover to replica s3 mirror.
+  if (req.restarts == 3) {
+    set req.backend = F_mirrorS3Replica;
+    set req.http.host = "<%= config.fetch('s3_mirror_replica_hostname') %>";
+    set req.http.Fastly-Backend-Name = "mirrorS3Replica";
+
+    # Add bucket directory prefix to all the requests
+    set req.url = "/<%= config.fetch('s3_mirror_replica_prefix') %>" req.url;
+  }
+
+  # Failover to GCS mirror.
+  if (req.restarts > 3) {
+    set req.backend = F_mirrorGCS;
+    set req.http.host = "<%= config.fetch('gcs_mirror_hostname') %>";
+    set req.http.Fastly-Backend-Name = "mirrorGCS";
+
+    # Add bucket directory prefix to all the requests
+    set req.url = "/<%= config.fetch('gcs_mirror_prefix') %>" req.url;
+
+    set req.http.Date = now;
+    set req.http.Authorization = "AWS <%= config.fetch('gcs_mirror_access_id') %>:" digest.hmac_sha1_base64("<%= config.fetch('gcs_mirror_secret_key') %>", "GET" LF LF LF now LF "/<%= config.fetch('gcs_mirror_bucket_name') %>" req.url.path);
+  }
+  <% end %>
 
   # Unspoofable original client address.
   set req.http.True-Client-IP = req.http.Fastly-Client-IP;


### PR DESCRIPTION
# Context

New gov.uk mirror redesign:
If the www origin backend is down, fastly will use stale cache as before.
If object is not in cache, the S3 mirror bucket in London is used. If this fails, the
replica S3 mirror bucket in Ireland is used. As last resort,
we use the Google Cloud Storage bucket in multi-region EU.

Other changes:
1. we no longer have a sick backend because it is pointless as we keep the grace period to 24 hours regardless, so the example previously followed: https://book.varnish-software.com/3.0/Saving_a_request.html#example-evil-backend-hack no longer applies. Confirmed with fastly that this is fine.
2. if the backend is origin and we encounter an error from the origin, we try to serve stale too.

# Decisions
1. re-write the www vcl config to accommodate the 3 mirror buckets and removal of mirror machines in Carrenza 

Data component of this PR is in: https://github.com/alphagov/govuk-cdn-config-secrets/pull/102 