### PR TITLE
if object is 404, serve govuk 404 body rather than backend 404 body

### DIFF
--- a/spec/test-outputs/mirror-integration.out.vcl
+++ b/spec/test-outputs/mirror-integration.out.vcl
@@ -338,7 +338,7 @@ sub vcl_error {
     return (deliver);
   }
 
-  if (obj.status == 804) {
+  if ((obj.status == 804) || (obj.status == 404 && req.restarts > 0))
     set obj.status = 404;
     set obj.response = "Not Found";
     set obj.http.Fastly-Backend-Name = "force_not_found";

--- a/spec/test-outputs/mirror-production.out.vcl
+++ b/spec/test-outputs/mirror-production.out.vcl
@@ -500,7 +500,7 @@ sub vcl_error {
     return (deliver);
   }
 
-  if (obj.status == 804) {
+  if ((obj.status == 804) || (obj.status == 404 && req.restarts > 0))
     set obj.status = 404;
     set obj.response = "Not Found";
     set obj.http.Fastly-Backend-Name = "force_not_found";

--- a/spec/test-outputs/mirror-staging.out.vcl
+++ b/spec/test-outputs/mirror-staging.out.vcl
@@ -500,7 +500,7 @@ sub vcl_error {
     return (deliver);
   }
 
-  if (obj.status == 804) {
+  if ((obj.status == 804) || (obj.status == 404 && req.restarts > 0))
     set obj.status = 404;
     set obj.response = "Not Found";
     set obj.http.Fastly-Backend-Name = "force_not_found";

--- a/spec/test-outputs/www-integration.out.vcl
+++ b/spec/test-outputs/www-integration.out.vcl
@@ -337,7 +337,7 @@ sub vcl_error {
     return (deliver);
   }
 
-  if (obj.status == 804) {
+  if ((obj.status == 804) || (obj.status == 404 && req.restarts > 0)) {
     set obj.status = 404;
     set obj.response = "Not Found";
     set obj.http.Fastly-Backend-Name = "force_not_found";

--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -495,7 +495,7 @@ sub vcl_error {
     return (deliver);
   }
 
-  if (obj.status == 804) {
+  if ((obj.status == 804) || (obj.status == 404 && req.restarts > 0)) {
     set obj.status = 404;
     set obj.response = "Not Found";
     set obj.http.Fastly-Backend-Name = "force_not_found";

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -504,7 +504,7 @@ sub vcl_error {
     return (deliver);
   }
 
-  if (obj.status == 804) {
+  if ((obj.status == 804) || (obj.status == 404 && req.restarts > 0)) {
     set obj.status = 404;
     set obj.response = "Not Found";
     set obj.http.Fastly-Backend-Name = "force_not_found";

--- a/vcl_templates/mirror.vcl.erb
+++ b/vcl_templates/mirror.vcl.erb
@@ -442,7 +442,7 @@ sub vcl_error {
     return (deliver);
   }
 
-  if (obj.status == 804) {
+  if ((obj.status == 804) || (obj.status == 404 && req.restarts > 0))
     set obj.status = 404;
     set obj.response = "Not Found";
     set obj.http.Fastly-Backend-Name = "force_not_found";

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -446,7 +446,7 @@ sub vcl_error {
     return (deliver);
   }
 
-  if (obj.status == 804) {
+  if ((obj.status == 804) || (obj.status == 404 && req.restarts > 0)) {
     set obj.status = 404;
     set obj.response = "Not Found";
     set obj.http.Fastly-Backend-Name = "force_not_found";


### PR DESCRIPTION
# Context

There is a fallback to mirrors if page not found on origin website and if the page is not found in the mirrors, the mirror response body is sent to the client. We actually want the response body to be the govuk customize message.

# Decisions
If an object is 404 and comes from the mirrors, send the govuk 404 custom response body.