### PR TITLE
Add recommended related links header to www vcl

### DIFF
--- a/spec/test-outputs/www-integration.out.vcl
+++ b/spec/test-outputs/www-integration.out.vcl
@@ -91,6 +91,10 @@ sub vcl_recv {
   set req.backend = F_origin;
   set req.http.Fastly-Backend-Name = "origin";
 
+  # Set header to show recommended related links for Whitehall content. This is to be used
+  # as a rollback mechanism should we ever need to stop showing these links.
+  set req.http.Govuk-Use-Recommended-Related-Links = "true";
+
   
 
   # Unspoofable original client address.

--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -188,6 +188,10 @@ sub vcl_recv {
   set req.backend = F_origin;
   set req.http.Fastly-Backend-Name = "origin";
 
+  # Set header to show recommended related links for Whitehall content. This is to be used
+  # as a rollback mechanism should we ever need to stop showing these links.
+  set req.http.Govuk-Use-Recommended-Related-Links = "true";
+
   
 
   # Save original request url because req.url changes after restarts.

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -197,6 +197,10 @@ sub vcl_recv {
   set req.backend = F_origin;
   set req.http.Fastly-Backend-Name = "origin";
 
+  # Set header to show recommended related links for Whitehall content. This is to be used
+  # as a rollback mechanism should we ever need to stop showing these links.
+  set req.http.Govuk-Use-Recommended-Related-Links = "true";
+
   
 
   # Save original request url because req.url changes after restarts.

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -229,6 +229,10 @@ sub vcl_recv {
   set req.backend = F_origin;
   set req.http.Fastly-Backend-Name = "origin";
 
+  # Set header to show recommended related links for Whitehall content. This is to be used
+  # as a rollback mechanism should we ever need to stop showing these links.
+  set req.http.Govuk-Use-Recommended-Related-Links = "true";
+
   <% if %w(staging production).include?(environment) %>
 
   # Save original request url because req.url changes after restarts.


### PR DESCRIPTION
This PR adds a new header `Govuk-Use-Recommended-Related-Links` to the `www` vcl. This header is used by `government-frontend` to determine whether to show the new recommended related links, or by its absence to default back to existing related links.

We're adding this as a separate header to the CDN to enable quick rollback of the auto-generated recommended related links to existing related links for our users.