### PR TITLE
Switch to API key based authentication

### DIFF
--- a/lib/govuk_fastly.rb
+++ b/lib/govuk_fastly.rb
@@ -1,14 +1,7 @@
 class GovukFastly
   def self.client
-    %w[FASTLY_USER FASTLY_PASS].each do |envvar|
-      if ENV[envvar].nil?
-        raise "#{envvar} is not set in the environment"
-      end
-    end
-
-    Fastly.new(
-      user: ENV['FASTLY_USER'],
-      password: ENV['FASTLY_PASS']
-    )
+    Fastly.new(api_key: ENV.fetch("FASTLY_API_KEY"))
+  rescue KeyError
+    raise "FASTLY_API_KEY is not set in the environment"
   end
 end

--- a/spec/deploy_bouncer_spec.rb
+++ b/spec/deploy_bouncer_spec.rb
@@ -3,9 +3,6 @@ describe DeployBouncer do
     it 'deploys the VCL for bouncer' do
       @requests = []
 
-      # This call is made by the Fastly library when you call `Fastly.new`
-      @requests << stub_request(:post, "https://api.fastly.com/login").to_return(body: "{}")
-
       # Fastly#get_service. Return a service with two VCL "versions" (https://docs.fastly.com/api/config#version)
       @requests << stub_request(:get, "https://api.fastly.com/service/123321abc").
         to_return(body: File.read("spec/fixtures/fastly-get-service-response.json"))
@@ -66,7 +63,7 @@ describe DeployBouncer do
       @requests << stub_request(:put, "https://api.fastly.com/service/123321abc/version/3/activate").
         to_return(body: "{}")
 
-      ClimateControl.modify APP_DOMAIN: "gov.uk", FASTLY_SERVICE_ID: "123321abc", FASTLY_USER: 'fastly@example.com', FASTLY_PASS: '123' do
+      ClimateControl.modify APP_DOMAIN: "gov.uk", FASTLY_SERVICE_ID: "123321abc", FASTLY_API_KEY: 'fastly@example.com' do
         DeployBouncer.new.deploy!
 
         @requests.each do |request|

--- a/spec/deploy_dictionaries_spec.rb
+++ b/spec/deploy_dictionaries_spec.rb
@@ -3,9 +3,6 @@ describe DeployDictionaries do
     it 'deploys the dictionaries' do
       @requests = []
 
-      # This call is made by the Fastly library when you call `Fastly.new`
-      @requests << stub_request(:post, "https://api.fastly.com/login").to_return(body: "{}")
-
       # Fastly#get_service. Return a service with two VCL "versions" (https://docs.fastly.com/api/config#version)
       @requests << stub_request(:get, "https://api.fastly.com/service/123321abc").
         to_return(body: File.read("spec/fixtures/fastly-get-service-response.json"))
@@ -48,7 +45,7 @@ describe DeployDictionaries do
       @requests << stub_request(:put, "https://api.fastly.com/service/123321abc/version/3/activate").
           to_return(body: "{}")
 
-      ClimateControl.modify FASTLY_USER: 'fastly@example.com', FASTLY_PASS: '123' do
+      ClimateControl.modify FASTLY_API_KEY: 'fastly@example.com' do
         DeployDictionaries.new.deploy!(%w[test production])
 
         @requests.each do |request|

--- a/spec/deploy_service_spec.rb
+++ b/spec/deploy_service_spec.rb
@@ -3,9 +3,6 @@ describe DeployService do
     it 'deploys the VCL' do
       @requests = []
 
-      # This call is made by the Fastly library when you call `Fastly.new`
-      @requests << stub_request(:post, "https://api.fastly.com/login").to_return(body: "{}")
-
       # Fastly#get_service. Return a service with two VCL "versions" (https://docs.fastly.com/api/config#version)
       @requests << stub_request(:get, "https://api.fastly.com/service/123321abc").
         to_return(body: File.read("spec/fixtures/fastly-get-service-response.json"))
@@ -61,7 +58,7 @@ describe DeployService do
 
       deployer = DeployService.new
 
-      ClimateControl.modify FASTLY_USER: 'fastly@example.com', FASTLY_PASS: '123' do
+      ClimateControl.modify FASTLY_API_KEY: 'fastly@example.com' do
         deployer.deploy!(%w[test production])
 
         @requests.each do |request|


### PR DESCRIPTION
It looks like the Fastly API no longer supports username/passwords for authentication.

[Trello Card](https://trello.com/c/19Gc1KkK/1109-fix-auth-issue-for-cdn-deploy-bouncer-configs-job-in-prod)