### PR TITLE
New www and assets vcl mirror

### DIFF
--- a/spec/test-outputs/assets-integration.out.vcl
+++ b/spec/test-outputs/assets-integration.out.vcl
@@ -61,78 +61,6 @@ backend F_awsorigin {
       }
 }
 
-# Mirror backend for provider 0
-backend F_mirror1 {
-    .connect_timeout = 1s;
-    .dynamic = true;
-    .port = "443";
-    .host = "foo";
-    .first_byte_timeout = 15s;
-    .max_connections = 200;
-    .between_bytes_timeout = 10s;
-    .share_key = "123";
-
-    .ssl = true;
-    .ssl_check_cert = always;
-    .min_tls_version = "1.2";
-    .ssl_cert_hostname = "foo";
-    .ssl_sni_hostname = "foo";
-
-    .probe = {
-        .request =
-            "HEAD /__canary__ HTTP/1.1"
-            "Host: foo"
-            "User-Agent: Fastly healthcheck (git version: )"
-            "Connection: close";
-        .threshold = 1;
-        .window = 2;
-        .timeout = 5s;
-        .initial = 1;
-        .expected_response = 200;
-        .interval = 10s;
-    }
-}
-# Mirror backend for S3
-backend F_mirrorS3 {
-    .connect_timeout = 1s;
-    .dynamic = true;
-    .port = "443";
-    .host = "bar";
-    .first_byte_timeout = 15s;
-    .max_connections = 200;
-    .between_bytes_timeout = 10s;
-    .share_key = "123";
-
-    .ssl = true;
-    .ssl_check_cert = always;
-    .min_tls_version = "1.2";
-    .ssl_cert_hostname = "bar";
-    .ssl_sni_hostname = "bar";
-
-    .probe = {
-        .request =
-            "HEAD / HTTP/1.1"
-            "Host: bar"
-            "User-Agent: Fastly healthcheck (git version: )"
-            "Connection: close";
-        .threshold = 1;
-        .window = 2;
-        .timeout = 5s;
-        .initial = 1;
-        .expected_response = 200;
-        .interval = 10s;
-    }
-}
-
-backend sick_force_grace {
-  .host = "127.0.0.1";
-  .port = "1";
-  .probe = {
-    .request = "invalid";
-    .interval = 365d;
-    .initial = 0;
-  }
-}
 
 
 acl purge_ip_whitelist {
@@ -191,35 +119,7 @@ sub vcl_recv {
       set req.http.host = "foo";
   }
 
-  # Serve stale if it exists.
-  if (req.restarts > 0) {
-    set req.backend = sick_force_grace;
-    set req.http.Fastly-Backend-Name = "stale";
-  }
-
-  # Failover to mirror.
-  if (req.restarts > 1) {
-    # Don't serve from stale for mirrors
-    set req.grace = 0s;
-    set req.http.Fastly-Failover = "1";
-
-    set req.backend = F_mirror1;
-    set req.http.Fastly-Backend-Name = "mirror1";
-    set req.http.host = "foo";
-  }
-
-  # FIXME: Prefer a fallback director if we move to Varnish 3
-  if (req.restarts > 2) {
-    set req.backend = F_mirrorS3;
-    set req.http.host = "bar";
-    set req.http.Fastly-Backend-Name = "mirrorS3";
-
-    # Replace multiple /
-    set req.url = regsuball(req.url, "([^:])//+", "\1/");
-
-    # Rewrite adding bucket directory prefix
-    set req.url = "/foo_" req.url;
-  }
+  
 
   # Unspoofable original client address.
   set req.http.True-Client-IP = req.http.Fastly-Client-IP;
@@ -320,6 +220,17 @@ sub vcl_error {
     set obj.status = 200;
     synthetic {""};
     return(deliver);
+  }
+
+  # Serve stale from error subroutine as recommended in:
+  # https://docs.fastly.com/guides/performance-tuning/serving-stale-content
+  # The use of `req.restarts == 0` condition is to enforce the restriction
+  # of serving stale only when the backend is the origin.
+  if ((req.restarts == 0) && (obj.status >= 500 && obj.status < 600)) {
+    /* deliver stale object if it is available */
+    if (stale.exists) {
+      return(deliver_stale);
+    }
   }
 
   # Assume we've hit vcl_error() because the backend is unavailable

--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -28,37 +28,8 @@ backend F_origin {
         .interval = 10s;
     }
 }
-# Mirror backend for provider 0
-backend F_mirror1 {
-    .connect_timeout = 1s;
-    .dynamic = true;
-    .port = "443";
-    .host = "foo";
-    .first_byte_timeout = 15s;
-    .max_connections = 200;
-    .between_bytes_timeout = 10s;
-    .share_key = "123";
 
-    .ssl = true;
-    .ssl_check_cert = always;
-    .min_tls_version = "1.2";
-    .ssl_cert_hostname = "foo";
-    .ssl_sni_hostname = "foo";
 
-    .probe = {
-        .request =
-            "HEAD / HTTP/1.1"
-            "Host: foo"
-            "User-Agent: Fastly healthcheck (git version: )"
-            "Connection: close";
-        .threshold = 1;
-        .window = 2;
-        .timeout = 5s;
-        .initial = 1;
-        .expected_response = 200;
-        .interval = 10s;
-    }
-}
 # Mirror backend for S3
 backend F_mirrorS3 {
     .connect_timeout = 1s;
@@ -91,14 +62,68 @@ backend F_mirrorS3 {
     }
 }
 
-backend sick_force_grace {
-  .host = "127.0.0.1";
-  .port = "1";
-  .probe = {
-    .request = "invalid";
-    .interval = 365d;
-    .initial = 0;
-  }
+# Mirror backend for S3 replica
+backend F_mirrorS3Replica {
+    .connect_timeout = 1s;
+    .dynamic = true;
+    .port = "443";
+    .host = "s3-mirror-replica.aws.com";
+    .first_byte_timeout = 15s;
+    .max_connections = 200;
+    .between_bytes_timeout = 10s;
+    .share_key = "123";
+
+    .ssl = true;
+    .ssl_check_cert = always;
+    .min_tls_version = "1.2";
+    .ssl_cert_hostname = "s3-mirror-replica.aws.com";
+    .ssl_sni_hostname = "s3-mirror-replica.aws.com";
+
+    .probe = {
+        .request =
+            "HEAD / HTTP/1.1"
+            "Host: s3-mirror-replica.aws.com"
+            "User-Agent: Fastly healthcheck (git version: )"
+            "Connection: close";
+        .threshold = 1;
+        .window = 2;
+        .timeout = 5s;
+        .initial = 1;
+        .expected_response = 200;
+        .interval = 10s;
+    }
+}
+
+# Mirror backend for GCS
+backend F_mirrorGCS {
+    .connect_timeout = 1s;
+    .dynamic = true;
+    .port = "443";
+    .host = "gcs-mirror.google.com";
+    .first_byte_timeout = 15s;
+    .max_connections = 200;
+    .between_bytes_timeout = 10s;
+    .share_key = "123";
+
+    .ssl = true;
+    .ssl_check_cert = always;
+    .min_tls_version = "1.2";
+    .ssl_cert_hostname = "gcs-mirror.google.com";
+    .ssl_sni_hostname = "gcs-mirror.google.com";
+
+    .probe = {
+        .request =
+            "HEAD / HTTP/1.1"
+            "Host: gcs-mirror.google.com"
+            "User-Agent: Fastly healthcheck (git version: )"
+            "Connection: close";
+        .threshold = 1;
+        .window = 2;
+        .timeout = 5s;
+        .initial = 1;
+        .expected_response = 403;
+        .interval = 10s;
+    }
 }
 
 
@@ -158,32 +183,25 @@ sub vcl_recv {
   # Serve from stale for 24 hours if origin is sick
   set req.grace = 24h;
 
-  # Default backend.
+  # Default backend, these details will be overwritten if other backends are
+  # chosen
   set req.backend = F_origin;
   set req.http.Fastly-Backend-Name = "origin";
 
-  # Serve stale if it exists.
-  if (req.restarts > 0) {
-    set req.backend = sick_force_grace;
-    set req.http.Fastly-Backend-Name = "stale";
+  
+
+  # Save original request url because req.url changes after restarts.
+  if (req.restarts < 1) {
+    set req.http.original-url = req.url;
   }
 
-  # Failover to mirror.
-  if (req.restarts > 1) {
+  # Common config when failover to mirror buckets
+  if (req.restarts > 0) {
+    set req.url = req.http.original-url;
+
     # Don't serve from stale for mirrors
     set req.grace = 0s;
     set req.http.Fastly-Failover = "1";
-
-    set req.backend = F_mirror1;
-    set req.http.host = "foo";
-    set req.http.Fastly-Backend-Name = "mirror1";
-  }
-
-  # FIXME: Prefer a fallback director if we move to Varnish 3
-  if (req.restarts > 2) {
-    set req.backend = F_mirrorS3;
-    set req.http.host = "bar";
-    set req.http.Fastly-Backend-Name = "mirrorS3";
 
     # Requests to home page, rewrite to index.html
     if (req.url ~ "^/?([\?#].*)?$") {
@@ -197,9 +215,41 @@ sub vcl_recv {
     if (req.url !~ "^([^#\?\s]+)\.(atom|chm|css|csv|diff|doc|docx|dot|dxf|eps|gif|gml|html|ico|ics|jpeg|jpg|JPG|js|json|kml|odp|ods|odt|pdf|PDF|png|ppt|pptx|ps|rdf|rtf|sch|txt|wsdl|xls|xlsm|xlsx|xlt|xml|xsd|xslt|zip)([\?#]+.*)?$") {
       set req.url = regsub(req.url, "^([^#\?\s]+)([\?#]+.*)?$", "\1.html\2");
     }
-    # Add bucket directory prefix to all the requests
-    set req.url = "/foo_" req.url;
   }
+
+  # Failover to primary s3 mirror.
+  if (req.restarts == 1) {
+      set req.backend = F_mirrorS3;
+      set req.http.host = "bar";
+      set req.http.Fastly-Backend-Name = "mirrorS3";
+
+      # Add bucket directory prefix to all the requests
+      set req.url = "/foo_" req.url;
+  }
+
+  # Failover to replica s3 mirror.
+  if (req.restarts == 2) {
+    set req.backend = F_mirrorS3Replica;
+    set req.http.host = "s3-mirror-replica.aws.com";
+    set req.http.Fastly-Backend-Name = "mirrorS3Replica";
+
+    # Add bucket directory prefix to all the requests
+    set req.url = "/s3-mirror-replica" req.url;
+  }
+
+  # Failover to GCS mirror.
+  if (req.restarts > 2) {
+    set req.backend = F_mirrorGCS;
+    set req.http.host = "gcs-mirror.google.com";
+    set req.http.Fastly-Backend-Name = "mirrorGCS";
+
+    # Add bucket directory prefix to all the requests
+    set req.url = "/gcs-mirror" req.url;
+
+    set req.http.Date = now;
+    set req.http.Authorization = "AWS gcs-mirror-access-id:" digest.hmac_sha1_base64("gcs-mirror-secret-key", "GET" LF LF LF now LF "/gcs-bucket" req.url.path);
+  }
+  
 
   # Unspoofable original client address.
   set req.http.True-Client-IP = req.http.Fastly-Client-IP;
@@ -356,7 +406,7 @@ sub vcl_fetch {
   # a 301 status code. All errors from the mirrors are set to 503 as they
   # cannot know whether or not a page actually exists (e.g. /search is a valid
   # URL but the mirror cannot return it).
-  if (beresp.status != 200 && beresp.http.Fastly-Backend-Name ~ "mirror") {
+  if (beresp.status != 200 && beresp.http.Fastly-Backend-Name ~ "^mirror") {
     set beresp.status = 503;
   }
 
@@ -364,7 +414,7 @@ sub vcl_fetch {
     set req.http.Fastly-Cachetype = "ERROR";
     set beresp.ttl = 1s;
     set beresp.grace = 5s;
-    if (beresp.http.Fastly-Backend-Name ~ "mirrorS3") {
+    if (beresp.http.Fastly-Backend-Name ~ "^mirror") {
       error 503 "Error page";
     }
     return (deliver);
@@ -376,8 +426,8 @@ sub vcl_fetch {
     # apply the default ttl
     set beresp.ttl = 5000s;
 
-    # S3 does not set cache headers by default. Override TTL and add cache-control with 15 minutes
-    if (beresp.http.Fastly-Backend-Name ~ "mirrorS3") {
+    # Mirror buckets do not set cache headers by default. Override TTL and add cache-control with 15 minutes
+    if (beresp.http.Fastly-Backend-Name ~ "^mirror") {
       set beresp.ttl = 900s;
       set beresp.http.Cache-Control = "max-age=900";
     }
@@ -472,6 +522,17 @@ sub vcl_error {
   }
 
   
+
+  # Serve stale from error subroutine as recommended in:
+  # https://docs.fastly.com/guides/performance-tuning/serving-stale-content
+  # The use of `req.restarts == 0` condition is to enforce the restriction
+  # of serving stale only when the backend is the origin.
+  if ((req.restarts == 0) && (obj.status >= 500 && obj.status < 600)) {
+    /* deliver stale object if it is available */
+    if (stale.exists) {
+      return(deliver_stale);
+    }
+  }
 
   # Assume we've hit vcl_error() because the backend is unavailable
   # for the first two retries. By restarting, vcl_recv() will try

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -28,37 +28,8 @@ backend F_origin {
         .interval = 10s;
     }
 }
-# Mirror backend for provider 0
-backend F_mirror1 {
-    .connect_timeout = 1s;
-    .dynamic = true;
-    .port = "443";
-    .host = "foo";
-    .first_byte_timeout = 15s;
-    .max_connections = 200;
-    .between_bytes_timeout = 10s;
-    .share_key = "123";
 
-    .ssl = true;
-    .ssl_check_cert = always;
-    .min_tls_version = "1.2";
-    .ssl_cert_hostname = "foo";
-    .ssl_sni_hostname = "foo";
 
-    .probe = {
-        .request =
-            "HEAD / HTTP/1.1"
-            "Host: foo"
-            "User-Agent: Fastly healthcheck (git version: )"
-            "Connection: close";
-        .threshold = 1;
-        .window = 2;
-        .timeout = 5s;
-        .initial = 1;
-        .expected_response = 200;
-        .interval = 10s;
-    }
-}
 # Mirror backend for S3
 backend F_mirrorS3 {
     .connect_timeout = 1s;
@@ -91,14 +62,68 @@ backend F_mirrorS3 {
     }
 }
 
-backend sick_force_grace {
-  .host = "127.0.0.1";
-  .port = "1";
-  .probe = {
-    .request = "invalid";
-    .interval = 365d;
-    .initial = 0;
-  }
+# Mirror backend for S3 replica
+backend F_mirrorS3Replica {
+    .connect_timeout = 1s;
+    .dynamic = true;
+    .port = "443";
+    .host = "s3-mirror-replica.aws.com";
+    .first_byte_timeout = 15s;
+    .max_connections = 200;
+    .between_bytes_timeout = 10s;
+    .share_key = "123";
+
+    .ssl = true;
+    .ssl_check_cert = always;
+    .min_tls_version = "1.2";
+    .ssl_cert_hostname = "s3-mirror-replica.aws.com";
+    .ssl_sni_hostname = "s3-mirror-replica.aws.com";
+
+    .probe = {
+        .request =
+            "HEAD / HTTP/1.1"
+            "Host: s3-mirror-replica.aws.com"
+            "User-Agent: Fastly healthcheck (git version: )"
+            "Connection: close";
+        .threshold = 1;
+        .window = 2;
+        .timeout = 5s;
+        .initial = 1;
+        .expected_response = 200;
+        .interval = 10s;
+    }
+}
+
+# Mirror backend for GCS
+backend F_mirrorGCS {
+    .connect_timeout = 1s;
+    .dynamic = true;
+    .port = "443";
+    .host = "gcs-mirror.google.com";
+    .first_byte_timeout = 15s;
+    .max_connections = 200;
+    .between_bytes_timeout = 10s;
+    .share_key = "123";
+
+    .ssl = true;
+    .ssl_check_cert = always;
+    .min_tls_version = "1.2";
+    .ssl_cert_hostname = "gcs-mirror.google.com";
+    .ssl_sni_hostname = "gcs-mirror.google.com";
+
+    .probe = {
+        .request =
+            "HEAD / HTTP/1.1"
+            "Host: gcs-mirror.google.com"
+            "User-Agent: Fastly healthcheck (git version: )"
+            "Connection: close";
+        .threshold = 1;
+        .window = 2;
+        .timeout = 5s;
+        .initial = 1;
+        .expected_response = 403;
+        .interval = 10s;
+    }
 }
 
 
@@ -167,32 +192,25 @@ sub vcl_recv {
   # Serve from stale for 24 hours if origin is sick
   set req.grace = 24h;
 
-  # Default backend.
+  # Default backend, these details will be overwritten if other backends are
+  # chosen
   set req.backend = F_origin;
   set req.http.Fastly-Backend-Name = "origin";
 
-  # Serve stale if it exists.
-  if (req.restarts > 0) {
-    set req.backend = sick_force_grace;
-    set req.http.Fastly-Backend-Name = "stale";
+  
+
+  # Save original request url because req.url changes after restarts.
+  if (req.restarts < 1) {
+    set req.http.original-url = req.url;
   }
 
-  # Failover to mirror.
-  if (req.restarts > 1) {
+  # Common config when failover to mirror buckets
+  if (req.restarts > 0) {
+    set req.url = req.http.original-url;
+
     # Don't serve from stale for mirrors
     set req.grace = 0s;
     set req.http.Fastly-Failover = "1";
-
-    set req.backend = F_mirror1;
-    set req.http.host = "foo";
-    set req.http.Fastly-Backend-Name = "mirror1";
-  }
-
-  # FIXME: Prefer a fallback director if we move to Varnish 3
-  if (req.restarts > 2) {
-    set req.backend = F_mirrorS3;
-    set req.http.host = "bar";
-    set req.http.Fastly-Backend-Name = "mirrorS3";
 
     # Requests to home page, rewrite to index.html
     if (req.url ~ "^/?([\?#].*)?$") {
@@ -206,9 +224,41 @@ sub vcl_recv {
     if (req.url !~ "^([^#\?\s]+)\.(atom|chm|css|csv|diff|doc|docx|dot|dxf|eps|gif|gml|html|ico|ics|jpeg|jpg|JPG|js|json|kml|odp|ods|odt|pdf|PDF|png|ppt|pptx|ps|rdf|rtf|sch|txt|wsdl|xls|xlsm|xlsx|xlt|xml|xsd|xslt|zip)([\?#]+.*)?$") {
       set req.url = regsub(req.url, "^([^#\?\s]+)([\?#]+.*)?$", "\1.html\2");
     }
-    # Add bucket directory prefix to all the requests
-    set req.url = "/foo_" req.url;
   }
+
+  # Failover to primary s3 mirror.
+  if (req.restarts == 1) {
+      set req.backend = F_mirrorS3;
+      set req.http.host = "bar";
+      set req.http.Fastly-Backend-Name = "mirrorS3";
+
+      # Add bucket directory prefix to all the requests
+      set req.url = "/foo_" req.url;
+  }
+
+  # Failover to replica s3 mirror.
+  if (req.restarts == 2) {
+    set req.backend = F_mirrorS3Replica;
+    set req.http.host = "s3-mirror-replica.aws.com";
+    set req.http.Fastly-Backend-Name = "mirrorS3Replica";
+
+    # Add bucket directory prefix to all the requests
+    set req.url = "/s3-mirror-replica" req.url;
+  }
+
+  # Failover to GCS mirror.
+  if (req.restarts > 2) {
+    set req.backend = F_mirrorGCS;
+    set req.http.host = "gcs-mirror.google.com";
+    set req.http.Fastly-Backend-Name = "mirrorGCS";
+
+    # Add bucket directory prefix to all the requests
+    set req.url = "/gcs-mirror" req.url;
+
+    set req.http.Date = now;
+    set req.http.Authorization = "AWS gcs-mirror-access-id:" digest.hmac_sha1_base64("gcs-mirror-secret-key", "GET" LF LF LF now LF "/gcs-bucket" req.url.path);
+  }
+  
 
   # Unspoofable original client address.
   set req.http.True-Client-IP = req.http.Fastly-Client-IP;
@@ -365,7 +415,7 @@ sub vcl_fetch {
   # a 301 status code. All errors from the mirrors are set to 503 as they
   # cannot know whether or not a page actually exists (e.g. /search is a valid
   # URL but the mirror cannot return it).
-  if (beresp.status != 200 && beresp.http.Fastly-Backend-Name ~ "mirror") {
+  if (beresp.status != 200 && beresp.http.Fastly-Backend-Name ~ "^mirror") {
     set beresp.status = 503;
   }
 
@@ -373,7 +423,7 @@ sub vcl_fetch {
     set req.http.Fastly-Cachetype = "ERROR";
     set beresp.ttl = 1s;
     set beresp.grace = 5s;
-    if (beresp.http.Fastly-Backend-Name ~ "mirrorS3") {
+    if (beresp.http.Fastly-Backend-Name ~ "^mirror") {
       error 503 "Error page";
     }
     return (deliver);
@@ -385,8 +435,8 @@ sub vcl_fetch {
     # apply the default ttl
     set beresp.ttl = 5000s;
 
-    # S3 does not set cache headers by default. Override TTL and add cache-control with 15 minutes
-    if (beresp.http.Fastly-Backend-Name ~ "mirrorS3") {
+    # Mirror buckets do not set cache headers by default. Override TTL and add cache-control with 15 minutes
+    if (beresp.http.Fastly-Backend-Name ~ "^mirror") {
       set beresp.ttl = 900s;
       set beresp.http.Cache-Control = "max-age=900";
     }
@@ -481,6 +531,17 @@ sub vcl_error {
   }
 
   
+
+  # Serve stale from error subroutine as recommended in:
+  # https://docs.fastly.com/guides/performance-tuning/serving-stale-content
+  # The use of `req.restarts == 0` condition is to enforce the restriction
+  # of serving stale only when the backend is the origin.
+  if ((req.restarts == 0) && (obj.status >= 500 && obj.status < 600)) {
+    /* deliver stale object if it is available */
+    if (stale.exists) {
+      return(deliver_stale);
+    }
+  }
 
   # Assume we've hit vcl_error() because the backend is unavailable
   # for the first two retries. By restarting, vcl_recv() will try

--- a/vcl_templates/assets.vcl.erb
+++ b/vcl_templates/assets.vcl.erb
@@ -71,40 +71,7 @@ backend F_awsorigin {
       }
 }
 
-# Mirror backend for provider 0
-backend F_mirror1 {
-    .connect_timeout = 1s;
-    .dynamic = true;
-    .port = "<%= config.fetch('provider1_mirror_port', 443) %>";
-    .host = "<%= config.fetch('provider1_mirror_hostname') %>";
-    .first_byte_timeout = 15s;
-    .max_connections = 200;
-    .between_bytes_timeout = 10s;
-    .share_key = "<%= config.fetch('service_id') %>";
-
-    .ssl = true;
-    .ssl_check_cert = <%= config['disable_tls_validation'] ? 'never' : 'always' %>;
-    .min_tls_version = "<%= config.fetch('min_tls_version', '1.2') %>";
-    <%- if config['ssl_ciphers'] -%>
-    .ssl_ciphers = "<%= config['ssl_ciphers'] -%>";
-    <%- end -%>
-    .ssl_cert_hostname = "<%= config.fetch('ssl_cert_hostname', config.fetch('provider1_mirror_hostname')) %>";
-    .ssl_sni_hostname = "<%= config.fetch('ssl_sni_hostname', config.fetch('provider1_mirror_hostname')) %>";
-
-    .probe = {
-        .request =
-            "HEAD /__canary__ HTTP/1.1"
-            "Host: <%= config.fetch('provider1_mirror_hostname') %>"
-            "User-Agent: Fastly healthcheck (git version: <%= config['git_version'] %>)"
-            "Connection: close";
-        .threshold = 1;
-        .window = 2;
-        .timeout = 5s;
-        .initial = 1;
-        .expected_response = 200;
-        .interval = 10s;
-    }
-}
+<% if %w(staging production).include?(environment) %>
 # Mirror backend for S3
 backend F_mirrorS3 {
     .connect_timeout = 1s;
@@ -140,16 +107,76 @@ backend F_mirrorS3 {
     }
 }
 
-backend sick_force_grace {
-  .host = "127.0.0.1";
-  .port = "1";
-  .probe = {
-    .request = "invalid";
-    .interval = 365d;
-    .initial = 0;
-  }
+# Mirror backend for S3 replica
+backend F_mirrorS3Replica {
+    .connect_timeout = 1s;
+    .dynamic = true;
+    .port = "<%= config.fetch('s3_mirror_replica_port', 443) %>";
+    .host = "<%= config.fetch('s3_mirror_replica_hostname') %>";
+    .first_byte_timeout = 15s;
+    .max_connections = 200;
+    .between_bytes_timeout = 10s;
+    .share_key = "<%= config.fetch('service_id') %>";
+
+    .ssl = true;
+    .ssl_check_cert = <%= config['disable_tls_validation'] ? 'never' : 'always' %>;
+    .min_tls_version = "<%= config.fetch('min_tls_version', '1.2') %>";
+    <%- if config['ssl_ciphers'] -%>
+    .ssl_ciphers = "<%= config['ssl_ciphers'] -%>";
+    <%- end -%>
+    .ssl_cert_hostname = "<%= config.fetch('ssl_cert_hostname', config.fetch('s3_mirror_replica_hostname')) %>";
+    .ssl_sni_hostname = "<%= config.fetch('ssl_sni_hostname', config.fetch('s3_mirror_replica_hostname')) %>";
+
+    .probe = {
+        .request =
+            "HEAD <%= config.fetch('s3_mirror_replica_probe_request', '/') %> HTTP/1.1"
+            "Host: <%= config.fetch('s3_mirror_replica_hostname') %>"
+            "User-Agent: Fastly healthcheck (git version: <%= config['git_version'] %>)"
+            "Connection: close";
+        .threshold = 1;
+        .window = 2;
+        .timeout = 5s;
+        .initial = 1;
+        .expected_response = 200;
+        .interval = 10s;
+    }
 }
 
+# Mirror backend for GCS
+backend F_mirrorGCS {
+    .connect_timeout = 1s;
+    .dynamic = true;
+    .port = "<%= config.fetch('gcs_mirror_port', 443) %>";
+    .host = "<%= config.fetch('gcs_mirror_hostname') %>";
+    .first_byte_timeout = 15s;
+    .max_connections = 200;
+    .between_bytes_timeout = 10s;
+    .share_key = "<%= config.fetch('service_id') %>";
+
+    .ssl = true;
+    .ssl_check_cert = <%= config['disable_tls_validation'] ? 'never' : 'always' %>;
+    .min_tls_version = "<%= config.fetch('min_tls_version', '1.2') %>";
+    <%- if config['ssl_ciphers'] -%>
+    .ssl_ciphers = "<%= config['ssl_ciphers'] -%>";
+    <%- end -%>
+    .ssl_cert_hostname = "<%= config.fetch('ssl_cert_hostname', config.fetch('gcs_mirror_hostname')) %>";
+    .ssl_sni_hostname = "<%= config.fetch('ssl_sni_hostname', config.fetch('gcs_mirror_hostname')) %>";
+
+    .probe = {
+        .request =
+            "HEAD <%= config.fetch('gcs_mirror_probe_request', '/') %> HTTP/1.1"
+            "Host: <%= config.fetch('gcs_mirror_hostname') %>"
+            "User-Agent: Fastly healthcheck (git version: <%= config['git_version'] %>)"
+            "Connection: close";
+        .threshold = 1;
+        .window = 2;
+        .timeout = 5s;
+        .initial = 1;
+        .expected_response = 403;
+        .interval = 10s;
+    }
+}
+<% end %>
 
 acl purge_ip_whitelist {
   "37.26.93.252";     # Skyscape mirrors
@@ -217,35 +244,58 @@ sub vcl_recv {
       set req.http.host = "<%= config.fetch('carrenza_origin_hostname') %>";
   }
 
-  # Serve stale if it exists.
-  if (req.restarts > 0) {
-    set req.backend = sick_force_grace;
-    set req.http.Fastly-Backend-Name = "stale";
+  <% if %w(staging production).include?(environment) %>
+
+  # Save original request url because req.url changes after restarts.
+  if (req.restarts < 1) {
+    set req.http.original-url = req.url;
   }
 
-  # Failover to mirror.
-  if (req.restarts > 1) {
+  # Common config when failover to mirror buckets
+  if (req.restarts > 0) {
+    set req.url = req.http.original-url;
+
     # Don't serve from stale for mirrors
     set req.grace = 0s;
     set req.http.Fastly-Failover = "1";
 
-    set req.backend = F_mirror1;
-    set req.http.Fastly-Backend-Name = "mirror1";
-    set req.http.host = "<%= config.fetch('provider1_mirror_hostname') %>";
-  }
-
-  # FIXME: Prefer a fallback director if we move to Varnish 3
-  if (req.restarts > 2) {
-    set req.backend = F_mirrorS3;
-    set req.http.host = "<%= config.fetch('s3_mirror_hostname') %>";
-    set req.http.Fastly-Backend-Name = "mirrorS3";
-
     # Replace multiple /
     set req.url = regsuball(req.url, "([^:])//+", "\1/");
-
-    # Rewrite adding bucket directory prefix
-    set req.url = "/<%= config.fetch('s3_mirror_prefix') %>" req.url;
   }
+
+  # Failover to primary s3 mirror.
+  if (req.restarts == 1) {
+      set req.backend = F_mirrorS3;
+      set req.http.host = "<%= config.fetch('s3_mirror_hostname') %>";
+      set req.http.Fastly-Backend-Name = "mirrorS3";
+
+      # Add bucket directory prefix to all the requests
+      set req.url = "/<%= config.fetch('s3_mirror_prefix') %>" req.url;
+  }
+
+  # Failover to replica s3 mirror.
+  if (req.restarts == 2) {
+    set req.backend = F_mirrorS3Replica;
+    set req.http.host = "<%= config.fetch('s3_mirror_replica_hostname') %>";
+    set req.http.Fastly-Backend-Name = "mirrorS3Replica";
+
+    # Add bucket directory prefix to all the requests
+    set req.url = "/<%= config.fetch('s3_mirror_replica_prefix') %>" req.url;
+  }
+
+  # Failover to GCS mirror.
+  if (req.restarts > 2) {
+    set req.backend = F_mirrorGCS;
+    set req.http.host = "<%= config.fetch('gcs_mirror_hostname') %>";
+    set req.http.Fastly-Backend-Name = "mirrorGCS";
+
+    # Add bucket directory prefix to all the requests
+    set req.url = "/<%= config.fetch('gcs_mirror_prefix') %>" req.url;
+
+    set req.http.Date = now;
+    set req.http.Authorization = "AWS <%= config.fetch('gcs_mirror_access_id') %>:" digest.hmac_sha1_base64("<%= config.fetch('gcs_mirror_secret_key') %>", "GET" LF LF LF now LF "/<%= config.fetch('gcs_mirror_bucket_name') %>" req.url.path);
+  }
+  <% end %>
 
   # Unspoofable original client address.
   set req.http.True-Client-IP = req.http.Fastly-Client-IP;
@@ -346,6 +396,17 @@ sub vcl_error {
     set obj.status = 200;
     synthetic {""};
     return(deliver);
+  }
+
+  # Serve stale from error subroutine as recommended in:
+  # https://docs.fastly.com/guides/performance-tuning/serving-stale-content
+  # The use of `req.restarts == 0` condition is to enforce the restriction
+  # of serving stale only when the backend is the origin.
+  if ((req.restarts == 0) && (obj.status >= 500 && obj.status < 600)) {
+    /* deliver stale object if it is available */
+    if (stale.exists) {
+      return(deliver_stale);
+    }
   }
 
   # Assume we've hit vcl_error() because the backend is unavailable

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -37,40 +37,8 @@ backend F_origin {
         .interval = 10s;
     }
 }
-# Mirror backend for provider 0
-backend F_mirror1 {
-    .connect_timeout = 1s;
-    .dynamic = true;
-    .port = "<%= config.fetch('provider1_mirror_port', 443) %>";
-    .host = "<%= config.fetch('provider1_mirror_hostname') %>";
-    .first_byte_timeout = 15s;
-    .max_connections = 200;
-    .between_bytes_timeout = 10s;
-    .share_key = "<%= config.fetch('service_id') %>";
 
-    .ssl = true;
-    .ssl_check_cert = <%= config['disable_tls_validation'] ? 'never' : 'always' %>;
-    .min_tls_version = "<%= config.fetch('min_tls_version', '1.2') %>";
-    <%- if config['ssl_ciphers'] -%>
-    .ssl_ciphers = "<%= config['ssl_ciphers'] -%>";
-    <%- end -%>
-    .ssl_cert_hostname = "<%= config.fetch('ssl_cert_hostname', config.fetch('provider1_mirror_hostname')) %>";
-    .ssl_sni_hostname = "<%= config.fetch('ssl_sni_hostname', config.fetch('provider1_mirror_hostname')) %>";
-
-    .probe = {
-        .request =
-            "HEAD / HTTP/1.1"
-            "Host: <%= config.fetch('provider1_mirror_hostname') %>"
-            "User-Agent: Fastly healthcheck (git version: <%= config['git_version'] %>)"
-            "Connection: close";
-        .threshold = 1;
-        .window = 2;
-        .timeout = 5s;
-        .initial = 1;
-        .expected_response = 200;
-        .interval = 10s;
-    }
-}
+<% if %w(staging production).include?(environment) %>
 # Mirror backend for S3
 backend F_mirrorS3 {
     .connect_timeout = 1s;
@@ -106,16 +74,76 @@ backend F_mirrorS3 {
     }
 }
 
-backend sick_force_grace {
-  .host = "127.0.0.1";
-  .port = "1";
-  .probe = {
-    .request = "invalid";
-    .interval = 365d;
-    .initial = 0;
-  }
+# Mirror backend for S3 replica
+backend F_mirrorS3Replica {
+    .connect_timeout = 1s;
+    .dynamic = true;
+    .port = "<%= config.fetch('s3_mirror_replica_port', 443) %>";
+    .host = "<%= config.fetch('s3_mirror_replica_hostname') %>";
+    .first_byte_timeout = 15s;
+    .max_connections = 200;
+    .between_bytes_timeout = 10s;
+    .share_key = "<%= config.fetch('service_id') %>";
+
+    .ssl = true;
+    .ssl_check_cert = <%= config['disable_tls_validation'] ? 'never' : 'always' %>;
+    .min_tls_version = "<%= config.fetch('min_tls_version', '1.2') %>";
+    <%- if config['ssl_ciphers'] -%>
+    .ssl_ciphers = "<%= config['ssl_ciphers'] -%>";
+    <%- end -%>
+    .ssl_cert_hostname = "<%= config.fetch('ssl_cert_hostname', config.fetch('s3_mirror_replica_hostname')) %>";
+    .ssl_sni_hostname = "<%= config.fetch('ssl_sni_hostname', config.fetch('s3_mirror_replica_hostname')) %>";
+
+    .probe = {
+        .request =
+            "HEAD <%= config.fetch('s3_mirror_replica_probe_request', '/') %> HTTP/1.1"
+            "Host: <%= config.fetch('s3_mirror_replica_hostname') %>"
+            "User-Agent: Fastly healthcheck (git version: <%= config['git_version'] %>)"
+            "Connection: close";
+        .threshold = 1;
+        .window = 2;
+        .timeout = 5s;
+        .initial = 1;
+        .expected_response = 200;
+        .interval = 10s;
+    }
 }
 
+# Mirror backend for GCS
+backend F_mirrorGCS {
+    .connect_timeout = 1s;
+    .dynamic = true;
+    .port = "<%= config.fetch('gcs_mirror_port', 443) %>";
+    .host = "<%= config.fetch('gcs_mirror_hostname') %>";
+    .first_byte_timeout = 15s;
+    .max_connections = 200;
+    .between_bytes_timeout = 10s;
+    .share_key = "<%= config.fetch('service_id') %>";
+
+    .ssl = true;
+    .ssl_check_cert = <%= config['disable_tls_validation'] ? 'never' : 'always' %>;
+    .min_tls_version = "<%= config.fetch('min_tls_version', '1.2') %>";
+    <%- if config['ssl_ciphers'] -%>
+    .ssl_ciphers = "<%= config['ssl_ciphers'] -%>";
+    <%- end -%>
+    .ssl_cert_hostname = "<%= config.fetch('ssl_cert_hostname', config.fetch('gcs_mirror_hostname')) %>";
+    .ssl_sni_hostname = "<%= config.fetch('ssl_sni_hostname', config.fetch('gcs_mirror_hostname')) %>";
+
+    .probe = {
+        .request =
+            "HEAD <%= config.fetch('gcs_mirror_probe_request', '/') %> HTTP/1.1"
+            "Host: <%= config.fetch('gcs_mirror_hostname') %>"
+            "User-Agent: Fastly healthcheck (git version: <%= config['git_version'] %>)"
+            "Connection: close";
+        .threshold = 1;
+        .window = 2;
+        .timeout = 5s;
+        .initial = 1;
+        .expected_response = 403;
+        .interval = 10s;
+    }
+}
+<% end %>
 
 acl purge_ip_whitelist {
   "37.26.93.252";     # Skyscape mirrors
@@ -196,32 +224,25 @@ sub vcl_recv {
   # Serve from stale for 24 hours if origin is sick
   set req.grace = 24h;
 
-  # Default backend.
+  # Default backend, these details will be overwritten if other backends are
+  # chosen
   set req.backend = F_origin;
   set req.http.Fastly-Backend-Name = "origin";
 
-  # Serve stale if it exists.
-  if (req.restarts > 0) {
-    set req.backend = sick_force_grace;
-    set req.http.Fastly-Backend-Name = "stale";
+  <% if %w(staging production).include?(environment) %>
+
+  # Save original request url because req.url changes after restarts.
+  if (req.restarts < 1) {
+    set req.http.original-url = req.url;
   }
 
-  # Failover to mirror.
-  if (req.restarts > 1) {
+  # Common config when failover to mirror buckets
+  if (req.restarts > 0) {
+    set req.url = req.http.original-url;
+
     # Don't serve from stale for mirrors
     set req.grace = 0s;
     set req.http.Fastly-Failover = "1";
-
-    set req.backend = F_mirror1;
-    set req.http.host = "<%= config.fetch('provider1_mirror_hostname') %>";
-    set req.http.Fastly-Backend-Name = "mirror1";
-  }
-
-  # FIXME: Prefer a fallback director if we move to Varnish 3
-  if (req.restarts > 2) {
-    set req.backend = F_mirrorS3;
-    set req.http.host = "<%= config.fetch('s3_mirror_hostname') %>";
-    set req.http.Fastly-Backend-Name = "mirrorS3";
 
     # Requests to home page, rewrite to index.html
     if (req.url ~ "^/?([\?#].*)?$") {
@@ -235,9 +256,41 @@ sub vcl_recv {
     if (req.url !~ "^([^#\?\s]+)\.(atom|chm|css|csv|diff|doc|docx|dot|dxf|eps|gif|gml|html|ico|ics|jpeg|jpg|JPG|js|json|kml|odp|ods|odt|pdf|PDF|png|ppt|pptx|ps|rdf|rtf|sch|txt|wsdl|xls|xlsm|xlsx|xlt|xml|xsd|xslt|zip)([\?#]+.*)?$") {
       set req.url = regsub(req.url, "^([^#\?\s]+)([\?#]+.*)?$", "\1.html\2");
     }
-    # Add bucket directory prefix to all the requests
-    set req.url = "/<%= config.fetch('s3_mirror_prefix') %>" req.url;
   }
+
+  # Failover to primary s3 mirror.
+  if (req.restarts == 1) {
+      set req.backend = F_mirrorS3;
+      set req.http.host = "<%= config.fetch('s3_mirror_hostname') %>";
+      set req.http.Fastly-Backend-Name = "mirrorS3";
+
+      # Add bucket directory prefix to all the requests
+      set req.url = "/<%= config.fetch('s3_mirror_prefix') %>" req.url;
+  }
+
+  # Failover to replica s3 mirror.
+  if (req.restarts == 2) {
+    set req.backend = F_mirrorS3Replica;
+    set req.http.host = "<%= config.fetch('s3_mirror_replica_hostname') %>";
+    set req.http.Fastly-Backend-Name = "mirrorS3Replica";
+
+    # Add bucket directory prefix to all the requests
+    set req.url = "/<%= config.fetch('s3_mirror_replica_prefix') %>" req.url;
+  }
+
+  # Failover to GCS mirror.
+  if (req.restarts > 2) {
+    set req.backend = F_mirrorGCS;
+    set req.http.host = "<%= config.fetch('gcs_mirror_hostname') %>";
+    set req.http.Fastly-Backend-Name = "mirrorGCS";
+
+    # Add bucket directory prefix to all the requests
+    set req.url = "/<%= config.fetch('gcs_mirror_prefix') %>" req.url;
+
+    set req.http.Date = now;
+    set req.http.Authorization = "AWS <%= config.fetch('gcs_mirror_access_id') %>:" digest.hmac_sha1_base64("<%= config.fetch('gcs_mirror_secret_key') %>", "GET" LF LF LF now LF "/<%= config.fetch('gcs_mirror_bucket_name') %>" req.url.path);
+  }
+  <% end %>
 
   # Unspoofable original client address.
   set req.http.True-Client-IP = req.http.Fastly-Client-IP;
@@ -302,7 +355,7 @@ sub vcl_fetch {
   # a 301 status code. All errors from the mirrors are set to 503 as they
   # cannot know whether or not a page actually exists (e.g. /search is a valid
   # URL but the mirror cannot return it).
-  if (beresp.status != 200 && beresp.http.Fastly-Backend-Name ~ "mirror") {
+  if (beresp.status != 200 && beresp.http.Fastly-Backend-Name ~ "^mirror") {
     set beresp.status = 503;
   }
 
@@ -310,7 +363,7 @@ sub vcl_fetch {
     set req.http.Fastly-Cachetype = "ERROR";
     set beresp.ttl = 1s;
     set beresp.grace = 5s;
-    if (beresp.http.Fastly-Backend-Name ~ "mirrorS3") {
+    if (beresp.http.Fastly-Backend-Name ~ "^mirror") {
       error 503 "Error page";
     }
     return (deliver);
@@ -322,8 +375,8 @@ sub vcl_fetch {
     # apply the default ttl
     set beresp.ttl = <%= config.fetch('default_ttl') %>s;
 
-    # S3 does not set cache headers by default. Override TTL and add cache-control with 15 minutes
-    if (beresp.http.Fastly-Backend-Name ~ "mirrorS3") {
+    # Mirror buckets do not set cache headers by default. Override TTL and add cache-control with 15 minutes
+    if (beresp.http.Fastly-Backend-Name ~ "^mirror") {
       set beresp.ttl = 900s;
       set beresp.http.Cache-Control = "max-age=900";
     }
@@ -426,6 +479,17 @@ sub vcl_error {
     return (deliver);
   }
   <% end %>
+
+  # Serve stale from error subroutine as recommended in:
+  # https://docs.fastly.com/guides/performance-tuning/serving-stale-content
+  # The use of `req.restarts == 0` condition is to enforce the restriction
+  # of serving stale only when the backend is the origin.
+  if ((req.restarts == 0) && (obj.status >= 500 && obj.status < 600)) {
+    /* deliver stale object if it is available */
+    if (stale.exists) {
+      return(deliver_stale);
+    }
+  }
 
   # Assume we've hit vcl_error() because the backend is unavailable
   # for the first two retries. By restarting, vcl_recv() will try


### PR DESCRIPTION
# Context

New gov.uk mirror redesign:
If the www origin backend is down, fastly will use stale cache as before.
If object is not in cache, the S3 mirror bucket in London is used. If this fails, the
replica S3 mirror bucket in Ireland is used. As last resort,
we use the Google Cloud Storage bucket in multi-region EU.

Other changes:
1. we no longer have a sick backend because it is pointless as we keep the grace period to 24 hours regardless, so the example previously followed: https://book.varnish-software.com/3.0/Saving_a_request.html#example-evil-backend-hack no longer applies. Confirmed with fastly that this is fine.
2. if the backend is origin and we encounter an error from the origin, we try to serve stale too.

# Decisions
1. re-write the www vcl config to accommodate the 3 mirror buckets and removal of mirror machines in Carrenza 

Data component of this PR is in: https://github.com/alphagov/govuk-cdn-config-secrets/pull/106 