### PR TITLE
Cache non-GET/HEAD requests with 404/405 responses

### DIFF
--- a/spec/test-outputs/www-integration.out.vcl
+++ b/spec/test-outputs/www-integration.out.vcl
@@ -212,10 +212,6 @@ sub vcl_recv {
 
 #FASTLY recv
 
-  if (req.request != "HEAD" && req.request != "GET" && req.request != "FASTLYPURGE") {
-    return(pass);
-  }
-
     # Begin dynamic section
 if (table.lookup(active_ab_tests, "Example") == "true") {
   if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
@@ -382,6 +378,18 @@ sub vcl_fetch {
     }
   }
 
+  # Cache non-GET/HEAD/FASTLYPURGE requests if they return a 404 or 405
+  if (!(req.request == "GET" || req.request == "HEAD" || req.request == "FASTLYPURGE")) {
+    if (http_status_matches(beresp.status, "404,405")) {
+      # Cache these 404/405 responses
+      set beresp.ttl = 5000s;
+      set beresp.cacheable = true;
+    } else {
+      # Don't cache these responses.
+      set beresp.cacheable = false;
+    }
+  }
+
   # Override default.vcl behaviour of return(pass).
   if (beresp.http.Set-Cookie) {
     return (deliver);
@@ -510,5 +518,21 @@ sub vcl_pass {
 }
 
 sub vcl_hash {
+  # include request method
+  set req.hash += req.request;
+
+  # support caching non-GET/HEAD requests
+  if (!(req.request == "GET" || req.request == "HEAD" || req.request == "FASTLYPURGE") && req.postbody) {
+    set req.hash += req.postbody;
+  }
+
+  # if handling GET/HEAD requests, fall back to normal
+  {
+    set req.hash += req.url;
+    set req.hash += req.http.host;
+    set req.hash += "#####GENERATION#####";
+    return (hash);
+  }
+
 #FASTLY hash
 }

--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -213,10 +213,6 @@ sub vcl_recv {
 
 #FASTLY recv
 
-  if (req.request != "HEAD" && req.request != "GET" && req.request != "FASTLYPURGE") {
-    return(pass);
-  }
-
     # Begin dynamic section
 if (table.lookup(active_ab_tests, "Example") == "true") {
   if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
@@ -383,6 +379,18 @@ sub vcl_fetch {
     }
   }
 
+  # Cache non-GET/HEAD/FASTLYPURGE requests if they return a 404 or 405
+  if (!(req.request == "GET" || req.request == "HEAD" || req.request == "FASTLYPURGE")) {
+    if (http_status_matches(beresp.status, "404,405")) {
+      # Cache these 404/405 responses
+      set beresp.ttl = 5000s;
+      set beresp.cacheable = true;
+    } else {
+      # Don't cache these responses.
+      set beresp.cacheable = false;
+    }
+  }
+
   # Override default.vcl behaviour of return(pass).
   if (beresp.http.Set-Cookie) {
     return (deliver);
@@ -511,5 +519,21 @@ sub vcl_pass {
 }
 
 sub vcl_hash {
+  # include request method
+  set req.hash += req.request;
+
+  # support caching non-GET/HEAD requests
+  if (!(req.request == "GET" || req.request == "HEAD" || req.request == "FASTLYPURGE") && req.postbody) {
+    set req.hash += req.postbody;
+  }
+
+  # if handling GET/HEAD requests, fall back to normal
+  {
+    set req.hash += req.url;
+    set req.hash += req.http.host;
+    set req.hash += "#####GENERATION#####";
+    return (hash);
+  }
+
 #FASTLY hash
 }

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -222,10 +222,6 @@ sub vcl_recv {
 
 #FASTLY recv
 
-  if (req.request != "HEAD" && req.request != "GET" && req.request != "FASTLYPURGE") {
-    return(pass);
-  }
-
     # Begin dynamic section
 if (table.lookup(active_ab_tests, "Example") == "true") {
   if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
@@ -392,6 +388,18 @@ sub vcl_fetch {
     }
   }
 
+  # Cache non-GET/HEAD/FASTLYPURGE requests if they return a 404 or 405
+  if (!(req.request == "GET" || req.request == "HEAD" || req.request == "FASTLYPURGE")) {
+    if (http_status_matches(beresp.status, "404,405")) {
+      # Cache these 404/405 responses
+      set beresp.ttl = 5000s;
+      set beresp.cacheable = true;
+    } else {
+      # Don't cache these responses.
+      set beresp.cacheable = false;
+    }
+  }
+
   # Override default.vcl behaviour of return(pass).
   if (beresp.http.Set-Cookie) {
     return (deliver);
@@ -520,5 +528,21 @@ sub vcl_pass {
 }
 
 sub vcl_hash {
+  # include request method
+  set req.hash += req.request;
+
+  # support caching non-GET/HEAD requests
+  if (!(req.request == "GET" || req.request == "HEAD" || req.request == "FASTLYPURGE") && req.postbody) {
+    set req.hash += req.postbody;
+  }
+
+  # if handling GET/HEAD requests, fall back to normal
+  {
+    set req.hash += req.url;
+    set req.hash += req.http.host;
+    set req.hash += "#####GENERATION#####";
+    return (hash);
+  }
+
 #FASTLY hash
 }

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -256,10 +256,6 @@ sub vcl_recv {
 
 #FASTLY recv
 
-  if (req.request != "HEAD" && req.request != "GET" && req.request != "FASTLYPURGE") {
-    return(pass);
-  }
-
   <% template_path = File.join(File.dirname(__FILE__), "vcl_templates/_multivariate_tests.vcl.erb") -%>
   <%= ERB.new(File.new(template_path).read, nil, "-", "_erbout2").result(binding) %>
 
@@ -326,6 +322,18 @@ sub vcl_fetch {
     if (beresp.http.Fastly-Backend-Name ~ "mirrorS3") {
       set beresp.ttl = 900s;
       set beresp.http.Cache-Control = "max-age=900";
+    }
+  }
+
+  # Cache non-GET/HEAD/FASTLYPURGE requests if they return a 404 or 405
+  if (!(req.request == "GET" || req.request == "HEAD" || req.request == "FASTLYPURGE")) {
+    if (http_status_matches(beresp.status, "404,405")) {
+      # Cache these 404/405 responses
+      set beresp.ttl = <%= config.fetch('default_ttl') %>s;
+      set beresp.cacheable = true;
+    } else {
+      # Don't cache these responses.
+      set beresp.cacheable = false;
     }
   }
 
@@ -465,5 +473,21 @@ sub vcl_pass {
 }
 
 sub vcl_hash {
+  # include request method
+  set req.hash += req.request;
+
+  # support caching non-GET/HEAD requests
+  if (!(req.request == "GET" || req.request == "HEAD" || req.request == "FASTLYPURGE") && req.postbody) {
+    set req.hash += req.postbody;
+  }
+
+  # if handling GET/HEAD requests, fall back to normal
+  {
+    set req.hash += req.url;
+    set req.hash += req.http.host;
+    set req.hash += "#####GENERATION#####";
+    return (hash);
+  }
+
 #FASTLY hash
 }


### PR DESCRIPTION
Trello: https://trello.com/c/6P4c8RiN/396

I would appreciate thoughts on this (implementation details, concerns/risks, in general and in response to the P1 issue).

## What does this change do?

At the moment we only cache GET/HEAD requests.

Now we'll cache any request, if that request returns a 404 (Not Found) or 405 (Method Not Allowed).

Note that administration/publishing applications don't sit behind this cache, so (e.g.) requests to create documents won't be affected by this change.

### Example

If a DELETE request is made to a page on the gov.uk website - for the most part not permitted - this should return a 405.

We then cache this response, so future DELETE requests to the same resource will not reach the origin until the Time-to-live (TTL) for the cached object expires (for this case, 10 seconds).

## Motivation for the change

This change is in response to a P1 issue in February 2019. More details of the P1: https://trello.com/c/6P4c8RiN/396 (if you can't access this let me know).

In general, it will reduce the workload for servers behind the cache.

## Explain it to me like I didn't read the VCL documentation

Varnish (our cache), which is run as a managed service by Fastly (our CDN), allows us to modify how we cache responses. This is made possible with VCL ([Varnish Configuration Language](https://varnish-cache.org/docs/2.1/reference/vcl.html#varnish-configuration-language) version 2.1).

This change modifies the VCL we run for www.gov.uk on all environments.

The change to `vcl_recv` (run before we've made a request to the backend servers) means that we lookup all requests (regardless of request method) in the cache. Therefore, any cached POST/DELETE/GET/etc. response that is cached, if requested again, will be served by the cache and won't reach servers behind the cache.

The change to `vcl_fetch` (run after we've got a response from the backend servers) means that we only cache non-GET/HEAD requests if they return a 404 or 405.

## Concerns

These are questions that have come up, which others more experienced with Fastly/Varnish may have thoughts about.

**Is it possible that sensitive data could be cached?**

I think that sensitive data won't be cached. The new cached objects are only 404 / 405 responses, though I might be wrong. We will store hashed requests (including query params) in the same way as GET requests, though I'm not sure if we consider these sensitive.

**Is it possible that this cache logic could prevent valid requests?**

I don't think so, since query params and so on are cached and create unique cache objects. For example: `gov.uk/search?q=breakfast` and `gov.uk/search?q=lunch` will create two unique cache objects. In this case, you won't receive breakfast when you've asked for lunch.

More dangerously, if a DELETE request is made on a resource, which returns a 404, and then the resource is created and the cache is not invalidated, then a subsequent DELETE request might return an invalid 404.

```
DELETE /horse/1
> 404 Not Found (horse doesn't exist)
CREATE /horse { id: 1 }
DELETE /horse/1
> (from cache): 404 Not Found (horse doesn't exist) <- incorrect.
```

**Will backends that incorrectly respond with 404/405 then lead to a confusing debugging experience for developers?**

**Will a higher number of `lookup` calls on the Varnish cache have an adverse affect?**

I suspect not, since we pretty much only see GET requests. The ratio of GET requests to other requests is expected to stay the same.