### PR TITLE
new production and staging mirror fastly service

### DIFF
--- a/spec/test-outputs/mirror-integration.out.vcl
+++ b/spec/test-outputs/mirror-integration.out.vcl
@@ -1,9 +1,8 @@
-# Mirror backend for S3
-backend F_mirrorS3 {
-    .connect_timeout = 1s;
+backend F_origin {
+    .connect_timeout = 5s;
     .dynamic = true;
     .port = "443";
-    .host = "bar";
+    .host = "foo";
     .first_byte_timeout = 15s;
     .max_connections = 200;
     .between_bytes_timeout = 10s;
@@ -12,13 +11,13 @@ backend F_mirrorS3 {
     .ssl = true;
     .ssl_check_cert = always;
     .min_tls_version = "1.2";
-    .ssl_cert_hostname = "bar";
-    .ssl_sni_hostname = "bar";
+    .ssl_cert_hostname = "foo";
+    .ssl_sni_hostname = "foo";
 
     .probe = {
         .request =
             "HEAD / HTTP/1.1"
-            "Host: bar"
+            "Host: foo"
             "User-Agent: Fastly healthcheck (git version: )"
             "Connection: close";
         .threshold = 1;
@@ -30,79 +29,6 @@ backend F_mirrorS3 {
     }
 }
 
-# Mirror backend for S3 replica
-backend F_mirrorS3Replica {
-    .connect_timeout = 1s;
-    .dynamic = true;
-    .port = "443";
-    .host = "s3-mirror-replica.aws.com";
-    .first_byte_timeout = 15s;
-    .max_connections = 200;
-    .between_bytes_timeout = 10s;
-    .share_key = "123";
-
-    .ssl = true;
-    .ssl_check_cert = always;
-    .min_tls_version = "1.2";
-    .ssl_cert_hostname = "s3-mirror-replica.aws.com";
-    .ssl_sni_hostname = "s3-mirror-replica.aws.com";
-
-    .probe = {
-        .request =
-            "HEAD / HTTP/1.1"
-            "Host: s3-mirror-replica.aws.com"
-            "User-Agent: Fastly healthcheck (git version: )"
-            "Connection: close";
-        .threshold = 1;
-        .window = 2;
-        .timeout = 5s;
-        .initial = 1;
-        .expected_response = 200;
-        .interval = 10s;
-    }
-}
-
-# Mirror backend for GCS
-backend F_mirrorGCS {
-    .connect_timeout = 1s;
-    .dynamic = true;
-    .port = "443";
-    .host = "gcs-mirror.google.com";
-    .first_byte_timeout = 15s;
-    .max_connections = 200;
-    .between_bytes_timeout = 10s;
-    .share_key = "123";
-
-    .ssl = true;
-    .ssl_check_cert = always;
-    .min_tls_version = "1.2";
-    .ssl_cert_hostname = "gcs-mirror.google.com";
-    .ssl_sni_hostname = "gcs-mirror.google.com";
-
-    .probe = {
-        .request =
-            "HEAD / HTTP/1.1"
-            "Host: gcs-mirror.google.com"
-            "User-Agent: Fastly healthcheck (git version: )"
-            "Connection: close";
-        .threshold = 1;
-        .window = 2;
-        .timeout = 5s;
-        .initial = 1;
-        .expected_response = 403;
-        .interval = 10s;
-    }
-}
-
-backend sick_force_grace {
-  .host = "127.0.0.1";
-  .port = "1";
-  .probe = {
-    .request = "invalid";
-    .interval = 365d;
-    .initial = 0;
-  }
-}
 
 
 acl purge_ip_whitelist {
@@ -141,6 +67,13 @@ sub vcl_recv {
     error 403 "Forbidden";
   }
 
+  # Check whether the remote IP address is in the list of blocked IPs
+  if (table.lookup(ip_address_blacklist, client.ip)) {
+    error 403 "Forbidden";
+  }
+
+  
+
   # Force SSL.
   if (!req.http.Fastly-SSL) {
      error 801 "Force SSL";
@@ -154,81 +87,12 @@ sub vcl_recv {
   # Serve from stale for 24 hours if origin is sick
   set req.grace = 24h;
 
-  #################### Start of default mirror backend ########################
-  if (req.restarts < 1) {
-    set req.http.original-url = req.url;
+  # Default backend, these details will be overwritten if other backends are
+  # chosen
+  set req.backend = F_origin;
+  set req.http.Fastly-Backend-Name = "origin";
 
-    set req.backend = F_mirrorS3;
-    set req.http.host = "bar";
-    set req.http.Fastly-Backend-Name = "mirrorS3";
-
-    # Requests to home page, rewrite to index.html
-    if (req.url ~ "^/?([\?#].*)?$") {
-      set req.url = regsub(req.url, "^/?([\?#].*)?$", "/index.html\1");
-    }
-
-    # Replace multiple /
-    set req.url = regsuball(req.url, "([^:])//+", "\1/");
-
-    # Requests without document extension, rewrite adding .html
-    if (req.url !~ "^([^#\?\s]+)\.(atom|chm|css|csv|diff|doc|docx|dot|dxf|eps|gif|gml|html|ico|ics|jpeg|jpg|JPG|js|json|kml|odp|ods|odt|pdf|PDF|png|ppt|pptx|ps|rdf|rtf|sch|txt|wsdl|xls|xlsm|xlsx|xlt|xml|xsd|xslt|zip)([\?#]+.*)?$") {
-      set req.url = regsub(req.url, "^([^#\?\s]+)([\?#]+.*)?$", "\1.html\2");
-    }
-    # Add bucket directory prefix to all the requests
-    set req.url = "/foo_" req.url;
-  }
-  #################### End of default mirror backend ##########################
-
-  # Serve stale if it exists.
-  if (req.restarts > 0) {
-    set req.backend = sick_force_grace;
-    set req.http.Fastly-Backend-Name = "stale";
-  }
-
-  # Common config when failover to mirror buckets
-  if (req.restarts > 1) {
-    set req.url = req.http.original-url;
-
-    # Don't serve from stale for mirrors
-    set req.grace = 0s;
-    set req.http.Fastly-Failover = "1";
-
-    # Requests to home page, rewrite to index.html
-    if (req.url ~ "^/?([\?#].*)?$") {
-      set req.url = regsub(req.url, "^/?([\?#].*)?$", "/index.html\1");
-    }
-
-    # Replace multiple /
-    set req.url = regsuball(req.url, "([^:])//+", "\1/");
-
-    # Requests without document extension, rewrite adding .html
-    if (req.url !~ "^([^#\?\s]+)\.(atom|chm|css|csv|diff|doc|docx|dot|dxf|eps|gif|gml|html|ico|ics|jpeg|jpg|JPG|js|json|kml|odp|ods|odt|pdf|PDF|png|ppt|pptx|ps|rdf|rtf|sch|txt|wsdl|xls|xlsm|xlsx|xlt|xml|xsd|xslt|zip)([\?#]+.*)?$") {
-      set req.url = regsub(req.url, "^([^#\?\s]+)([\?#]+.*)?$", "\1.html\2");
-    }
-  }
-
-  # Failover to s3 mirror replica
-  if (req.restarts == 2) {
-    set req.backend = F_mirrorS3Replica;
-    set req.http.host = "s3-mirror-replica.aws.com";
-    set req.http.Fastly-Backend-Name = "mirrorS3Replica";
-
-    # Add bucket directory prefix to all the requests
-    set req.url = "/s3-mirror-replica" req.url;
-  }
-
-  # Failover to GCS mirror
-  if (req.restarts > 2) {
-    set req.backend = F_mirrorGCS;
-    set req.http.host = "gcs-mirror.google.com";
-    set req.http.Fastly-Backend-Name = "mirrorGCS";
-
-    # Add bucket directory prefix to all the requests
-    set req.url = "/gcs-mirror" req.url;
-
-    set req.http.Date = now;
-    set req.http.Authorization = "AWS gcs-mirror-access-id:" digest.hmac_sha1_base64("gcs-mirror-secret-key", "GET" LF LF LF now LF "/gcs-bucket" req.url.path);
-  }
+  
 
   # Unspoofable original client address.
   set req.http.True-Client-IP = req.http.Fastly-Client-IP;
@@ -239,11 +103,112 @@ sub vcl_recv {
     set req.http.TLSversion = tls.client.protocol;
   }
 
-  #FASTLY recv
+
+#FASTLY recv
 
   if (req.request != "HEAD" && req.request != "GET" && req.request != "FASTLYPURGE") {
     return(pass);
   }
+
+    # Begin dynamic section
+if (table.lookup(active_ab_tests, "Example") == "true") {
+  if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
+    set req.http.GOVUK-ABTest-Example = "A";
+  } else if (req.url ~ "[\?\&]ABTest-Example=A(&|$)") {
+    # Some users, such as remote testers, will be given a URL with a query string
+    # to place them into a specific bucket.
+    set req.http.GOVUK-ABTest-Example = "A";
+  } else if (req.url ~ "[\?\&]ABTest-Example=B(&|$)") {
+    # Some users, such as remote testers, will be given a URL with a query string
+    # to place them into a specific bucket.
+    set req.http.GOVUK-ABTest-Example = "B";
+  } else if (req.http.Cookie ~ "ABTest-Example") {
+    # Set the value of the header to whatever decision was previously made
+    set req.http.GOVUK-ABTest-Example = req.http.Cookie:ABTest-Example;
+  } else {
+    declare local var.denominator_Example INTEGER;
+    declare local var.denominator_Example_A INTEGER;
+    declare local var.nominator_Example_A INTEGER;
+    set var.nominator_Example_A = std.atoi(table.lookup(example_percentages, "A"));
+    set var.denominator_Example += var.nominator_Example_A;
+    declare local var.denominator_Example_B INTEGER;
+    declare local var.nominator_Example_B INTEGER;
+    set var.nominator_Example_B = std.atoi(table.lookup(example_percentages, "B"));
+    set var.denominator_Example += var.nominator_Example_B;
+    set var.denominator_Example_A = var.denominator_Example;
+    if (randombool(var.nominator_Example_A, var.denominator_Example_A)) {
+      set req.http.GOVUK-ABTest-Example = "A";
+    } else {
+      set req.http.GOVUK-ABTest-Example = "B";
+    }
+  }
+}
+if (table.lookup(active_ab_tests, "ViewDrivingLicence") == "true") {
+  if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
+    set req.http.GOVUK-ABTest-ViewDrivingLicence = "A";
+  } else if (req.url ~ "[\?\&]ABTest-ViewDrivingLicence=A(&|$)") {
+    # Some users, such as remote testers, will be given a URL with a query string
+    # to place them into a specific bucket.
+    set req.http.GOVUK-ABTest-ViewDrivingLicence = "A";
+  } else if (req.url ~ "[\?\&]ABTest-ViewDrivingLicence=B(&|$)") {
+    # Some users, such as remote testers, will be given a URL with a query string
+    # to place them into a specific bucket.
+    set req.http.GOVUK-ABTest-ViewDrivingLicence = "B";
+  } else if (req.http.Cookie ~ "ABTest-ViewDrivingLicence") {
+    # Set the value of the header to whatever decision was previously made
+    set req.http.GOVUK-ABTest-ViewDrivingLicence = req.http.Cookie:ABTest-ViewDrivingLicence;
+  } else {
+    declare local var.denominator_ViewDrivingLicence INTEGER;
+    declare local var.denominator_ViewDrivingLicence_A INTEGER;
+    declare local var.nominator_ViewDrivingLicence_A INTEGER;
+    set var.nominator_ViewDrivingLicence_A = std.atoi(table.lookup(viewdrivinglicence_percentages, "A"));
+    set var.denominator_ViewDrivingLicence += var.nominator_ViewDrivingLicence_A;
+    declare local var.denominator_ViewDrivingLicence_B INTEGER;
+    declare local var.nominator_ViewDrivingLicence_B INTEGER;
+    set var.nominator_ViewDrivingLicence_B = std.atoi(table.lookup(viewdrivinglicence_percentages, "B"));
+    set var.denominator_ViewDrivingLicence += var.nominator_ViewDrivingLicence_B;
+    set var.denominator_ViewDrivingLicence_A = var.denominator_ViewDrivingLicence;
+    if (randombool(var.nominator_ViewDrivingLicence_A, var.denominator_ViewDrivingLicence_A)) {
+      set req.http.GOVUK-ABTest-ViewDrivingLicence = "A";
+    } else {
+      set req.http.GOVUK-ABTest-ViewDrivingLicence = "B";
+    }
+  }
+}
+if (table.lookup(active_ab_tests, "FinderAnswerABTest") == "true") {
+  if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
+    set req.http.GOVUK-ABTest-FinderAnswerABTest = "A";
+  } else if (req.url ~ "[\?\&]ABTest-FinderAnswerABTest=A(&|$)") {
+    # Some users, such as remote testers, will be given a URL with a query string
+    # to place them into a specific bucket.
+    set req.http.GOVUK-ABTest-FinderAnswerABTest = "A";
+  } else if (req.url ~ "[\?\&]ABTest-FinderAnswerABTest=B(&|$)") {
+    # Some users, such as remote testers, will be given a URL with a query string
+    # to place them into a specific bucket.
+    set req.http.GOVUK-ABTest-FinderAnswerABTest = "B";
+  } else if (req.http.Cookie ~ "ABTest-FinderAnswerABTest") {
+    # Set the value of the header to whatever decision was previously made
+    set req.http.GOVUK-ABTest-FinderAnswerABTest = req.http.Cookie:ABTest-FinderAnswerABTest;
+  } else {
+    declare local var.denominator_FinderAnswerABTest INTEGER;
+    declare local var.denominator_FinderAnswerABTest_A INTEGER;
+    declare local var.nominator_FinderAnswerABTest_A INTEGER;
+    set var.nominator_FinderAnswerABTest_A = std.atoi(table.lookup(finderanswerabtest_percentages, "A"));
+    set var.denominator_FinderAnswerABTest += var.nominator_FinderAnswerABTest_A;
+    declare local var.denominator_FinderAnswerABTest_B INTEGER;
+    declare local var.nominator_FinderAnswerABTest_B INTEGER;
+    set var.nominator_FinderAnswerABTest_B = std.atoi(table.lookup(finderanswerabtest_percentages, "B"));
+    set var.denominator_FinderAnswerABTest += var.nominator_FinderAnswerABTest_B;
+    set var.denominator_FinderAnswerABTest_A = var.denominator_FinderAnswerABTest;
+    if (randombool(var.nominator_FinderAnswerABTest_A, var.denominator_FinderAnswerABTest_A)) {
+      set req.http.GOVUK-ABTest-FinderAnswerABTest = "A";
+    } else {
+      set req.http.GOVUK-ABTest-FinderAnswerABTest = "B";
+    }
+  }
+}
+# End dynamic section
+
 
   return(lookup);
 }
@@ -284,7 +249,7 @@ sub vcl_fetch {
   # a 301 status code. All errors from the mirrors are set to 503 as they
   # cannot know whether or not a page actually exists (e.g. /search is a valid
   # URL but the mirror cannot return it).
-  if (beresp.status != 200 && beresp.http.Fastly-Backend-Name ~ "mirror") {
+  if (beresp.status != 200 && beresp.http.Fastly-Backend-Name ~ "^mirror") {
     set beresp.status = 503;
   }
 
@@ -292,7 +257,7 @@ sub vcl_fetch {
     set req.http.Fastly-Cachetype = "ERROR";
     set beresp.ttl = 1s;
     set beresp.grace = 5s;
-    if (beresp.http.Fastly-Backend-Name ~ "mirrorS3") {
+    if (beresp.http.Fastly-Backend-Name ~ "^mirror") {
       error 503 "Error page";
     }
     return (deliver);
@@ -304,8 +269,8 @@ sub vcl_fetch {
     # apply the default ttl
     set beresp.ttl = 5000s;
 
-    # S3 does not set cache headers by default. Override TTL and add cache-control with 15 minutes
-    if (beresp.http.Fastly-Backend-Name ~ "mirrorS3") {
+    # Mirror buckets do not set cache headers by default. Override TTL and add cache-control with 15 minutes
+    if (beresp.http.Fastly-Backend-Name ~ "^mirror") {
       set beresp.ttl = 900s;
       set beresp.http.Cache-Control = "max-age=900";
     }
@@ -326,6 +291,33 @@ sub vcl_miss {
 }
 
 sub vcl_deliver {
+  # Set the A/B cookies
+  # Only set the A/B example cookie if the request is to the A/B test page. This
+  # ensures that most visitors to the site aren't assigned an irrelevant test
+  # cookie.
+  if (req.url ~ "^/help/ab-testing"
+    && req.http.User-Agent !~ "^GOV\.UK Crawler Worker"
+    && req.http.Cookie !~ "ABTest-Example") {
+    # Set a fairly short cookie expiry because this is just an A/B test demo.
+    add resp.http.Set-Cookie = "ABTest-Example=" req.http.GOVUK-ABTest-Example "; secure; expires=" now + 1d;
+  }
+
+  # Begin dynamic section
+  declare local var.expiry TIME;
+  if (table.lookup(active_ab_tests, "ViewDrivingLicence") == "true") {
+    if (req.http.Cookie !~ "ABTest-ViewDrivingLicence" || req.url ~ "[\?\&]ABTest-ViewDrivingLicence" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
+      set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "ViewDrivingLicence"))));
+      add resp.http.Set-Cookie = "ABTest-ViewDrivingLicence=" req.http.GOVUK-ABTest-ViewDrivingLicence "; secure; expires=" var.expiry "; path=/";
+    }
+  }
+  if (table.lookup(active_ab_tests, "FinderAnswerABTest") == "true") {
+    if (req.http.Cookie !~ "ABTest-FinderAnswerABTest" || req.url ~ "[\?\&]ABTest-FinderAnswerABTest" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
+      set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "FinderAnswerABTest"))));
+      add resp.http.Set-Cookie = "ABTest-FinderAnswerABTest=" req.http.GOVUK-ABTest-FinderAnswerABTest "; secure; expires=" var.expiry "; path=/";
+    }
+  }
+  # End dynamic section
+
   # Set the TLS version session cookie with the raw protocol version from
   # Fastly only if it isn't already set. We also check for a null TLS value,
   # which can occur when trying to access over HTTP (http>https upgrading).
@@ -373,6 +365,17 @@ sub vcl_error {
   }
 
   
+
+  # Serve stale from error subroutine as recommended in:
+  # https://docs.fastly.com/guides/performance-tuning/serving-stale-content
+  # The use of `req.restarts == 0` condition is to enforce the restriction
+  # of serving stale only when the backend is the origin.
+  if ((req.restarts == 0) && (obj.status >= 500 && obj.status < 600)) {
+    /* deliver stale object if it is available */
+    if (stale.exists) {
+      return(deliver_stale);
+    }
+  }
 
   # Assume we've hit vcl_error() because the backend is unavailable
   # for the first two retries. By restarting, vcl_recv() will try

--- a/spec/test-outputs/mirror-production.out.vcl
+++ b/spec/test-outputs/mirror-production.out.vcl
@@ -1,3 +1,35 @@
+backend F_origin {
+    .connect_timeout = 5s;
+    .dynamic = true;
+    .port = "443";
+    .host = "foo";
+    .first_byte_timeout = 15s;
+    .max_connections = 200;
+    .between_bytes_timeout = 10s;
+    .share_key = "123";
+
+    .ssl = true;
+    .ssl_check_cert = always;
+    .min_tls_version = "1.2";
+    .ssl_cert_hostname = "foo";
+    .ssl_sni_hostname = "foo";
+
+    .probe = {
+        .request =
+            "HEAD / HTTP/1.1"
+            "Host: foo"
+            "User-Agent: Fastly healthcheck (git version: )"
+            "Connection: close";
+        .threshold = 1;
+        .window = 2;
+        .timeout = 5s;
+        .initial = 1;
+        .expected_response = 200;
+        .interval = 10s;
+    }
+}
+
+
 # Mirror backend for S3
 backend F_mirrorS3 {
     .connect_timeout = 1s;
@@ -94,16 +126,6 @@ backend F_mirrorGCS {
     }
 }
 
-backend sick_force_grace {
-  .host = "127.0.0.1";
-  .port = "1";
-  .probe = {
-    .request = "invalid";
-    .interval = 365d;
-    .initial = 0;
-  }
-}
-
 
 acl purge_ip_whitelist {
   "37.26.93.252";     # Skyscape mirrors
@@ -146,6 +168,13 @@ sub vcl_recv {
     error 403 "Forbidden";
   }
 
+  # Check whether the remote IP address is in the list of blocked IPs
+  if (table.lookup(ip_address_blacklist, client.ip)) {
+    error 403 "Forbidden";
+  }
+
+  
+
   # Force SSL.
   if (!req.http.Fastly-SSL) {
      error 801 "Force SSL";
@@ -159,39 +188,20 @@ sub vcl_recv {
   # Serve from stale for 24 hours if origin is sick
   set req.grace = 24h;
 
-  #################### Start of default mirror backend ########################
+  # Default backend, these details will be overwritten if other backends are
+  # chosen
+  set req.backend = F_origin;
+  set req.http.Fastly-Backend-Name = "origin";
+
+  
+
+  # Save original request url because req.url changes after restarts.
   if (req.restarts < 1) {
     set req.http.original-url = req.url;
-
-    set req.backend = F_mirrorS3;
-    set req.http.host = "bar";
-    set req.http.Fastly-Backend-Name = "mirrorS3";
-
-    # Requests to home page, rewrite to index.html
-    if (req.url ~ "^/?([\?#].*)?$") {
-      set req.url = regsub(req.url, "^/?([\?#].*)?$", "/index.html\1");
-    }
-
-    # Replace multiple /
-    set req.url = regsuball(req.url, "([^:])//+", "\1/");
-
-    # Requests without document extension, rewrite adding .html
-    if (req.url !~ "^([^#\?\s]+)\.(atom|chm|css|csv|diff|doc|docx|dot|dxf|eps|gif|gml|html|ico|ics|jpeg|jpg|JPG|js|json|kml|odp|ods|odt|pdf|PDF|png|ppt|pptx|ps|rdf|rtf|sch|txt|wsdl|xls|xlsm|xlsx|xlt|xml|xsd|xslt|zip)([\?#]+.*)?$") {
-      set req.url = regsub(req.url, "^([^#\?\s]+)([\?#]+.*)?$", "\1.html\2");
-    }
-    # Add bucket directory prefix to all the requests
-    set req.url = "/foo_" req.url;
-  }
-  #################### End of default mirror backend ##########################
-
-  # Serve stale if it exists.
-  if (req.restarts > 0) {
-    set req.backend = sick_force_grace;
-    set req.http.Fastly-Backend-Name = "stale";
   }
 
   # Common config when failover to mirror buckets
-  if (req.restarts > 1) {
+  if (req.restarts > 0) {
     set req.url = req.http.original-url;
 
     # Don't serve from stale for mirrors
@@ -212,7 +222,17 @@ sub vcl_recv {
     }
   }
 
-  # Failover to s3 mirror replica
+  # Failover to primary s3 mirror.
+  if (req.restarts == 1) {
+      set req.backend = F_mirrorS3;
+      set req.http.host = "bar";
+      set req.http.Fastly-Backend-Name = "mirrorS3";
+
+      # Add bucket directory prefix to all the requests
+      set req.url = "/foo_" req.url;
+  }
+
+  # Failover to replica s3 mirror.
   if (req.restarts == 2) {
     set req.backend = F_mirrorS3Replica;
     set req.http.host = "s3-mirror-replica.aws.com";
@@ -222,7 +242,7 @@ sub vcl_recv {
     set req.url = "/s3-mirror-replica" req.url;
   }
 
-  # Failover to GCS mirror
+  # Failover to GCS mirror.
   if (req.restarts > 2) {
     set req.backend = F_mirrorGCS;
     set req.http.host = "gcs-mirror.google.com";
@@ -234,6 +254,7 @@ sub vcl_recv {
     set req.http.Date = now;
     set req.http.Authorization = "AWS gcs-mirror-access-id:" digest.hmac_sha1_base64("gcs-mirror-secret-key", "GET" LF LF LF now LF "/gcs-bucket" req.url.path);
   }
+  
 
   # Unspoofable original client address.
   set req.http.True-Client-IP = req.http.Fastly-Client-IP;
@@ -244,11 +265,112 @@ sub vcl_recv {
     set req.http.TLSversion = tls.client.protocol;
   }
 
-  #FASTLY recv
+
+#FASTLY recv
 
   if (req.request != "HEAD" && req.request != "GET" && req.request != "FASTLYPURGE") {
     return(pass);
   }
+
+    # Begin dynamic section
+if (table.lookup(active_ab_tests, "Example") == "true") {
+  if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
+    set req.http.GOVUK-ABTest-Example = "A";
+  } else if (req.url ~ "[\?\&]ABTest-Example=A(&|$)") {
+    # Some users, such as remote testers, will be given a URL with a query string
+    # to place them into a specific bucket.
+    set req.http.GOVUK-ABTest-Example = "A";
+  } else if (req.url ~ "[\?\&]ABTest-Example=B(&|$)") {
+    # Some users, such as remote testers, will be given a URL with a query string
+    # to place them into a specific bucket.
+    set req.http.GOVUK-ABTest-Example = "B";
+  } else if (req.http.Cookie ~ "ABTest-Example") {
+    # Set the value of the header to whatever decision was previously made
+    set req.http.GOVUK-ABTest-Example = req.http.Cookie:ABTest-Example;
+  } else {
+    declare local var.denominator_Example INTEGER;
+    declare local var.denominator_Example_A INTEGER;
+    declare local var.nominator_Example_A INTEGER;
+    set var.nominator_Example_A = std.atoi(table.lookup(example_percentages, "A"));
+    set var.denominator_Example += var.nominator_Example_A;
+    declare local var.denominator_Example_B INTEGER;
+    declare local var.nominator_Example_B INTEGER;
+    set var.nominator_Example_B = std.atoi(table.lookup(example_percentages, "B"));
+    set var.denominator_Example += var.nominator_Example_B;
+    set var.denominator_Example_A = var.denominator_Example;
+    if (randombool(var.nominator_Example_A, var.denominator_Example_A)) {
+      set req.http.GOVUK-ABTest-Example = "A";
+    } else {
+      set req.http.GOVUK-ABTest-Example = "B";
+    }
+  }
+}
+if (table.lookup(active_ab_tests, "ViewDrivingLicence") == "true") {
+  if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
+    set req.http.GOVUK-ABTest-ViewDrivingLicence = "A";
+  } else if (req.url ~ "[\?\&]ABTest-ViewDrivingLicence=A(&|$)") {
+    # Some users, such as remote testers, will be given a URL with a query string
+    # to place them into a specific bucket.
+    set req.http.GOVUK-ABTest-ViewDrivingLicence = "A";
+  } else if (req.url ~ "[\?\&]ABTest-ViewDrivingLicence=B(&|$)") {
+    # Some users, such as remote testers, will be given a URL with a query string
+    # to place them into a specific bucket.
+    set req.http.GOVUK-ABTest-ViewDrivingLicence = "B";
+  } else if (req.http.Cookie ~ "ABTest-ViewDrivingLicence") {
+    # Set the value of the header to whatever decision was previously made
+    set req.http.GOVUK-ABTest-ViewDrivingLicence = req.http.Cookie:ABTest-ViewDrivingLicence;
+  } else {
+    declare local var.denominator_ViewDrivingLicence INTEGER;
+    declare local var.denominator_ViewDrivingLicence_A INTEGER;
+    declare local var.nominator_ViewDrivingLicence_A INTEGER;
+    set var.nominator_ViewDrivingLicence_A = std.atoi(table.lookup(viewdrivinglicence_percentages, "A"));
+    set var.denominator_ViewDrivingLicence += var.nominator_ViewDrivingLicence_A;
+    declare local var.denominator_ViewDrivingLicence_B INTEGER;
+    declare local var.nominator_ViewDrivingLicence_B INTEGER;
+    set var.nominator_ViewDrivingLicence_B = std.atoi(table.lookup(viewdrivinglicence_percentages, "B"));
+    set var.denominator_ViewDrivingLicence += var.nominator_ViewDrivingLicence_B;
+    set var.denominator_ViewDrivingLicence_A = var.denominator_ViewDrivingLicence;
+    if (randombool(var.nominator_ViewDrivingLicence_A, var.denominator_ViewDrivingLicence_A)) {
+      set req.http.GOVUK-ABTest-ViewDrivingLicence = "A";
+    } else {
+      set req.http.GOVUK-ABTest-ViewDrivingLicence = "B";
+    }
+  }
+}
+if (table.lookup(active_ab_tests, "FinderAnswerABTest") == "true") {
+  if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
+    set req.http.GOVUK-ABTest-FinderAnswerABTest = "A";
+  } else if (req.url ~ "[\?\&]ABTest-FinderAnswerABTest=A(&|$)") {
+    # Some users, such as remote testers, will be given a URL with a query string
+    # to place them into a specific bucket.
+    set req.http.GOVUK-ABTest-FinderAnswerABTest = "A";
+  } else if (req.url ~ "[\?\&]ABTest-FinderAnswerABTest=B(&|$)") {
+    # Some users, such as remote testers, will be given a URL with a query string
+    # to place them into a specific bucket.
+    set req.http.GOVUK-ABTest-FinderAnswerABTest = "B";
+  } else if (req.http.Cookie ~ "ABTest-FinderAnswerABTest") {
+    # Set the value of the header to whatever decision was previously made
+    set req.http.GOVUK-ABTest-FinderAnswerABTest = req.http.Cookie:ABTest-FinderAnswerABTest;
+  } else {
+    declare local var.denominator_FinderAnswerABTest INTEGER;
+    declare local var.denominator_FinderAnswerABTest_A INTEGER;
+    declare local var.nominator_FinderAnswerABTest_A INTEGER;
+    set var.nominator_FinderAnswerABTest_A = std.atoi(table.lookup(finderanswerabtest_percentages, "A"));
+    set var.denominator_FinderAnswerABTest += var.nominator_FinderAnswerABTest_A;
+    declare local var.denominator_FinderAnswerABTest_B INTEGER;
+    declare local var.nominator_FinderAnswerABTest_B INTEGER;
+    set var.nominator_FinderAnswerABTest_B = std.atoi(table.lookup(finderanswerabtest_percentages, "B"));
+    set var.denominator_FinderAnswerABTest += var.nominator_FinderAnswerABTest_B;
+    set var.denominator_FinderAnswerABTest_A = var.denominator_FinderAnswerABTest;
+    if (randombool(var.nominator_FinderAnswerABTest_A, var.denominator_FinderAnswerABTest_A)) {
+      set req.http.GOVUK-ABTest-FinderAnswerABTest = "A";
+    } else {
+      set req.http.GOVUK-ABTest-FinderAnswerABTest = "B";
+    }
+  }
+}
+# End dynamic section
+
 
   return(lookup);
 }
@@ -289,7 +411,7 @@ sub vcl_fetch {
   # a 301 status code. All errors from the mirrors are set to 503 as they
   # cannot know whether or not a page actually exists (e.g. /search is a valid
   # URL but the mirror cannot return it).
-  if (beresp.status != 200 && beresp.http.Fastly-Backend-Name ~ "mirror") {
+  if (beresp.status != 200 && beresp.http.Fastly-Backend-Name ~ "^mirror") {
     set beresp.status = 503;
   }
 
@@ -297,7 +419,7 @@ sub vcl_fetch {
     set req.http.Fastly-Cachetype = "ERROR";
     set beresp.ttl = 1s;
     set beresp.grace = 5s;
-    if (beresp.http.Fastly-Backend-Name ~ "mirrorS3") {
+    if (beresp.http.Fastly-Backend-Name ~ "^mirror") {
       error 503 "Error page";
     }
     return (deliver);
@@ -309,8 +431,8 @@ sub vcl_fetch {
     # apply the default ttl
     set beresp.ttl = 5000s;
 
-    # S3 does not set cache headers by default. Override TTL and add cache-control with 15 minutes
-    if (beresp.http.Fastly-Backend-Name ~ "mirrorS3") {
+    # Mirror buckets do not set cache headers by default. Override TTL and add cache-control with 15 minutes
+    if (beresp.http.Fastly-Backend-Name ~ "^mirror") {
       set beresp.ttl = 900s;
       set beresp.http.Cache-Control = "max-age=900";
     }
@@ -331,6 +453,33 @@ sub vcl_miss {
 }
 
 sub vcl_deliver {
+  # Set the A/B cookies
+  # Only set the A/B example cookie if the request is to the A/B test page. This
+  # ensures that most visitors to the site aren't assigned an irrelevant test
+  # cookie.
+  if (req.url ~ "^/help/ab-testing"
+    && req.http.User-Agent !~ "^GOV\.UK Crawler Worker"
+    && req.http.Cookie !~ "ABTest-Example") {
+    # Set a fairly short cookie expiry because this is just an A/B test demo.
+    add resp.http.Set-Cookie = "ABTest-Example=" req.http.GOVUK-ABTest-Example "; secure; expires=" now + 1d;
+  }
+
+  # Begin dynamic section
+  declare local var.expiry TIME;
+  if (table.lookup(active_ab_tests, "ViewDrivingLicence") == "true") {
+    if (req.http.Cookie !~ "ABTest-ViewDrivingLicence" || req.url ~ "[\?\&]ABTest-ViewDrivingLicence" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
+      set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "ViewDrivingLicence"))));
+      add resp.http.Set-Cookie = "ABTest-ViewDrivingLicence=" req.http.GOVUK-ABTest-ViewDrivingLicence "; secure; expires=" var.expiry "; path=/";
+    }
+  }
+  if (table.lookup(active_ab_tests, "FinderAnswerABTest") == "true") {
+    if (req.http.Cookie !~ "ABTest-FinderAnswerABTest" || req.url ~ "[\?\&]ABTest-FinderAnswerABTest" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
+      set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "FinderAnswerABTest"))));
+      add resp.http.Set-Cookie = "ABTest-FinderAnswerABTest=" req.http.GOVUK-ABTest-FinderAnswerABTest "; secure; expires=" var.expiry "; path=/";
+    }
+  }
+  # End dynamic section
+
   # Set the TLS version session cookie with the raw protocol version from
   # Fastly only if it isn't already set. We also check for a null TLS value,
   # which can occur when trying to access over HTTP (http>https upgrading).
@@ -378,6 +527,17 @@ sub vcl_error {
   }
 
   
+
+  # Serve stale from error subroutine as recommended in:
+  # https://docs.fastly.com/guides/performance-tuning/serving-stale-content
+  # The use of `req.restarts == 0` condition is to enforce the restriction
+  # of serving stale only when the backend is the origin.
+  if ((req.restarts == 0) && (obj.status >= 500 && obj.status < 600)) {
+    /* deliver stale object if it is available */
+    if (stale.exists) {
+      return(deliver_stale);
+    }
+  }
 
   # Assume we've hit vcl_error() because the backend is unavailable
   # for the first two retries. By restarting, vcl_recv() will try

--- a/spec/test-outputs/mirror-staging.out.vcl
+++ b/spec/test-outputs/mirror-staging.out.vcl
@@ -1,3 +1,35 @@
+backend F_origin {
+    .connect_timeout = 5s;
+    .dynamic = true;
+    .port = "443";
+    .host = "foo";
+    .first_byte_timeout = 15s;
+    .max_connections = 200;
+    .between_bytes_timeout = 10s;
+    .share_key = "123";
+
+    .ssl = true;
+    .ssl_check_cert = always;
+    .min_tls_version = "1.2";
+    .ssl_cert_hostname = "foo";
+    .ssl_sni_hostname = "foo";
+
+    .probe = {
+        .request =
+            "HEAD / HTTP/1.1"
+            "Host: foo"
+            "User-Agent: Fastly healthcheck (git version: )"
+            "Connection: close";
+        .threshold = 1;
+        .window = 2;
+        .timeout = 5s;
+        .initial = 1;
+        .expected_response = 200;
+        .interval = 10s;
+    }
+}
+
+
 # Mirror backend for S3
 backend F_mirrorS3 {
     .connect_timeout = 1s;
@@ -94,16 +126,6 @@ backend F_mirrorGCS {
     }
 }
 
-backend sick_force_grace {
-  .host = "127.0.0.1";
-  .port = "1";
-  .probe = {
-    .request = "invalid";
-    .interval = 365d;
-    .initial = 0;
-  }
-}
-
 
 acl purge_ip_whitelist {
   "37.26.93.252";     # Skyscape mirrors
@@ -146,6 +168,13 @@ sub vcl_recv {
     error 403 "Forbidden";
   }
 
+  # Check whether the remote IP address is in the list of blocked IPs
+  if (table.lookup(ip_address_blacklist, client.ip)) {
+    error 403 "Forbidden";
+  }
+
+  
+
   # Force SSL.
   if (!req.http.Fastly-SSL) {
      error 801 "Force SSL";
@@ -159,39 +188,20 @@ sub vcl_recv {
   # Serve from stale for 24 hours if origin is sick
   set req.grace = 24h;
 
-  #################### Start of default mirror backend ########################
+  # Default backend, these details will be overwritten if other backends are
+  # chosen
+  set req.backend = F_origin;
+  set req.http.Fastly-Backend-Name = "origin";
+
+  
+
+  # Save original request url because req.url changes after restarts.
   if (req.restarts < 1) {
     set req.http.original-url = req.url;
-
-    set req.backend = F_mirrorS3;
-    set req.http.host = "bar";
-    set req.http.Fastly-Backend-Name = "mirrorS3";
-
-    # Requests to home page, rewrite to index.html
-    if (req.url ~ "^/?([\?#].*)?$") {
-      set req.url = regsub(req.url, "^/?([\?#].*)?$", "/index.html\1");
-    }
-
-    # Replace multiple /
-    set req.url = regsuball(req.url, "([^:])//+", "\1/");
-
-    # Requests without document extension, rewrite adding .html
-    if (req.url !~ "^([^#\?\s]+)\.(atom|chm|css|csv|diff|doc|docx|dot|dxf|eps|gif|gml|html|ico|ics|jpeg|jpg|JPG|js|json|kml|odp|ods|odt|pdf|PDF|png|ppt|pptx|ps|rdf|rtf|sch|txt|wsdl|xls|xlsm|xlsx|xlt|xml|xsd|xslt|zip)([\?#]+.*)?$") {
-      set req.url = regsub(req.url, "^([^#\?\s]+)([\?#]+.*)?$", "\1.html\2");
-    }
-    # Add bucket directory prefix to all the requests
-    set req.url = "/foo_" req.url;
-  }
-  #################### End of default mirror backend ##########################
-
-  # Serve stale if it exists.
-  if (req.restarts > 0) {
-    set req.backend = sick_force_grace;
-    set req.http.Fastly-Backend-Name = "stale";
   }
 
   # Common config when failover to mirror buckets
-  if (req.restarts > 1) {
+  if (req.restarts > 0) {
     set req.url = req.http.original-url;
 
     # Don't serve from stale for mirrors
@@ -212,7 +222,17 @@ sub vcl_recv {
     }
   }
 
-  # Failover to s3 mirror replica
+  # Failover to primary s3 mirror.
+  if (req.restarts == 1) {
+      set req.backend = F_mirrorS3;
+      set req.http.host = "bar";
+      set req.http.Fastly-Backend-Name = "mirrorS3";
+
+      # Add bucket directory prefix to all the requests
+      set req.url = "/foo_" req.url;
+  }
+
+  # Failover to replica s3 mirror.
   if (req.restarts == 2) {
     set req.backend = F_mirrorS3Replica;
     set req.http.host = "s3-mirror-replica.aws.com";
@@ -222,7 +242,7 @@ sub vcl_recv {
     set req.url = "/s3-mirror-replica" req.url;
   }
 
-  # Failover to GCS mirror
+  # Failover to GCS mirror.
   if (req.restarts > 2) {
     set req.backend = F_mirrorGCS;
     set req.http.host = "gcs-mirror.google.com";
@@ -234,6 +254,7 @@ sub vcl_recv {
     set req.http.Date = now;
     set req.http.Authorization = "AWS gcs-mirror-access-id:" digest.hmac_sha1_base64("gcs-mirror-secret-key", "GET" LF LF LF now LF "/gcs-bucket" req.url.path);
   }
+  
 
   # Unspoofable original client address.
   set req.http.True-Client-IP = req.http.Fastly-Client-IP;
@@ -244,11 +265,112 @@ sub vcl_recv {
     set req.http.TLSversion = tls.client.protocol;
   }
 
-  #FASTLY recv
+
+#FASTLY recv
 
   if (req.request != "HEAD" && req.request != "GET" && req.request != "FASTLYPURGE") {
     return(pass);
   }
+
+    # Begin dynamic section
+if (table.lookup(active_ab_tests, "Example") == "true") {
+  if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
+    set req.http.GOVUK-ABTest-Example = "A";
+  } else if (req.url ~ "[\?\&]ABTest-Example=A(&|$)") {
+    # Some users, such as remote testers, will be given a URL with a query string
+    # to place them into a specific bucket.
+    set req.http.GOVUK-ABTest-Example = "A";
+  } else if (req.url ~ "[\?\&]ABTest-Example=B(&|$)") {
+    # Some users, such as remote testers, will be given a URL with a query string
+    # to place them into a specific bucket.
+    set req.http.GOVUK-ABTest-Example = "B";
+  } else if (req.http.Cookie ~ "ABTest-Example") {
+    # Set the value of the header to whatever decision was previously made
+    set req.http.GOVUK-ABTest-Example = req.http.Cookie:ABTest-Example;
+  } else {
+    declare local var.denominator_Example INTEGER;
+    declare local var.denominator_Example_A INTEGER;
+    declare local var.nominator_Example_A INTEGER;
+    set var.nominator_Example_A = std.atoi(table.lookup(example_percentages, "A"));
+    set var.denominator_Example += var.nominator_Example_A;
+    declare local var.denominator_Example_B INTEGER;
+    declare local var.nominator_Example_B INTEGER;
+    set var.nominator_Example_B = std.atoi(table.lookup(example_percentages, "B"));
+    set var.denominator_Example += var.nominator_Example_B;
+    set var.denominator_Example_A = var.denominator_Example;
+    if (randombool(var.nominator_Example_A, var.denominator_Example_A)) {
+      set req.http.GOVUK-ABTest-Example = "A";
+    } else {
+      set req.http.GOVUK-ABTest-Example = "B";
+    }
+  }
+}
+if (table.lookup(active_ab_tests, "ViewDrivingLicence") == "true") {
+  if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
+    set req.http.GOVUK-ABTest-ViewDrivingLicence = "A";
+  } else if (req.url ~ "[\?\&]ABTest-ViewDrivingLicence=A(&|$)") {
+    # Some users, such as remote testers, will be given a URL with a query string
+    # to place them into a specific bucket.
+    set req.http.GOVUK-ABTest-ViewDrivingLicence = "A";
+  } else if (req.url ~ "[\?\&]ABTest-ViewDrivingLicence=B(&|$)") {
+    # Some users, such as remote testers, will be given a URL with a query string
+    # to place them into a specific bucket.
+    set req.http.GOVUK-ABTest-ViewDrivingLicence = "B";
+  } else if (req.http.Cookie ~ "ABTest-ViewDrivingLicence") {
+    # Set the value of the header to whatever decision was previously made
+    set req.http.GOVUK-ABTest-ViewDrivingLicence = req.http.Cookie:ABTest-ViewDrivingLicence;
+  } else {
+    declare local var.denominator_ViewDrivingLicence INTEGER;
+    declare local var.denominator_ViewDrivingLicence_A INTEGER;
+    declare local var.nominator_ViewDrivingLicence_A INTEGER;
+    set var.nominator_ViewDrivingLicence_A = std.atoi(table.lookup(viewdrivinglicence_percentages, "A"));
+    set var.denominator_ViewDrivingLicence += var.nominator_ViewDrivingLicence_A;
+    declare local var.denominator_ViewDrivingLicence_B INTEGER;
+    declare local var.nominator_ViewDrivingLicence_B INTEGER;
+    set var.nominator_ViewDrivingLicence_B = std.atoi(table.lookup(viewdrivinglicence_percentages, "B"));
+    set var.denominator_ViewDrivingLicence += var.nominator_ViewDrivingLicence_B;
+    set var.denominator_ViewDrivingLicence_A = var.denominator_ViewDrivingLicence;
+    if (randombool(var.nominator_ViewDrivingLicence_A, var.denominator_ViewDrivingLicence_A)) {
+      set req.http.GOVUK-ABTest-ViewDrivingLicence = "A";
+    } else {
+      set req.http.GOVUK-ABTest-ViewDrivingLicence = "B";
+    }
+  }
+}
+if (table.lookup(active_ab_tests, "FinderAnswerABTest") == "true") {
+  if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
+    set req.http.GOVUK-ABTest-FinderAnswerABTest = "A";
+  } else if (req.url ~ "[\?\&]ABTest-FinderAnswerABTest=A(&|$)") {
+    # Some users, such as remote testers, will be given a URL with a query string
+    # to place them into a specific bucket.
+    set req.http.GOVUK-ABTest-FinderAnswerABTest = "A";
+  } else if (req.url ~ "[\?\&]ABTest-FinderAnswerABTest=B(&|$)") {
+    # Some users, such as remote testers, will be given a URL with a query string
+    # to place them into a specific bucket.
+    set req.http.GOVUK-ABTest-FinderAnswerABTest = "B";
+  } else if (req.http.Cookie ~ "ABTest-FinderAnswerABTest") {
+    # Set the value of the header to whatever decision was previously made
+    set req.http.GOVUK-ABTest-FinderAnswerABTest = req.http.Cookie:ABTest-FinderAnswerABTest;
+  } else {
+    declare local var.denominator_FinderAnswerABTest INTEGER;
+    declare local var.denominator_FinderAnswerABTest_A INTEGER;
+    declare local var.nominator_FinderAnswerABTest_A INTEGER;
+    set var.nominator_FinderAnswerABTest_A = std.atoi(table.lookup(finderanswerabtest_percentages, "A"));
+    set var.denominator_FinderAnswerABTest += var.nominator_FinderAnswerABTest_A;
+    declare local var.denominator_FinderAnswerABTest_B INTEGER;
+    declare local var.nominator_FinderAnswerABTest_B INTEGER;
+    set var.nominator_FinderAnswerABTest_B = std.atoi(table.lookup(finderanswerabtest_percentages, "B"));
+    set var.denominator_FinderAnswerABTest += var.nominator_FinderAnswerABTest_B;
+    set var.denominator_FinderAnswerABTest_A = var.denominator_FinderAnswerABTest;
+    if (randombool(var.nominator_FinderAnswerABTest_A, var.denominator_FinderAnswerABTest_A)) {
+      set req.http.GOVUK-ABTest-FinderAnswerABTest = "A";
+    } else {
+      set req.http.GOVUK-ABTest-FinderAnswerABTest = "B";
+    }
+  }
+}
+# End dynamic section
+
 
   return(lookup);
 }
@@ -289,7 +411,7 @@ sub vcl_fetch {
   # a 301 status code. All errors from the mirrors are set to 503 as they
   # cannot know whether or not a page actually exists (e.g. /search is a valid
   # URL but the mirror cannot return it).
-  if (beresp.status != 200 && beresp.http.Fastly-Backend-Name ~ "mirror") {
+  if (beresp.status != 200 && beresp.http.Fastly-Backend-Name ~ "^mirror") {
     set beresp.status = 503;
   }
 
@@ -297,7 +419,7 @@ sub vcl_fetch {
     set req.http.Fastly-Cachetype = "ERROR";
     set beresp.ttl = 1s;
     set beresp.grace = 5s;
-    if (beresp.http.Fastly-Backend-Name ~ "mirrorS3") {
+    if (beresp.http.Fastly-Backend-Name ~ "^mirror") {
       error 503 "Error page";
     }
     return (deliver);
@@ -309,8 +431,8 @@ sub vcl_fetch {
     # apply the default ttl
     set beresp.ttl = 5000s;
 
-    # S3 does not set cache headers by default. Override TTL and add cache-control with 15 minutes
-    if (beresp.http.Fastly-Backend-Name ~ "mirrorS3") {
+    # Mirror buckets do not set cache headers by default. Override TTL and add cache-control with 15 minutes
+    if (beresp.http.Fastly-Backend-Name ~ "^mirror") {
       set beresp.ttl = 900s;
       set beresp.http.Cache-Control = "max-age=900";
     }
@@ -331,6 +453,33 @@ sub vcl_miss {
 }
 
 sub vcl_deliver {
+  # Set the A/B cookies
+  # Only set the A/B example cookie if the request is to the A/B test page. This
+  # ensures that most visitors to the site aren't assigned an irrelevant test
+  # cookie.
+  if (req.url ~ "^/help/ab-testing"
+    && req.http.User-Agent !~ "^GOV\.UK Crawler Worker"
+    && req.http.Cookie !~ "ABTest-Example") {
+    # Set a fairly short cookie expiry because this is just an A/B test demo.
+    add resp.http.Set-Cookie = "ABTest-Example=" req.http.GOVUK-ABTest-Example "; secure; expires=" now + 1d;
+  }
+
+  # Begin dynamic section
+  declare local var.expiry TIME;
+  if (table.lookup(active_ab_tests, "ViewDrivingLicence") == "true") {
+    if (req.http.Cookie !~ "ABTest-ViewDrivingLicence" || req.url ~ "[\?\&]ABTest-ViewDrivingLicence" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
+      set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "ViewDrivingLicence"))));
+      add resp.http.Set-Cookie = "ABTest-ViewDrivingLicence=" req.http.GOVUK-ABTest-ViewDrivingLicence "; secure; expires=" var.expiry "; path=/";
+    }
+  }
+  if (table.lookup(active_ab_tests, "FinderAnswerABTest") == "true") {
+    if (req.http.Cookie !~ "ABTest-FinderAnswerABTest" || req.url ~ "[\?\&]ABTest-FinderAnswerABTest" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
+      set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "FinderAnswerABTest"))));
+      add resp.http.Set-Cookie = "ABTest-FinderAnswerABTest=" req.http.GOVUK-ABTest-FinderAnswerABTest "; secure; expires=" var.expiry "; path=/";
+    }
+  }
+  # End dynamic section
+
   # Set the TLS version session cookie with the raw protocol version from
   # Fastly only if it isn't already set. We also check for a null TLS value,
   # which can occur when trying to access over HTTP (http>https upgrading).
@@ -378,6 +527,17 @@ sub vcl_error {
   }
 
   
+
+  # Serve stale from error subroutine as recommended in:
+  # https://docs.fastly.com/guides/performance-tuning/serving-stale-content
+  # The use of `req.restarts == 0` condition is to enforce the restriction
+  # of serving stale only when the backend is the origin.
+  if ((req.restarts == 0) && (obj.status >= 500 && obj.status < 600)) {
+    /* deliver stale object if it is available */
+    if (stale.exists) {
+      return(deliver_stale);
+    }
+  }
 
   # Assume we've hit vcl_error() because the backend is unavailable
   # for the first two retries. By restarting, vcl_recv() will try

--- a/vcl_templates/mirror.vcl.erb
+++ b/vcl_templates/mirror.vcl.erb
@@ -1,3 +1,44 @@
+backend F_origin {
+    .connect_timeout = 5s;
+    .dynamic = true;
+    .port = "<%= config.fetch('origin_port', 443) %>";
+    .host = "<%= config.fetch('origin_hostname') %>";
+    .first_byte_timeout = 15s;
+    .max_connections = 200;
+    .between_bytes_timeout = 10s;
+    .share_key = "<%= config.fetch('service_id') %>";
+
+    .ssl = true;
+    .ssl_check_cert = <%= config['disable_tls_validation'] ? 'never' : 'always' %>;
+    .min_tls_version = "<%= config.fetch('min_tls_version', '1.2') %>";
+    <%- if config['ssl_ciphers'] -%>
+    .ssl_ciphers = "<%= config['ssl_ciphers'] -%>";
+    <%- end -%>
+    .ssl_cert_hostname = "<%= config.fetch('ssl_cert_hostname', config.fetch('origin_hostname')) %>";
+    .ssl_sni_hostname = "<%= config.fetch('ssl_sni_hostname', config.fetch('origin_hostname')) %>";
+
+    .probe = {
+        .request =
+            "HEAD / HTTP/1.1"
+            "Host: <%= config.fetch('origin_hostname') %>"
+            "User-Agent: Fastly healthcheck (git version: <%= config['git_version'] %>)"
+<% if config['rate_limit_token'] -%>
+            "Rate-Limit-Token: <%= config['rate_limit_token'] %>"
+<% end -%>
+<% if config['basic_authentication'] -%>
+            "Authorization: Basic <%= config['basic_authentication'] %>"
+<% end -%>
+            "Connection: close";
+        .threshold = 1;
+        .window = 2;
+        .timeout = 5s;
+        .initial = 1;
+        .expected_response = 200;
+        .interval = 10s;
+    }
+}
+
+<% if %w(staging production).include?(environment) %>
 # Mirror backend for S3
 backend F_mirrorS3 {
     .connect_timeout = 1s;
@@ -102,17 +143,7 @@ backend F_mirrorGCS {
         .interval = 10s;
     }
 }
-
-backend sick_force_grace {
-  .host = "127.0.0.1";
-  .port = "1";
-  .probe = {
-    .request = "invalid";
-    .interval = 365d;
-    .initial = 0;
-  }
-}
-
+<% end %>
 
 acl purge_ip_whitelist {
   "37.26.93.252";     # Skyscape mirrors
@@ -162,6 +193,20 @@ sub vcl_recv {
     error 403 "Forbidden";
   }
 
+  # Check whether the remote IP address is in the list of blocked IPs
+  if (table.lookup(ip_address_blacklist, client.ip)) {
+    error 403 "Forbidden";
+  }
+
+  <% if config['basic_authentication'] %>
+  if (! (client.ip ~ allowed_ip_addresses)) {
+    # Check whether the basic auth credentials are correct in integration
+    if (req.http.Authorization != "Basic <%= config['basic_authentication'] %>") {
+      error 401 "Unauthorized";
+    }
+  }
+  <% end %>
+
   # Force SSL.
   if (!req.http.Fastly-SSL) {
      error 801 "Force SSL";
@@ -175,39 +220,20 @@ sub vcl_recv {
   # Serve from stale for 24 hours if origin is sick
   set req.grace = 24h;
 
-  #################### Start of default mirror backend ########################
+  # Default backend, these details will be overwritten if other backends are
+  # chosen
+  set req.backend = F_origin;
+  set req.http.Fastly-Backend-Name = "origin";
+
+  <% if %w(staging production).include?(environment) %>
+
+  # Save original request url because req.url changes after restarts.
   if (req.restarts < 1) {
     set req.http.original-url = req.url;
-
-    set req.backend = F_mirrorS3;
-    set req.http.host = "<%= config.fetch('s3_mirror_hostname') %>";
-    set req.http.Fastly-Backend-Name = "mirrorS3";
-
-    # Requests to home page, rewrite to index.html
-    if (req.url ~ "^/?([\?#].*)?$") {
-      set req.url = regsub(req.url, "^/?([\?#].*)?$", "/index.html\1");
-    }
-
-    # Replace multiple /
-    set req.url = regsuball(req.url, "([^:])//+", "\1/");
-
-    # Requests without document extension, rewrite adding .html
-    if (req.url !~ "^([^#\?\s]+)\.(atom|chm|css|csv|diff|doc|docx|dot|dxf|eps|gif|gml|html|ico|ics|jpeg|jpg|JPG|js|json|kml|odp|ods|odt|pdf|PDF|png|ppt|pptx|ps|rdf|rtf|sch|txt|wsdl|xls|xlsm|xlsx|xlt|xml|xsd|xslt|zip)([\?#]+.*)?$") {
-      set req.url = regsub(req.url, "^([^#\?\s]+)([\?#]+.*)?$", "\1.html\2");
-    }
-    # Add bucket directory prefix to all the requests
-    set req.url = "/<%= config.fetch('s3_mirror_prefix') %>" req.url;
-  }
-  #################### End of default mirror backend ##########################
-
-  # Serve stale if it exists.
-  if (req.restarts > 0) {
-    set req.backend = sick_force_grace;
-    set req.http.Fastly-Backend-Name = "stale";
   }
 
   # Common config when failover to mirror buckets
-  if (req.restarts > 1) {
+  if (req.restarts > 0) {
     set req.url = req.http.original-url;
 
     # Don't serve from stale for mirrors
@@ -228,7 +254,17 @@ sub vcl_recv {
     }
   }
 
-  # Failover to s3 mirror replica
+  # Failover to primary s3 mirror.
+  if (req.restarts == 1) {
+      set req.backend = F_mirrorS3;
+      set req.http.host = "<%= config.fetch('s3_mirror_hostname') %>";
+      set req.http.Fastly-Backend-Name = "mirrorS3";
+
+      # Add bucket directory prefix to all the requests
+      set req.url = "/<%= config.fetch('s3_mirror_prefix') %>" req.url;
+  }
+
+  # Failover to replica s3 mirror.
   if (req.restarts == 2) {
     set req.backend = F_mirrorS3Replica;
     set req.http.host = "<%= config.fetch('s3_mirror_replica_hostname') %>";
@@ -238,7 +274,7 @@ sub vcl_recv {
     set req.url = "/<%= config.fetch('s3_mirror_replica_prefix') %>" req.url;
   }
 
-  # Failover to GCS mirror
+  # Failover to GCS mirror.
   if (req.restarts > 2) {
     set req.backend = F_mirrorGCS;
     set req.http.host = "<%= config.fetch('gcs_mirror_hostname') %>";
@@ -250,6 +286,7 @@ sub vcl_recv {
     set req.http.Date = now;
     set req.http.Authorization = "AWS <%= config.fetch('gcs_mirror_access_id') %>:" digest.hmac_sha1_base64("<%= config.fetch('gcs_mirror_secret_key') %>", "GET" LF LF LF now LF "/<%= config.fetch('gcs_mirror_bucket_name') %>" req.url.path);
   }
+  <% end %>
 
   # Unspoofable original client address.
   set req.http.True-Client-IP = req.http.Fastly-Client-IP;
@@ -260,11 +297,20 @@ sub vcl_recv {
     set req.http.TLSversion = tls.client.protocol;
   }
 
-  #FASTLY recv
+<% if config['basic_authentication'] -%>
+  if (req.backend == F_origin) {
+    set req.http.Authorization = "Basic <%= config['basic_authentication'] %>";
+  }
+<% end -%>
+
+#FASTLY recv
 
   if (req.request != "HEAD" && req.request != "GET" && req.request != "FASTLYPURGE") {
     return(pass);
   }
+
+  <% template_path = File.join(File.dirname(__FILE__), "vcl_templates/_multivariate_tests.vcl.erb") -%>
+  <%= ERB.new(File.new(template_path).read, nil, "-", "_erbout2").result(binding) %>
 
   return(lookup);
 }
@@ -305,7 +351,7 @@ sub vcl_fetch {
   # a 301 status code. All errors from the mirrors are set to 503 as they
   # cannot know whether or not a page actually exists (e.g. /search is a valid
   # URL but the mirror cannot return it).
-  if (beresp.status != 200 && beresp.http.Fastly-Backend-Name ~ "mirror") {
+  if (beresp.status != 200 && beresp.http.Fastly-Backend-Name ~ "^mirror") {
     set beresp.status = 503;
   }
 
@@ -313,7 +359,7 @@ sub vcl_fetch {
     set req.http.Fastly-Cachetype = "ERROR";
     set beresp.ttl = 1s;
     set beresp.grace = 5s;
-    if (beresp.http.Fastly-Backend-Name ~ "mirrorS3") {
+    if (beresp.http.Fastly-Backend-Name ~ "^mirror") {
       error 503 "Error page";
     }
     return (deliver);
@@ -325,8 +371,8 @@ sub vcl_fetch {
     # apply the default ttl
     set beresp.ttl = <%= config.fetch('default_ttl') %>s;
 
-    # S3 does not set cache headers by default. Override TTL and add cache-control with 15 minutes
-    if (beresp.http.Fastly-Backend-Name ~ "mirrorS3") {
+    # Mirror buckets do not set cache headers by default. Override TTL and add cache-control with 15 minutes
+    if (beresp.http.Fastly-Backend-Name ~ "^mirror") {
       set beresp.ttl = 900s;
       set beresp.http.Cache-Control = "max-age=900";
     }
@@ -347,6 +393,35 @@ sub vcl_miss {
 }
 
 sub vcl_deliver {
+  # Set the A/B cookies
+  # Only set the A/B example cookie if the request is to the A/B test page. This
+  # ensures that most visitors to the site aren't assigned an irrelevant test
+  # cookie.
+  if (req.url ~ "^/help/ab-testing"
+    && req.http.User-Agent !~ "^GOV\.UK Crawler Worker"
+    && req.http.Cookie !~ "ABTest-Example") {
+    # Set a fairly short cookie expiry because this is just an A/B test demo.
+    add resp.http.Set-Cookie = "ABTest-Example=" req.http.GOVUK-ABTest-Example "; secure; expires=" now + 1d;
+  }
+
+  # Begin dynamic section
+<% if ab_tests -%>
+  declare local var.expiry TIME;
+<% ab_tests.each do |test_config| -%>
+<% test_config.each do |test, _| -%>
+<% unless test == "Example" -%>
+  if (table.lookup(active_ab_tests, "<%= test %>") == "true") {
+    if (req.http.Cookie !~ "ABTest-<%= test %>" || req.url ~ "[\?\&]ABTest-<%= test %>" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
+      set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "<%= test %>"))));
+      add resp.http.Set-Cookie = "ABTest-<%= test %>=" req.http.GOVUK-ABTest-<%= test %> "; secure; expires=" var.expiry "; path=/";
+    }
+  }
+<% end # unless -%>
+<% end # test_config.each -%>
+<% end # ab_tests.each -%>
+<% end # if -%>
+  # End dynamic section
+
   # Set the TLS version session cookie with the raw protocol version from
   # Fastly only if it isn't already set. We also check for a null TLS value,
   # which can occur when trying to access over HTTP (http>https upgrading).
@@ -400,6 +475,17 @@ sub vcl_error {
     return (deliver);
   }
   <% end %>
+
+  # Serve stale from error subroutine as recommended in:
+  # https://docs.fastly.com/guides/performance-tuning/serving-stale-content
+  # The use of `req.restarts == 0` condition is to enforce the restriction
+  # of serving stale only when the backend is the origin.
+  if ((req.restarts == 0) && (obj.status >= 500 && obj.status < 600)) {
+    /* deliver stale object if it is available */
+    if (stale.exists) {
+      return(deliver_stale);
+    }
+  }
 
   # Assume we've hit vcl_error() because the backend is unavailable
   # for the first two retries. By restarting, vcl_recv() will try


### PR DESCRIPTION
# Context

The `mirror` fastly service is used to test the mirrors for `www` fastly service.
Hence, the `mirror` fastly service will have the same vcl as the `www` fastly service except for:
1. clients should be in the whitelist to access the `mirror` fastly service.

We test the mirrors after deploying the `mirror` fastly service by going into the fastly management console and change the active vcl for the service so that it points to an unreachable origin and therefore the service will fallback to mirrors.

# Decisions
1. copy the future www template vcl to be tested to mirror template vcl and modify the template vcl to restrict client for all environments rather than staging and integration only. 
