### PR TITLE
fix 404 page still served from mirror if origin fails

### DIFF
--- a/spec/test-outputs/mirror-integration.out.vcl
+++ b/spec/test-outputs/mirror-integration.out.vcl
@@ -232,6 +232,30 @@ sub vcl_fetch {
     set beresp.http.Fastly-Restarts = req.restarts;
   }
 
+  # The only valid status from our mirrors is a 200. They cannot return e.g.
+  # a 301 status code. All errors from the mirrors are set to 503 as they
+  # cannot know whether or not a page actually exists (e.g. /search is a valid
+  # URL but the mirror cannot return it). It should be noted that the 503 is
+  # set only when the last mirror has been attempted.
+  if (beresp.status != 200 && beresp.http.Fastly-Backend-Name ~ "^mirror") {
+    if (req.restarts < 3 ){
+      set beresp.saintmode = 5s;
+      return (restart);
+    } else {
+      set beresp.status = 503;
+    }
+  }
+
+  if (beresp.status >= 500 && beresp.status <= 599) {
+    set req.http.Fastly-Cachetype = "ERROR";
+    set beresp.ttl = 1s;
+    set beresp.grace = 5s;
+    if (beresp.http.Fastly-Backend-Name ~ "^mirror") {
+      error 503 "Error page";
+    }
+    return (deliver);
+  }
+
   if (beresp.http.Cache-Control ~ "private") {
     set req.http.Fastly-Cachetype = "PRIVATE";
     return (pass);
@@ -243,24 +267,6 @@ sub vcl_fetch {
 
   if (beresp.http.Cache-Control ~ "no-(store|cache)") {
     return (pass);
-  }
-
-  # The only valid status from our mirrors is a 200. They cannot return e.g.
-  # a 301 status code. All errors from the mirrors are set to 503 as they
-  # cannot know whether or not a page actually exists (e.g. /search is a valid
-  # URL but the mirror cannot return it).
-  if (beresp.status != 200 && beresp.http.Fastly-Backend-Name ~ "^mirror") {
-    set beresp.status = 503;
-  }
-
-  if (beresp.status >= 500 && beresp.status <= 599) {
-    set req.http.Fastly-Cachetype = "ERROR";
-    set beresp.ttl = 1s;
-    set beresp.grace = 5s;
-    if (beresp.http.Fastly-Backend-Name ~ "^mirror") {
-      error 503 "Error page";
-    }
-    return (deliver);
   }
 
   if (beresp.http.Expires || beresp.http.Surrogate-Control ~ "max-age" || beresp.http.Cache-Control ~"(s-maxage|max-age)") {

--- a/spec/test-outputs/mirror-production.out.vcl
+++ b/spec/test-outputs/mirror-production.out.vcl
@@ -394,6 +394,30 @@ sub vcl_fetch {
     set beresp.http.Fastly-Restarts = req.restarts;
   }
 
+  # The only valid status from our mirrors is a 200. They cannot return e.g.
+  # a 301 status code. All errors from the mirrors are set to 503 as they
+  # cannot know whether or not a page actually exists (e.g. /search is a valid
+  # URL but the mirror cannot return it). It should be noted that the 503 is
+  # set only when the last mirror has been attempted.
+  if (beresp.status != 200 && beresp.http.Fastly-Backend-Name ~ "^mirror") {
+    if (req.restarts < 3 ){
+      set beresp.saintmode = 5s;
+      return (restart);
+    } else {
+      set beresp.status = 503;
+    }
+  }
+
+  if (beresp.status >= 500 && beresp.status <= 599) {
+    set req.http.Fastly-Cachetype = "ERROR";
+    set beresp.ttl = 1s;
+    set beresp.grace = 5s;
+    if (beresp.http.Fastly-Backend-Name ~ "^mirror") {
+      error 503 "Error page";
+    }
+    return (deliver);
+  }
+
   if (beresp.http.Cache-Control ~ "private") {
     set req.http.Fastly-Cachetype = "PRIVATE";
     return (pass);
@@ -405,24 +429,6 @@ sub vcl_fetch {
 
   if (beresp.http.Cache-Control ~ "no-(store|cache)") {
     return (pass);
-  }
-
-  # The only valid status from our mirrors is a 200. They cannot return e.g.
-  # a 301 status code. All errors from the mirrors are set to 503 as they
-  # cannot know whether or not a page actually exists (e.g. /search is a valid
-  # URL but the mirror cannot return it).
-  if (beresp.status != 200 && beresp.http.Fastly-Backend-Name ~ "^mirror") {
-    set beresp.status = 503;
-  }
-
-  if (beresp.status >= 500 && beresp.status <= 599) {
-    set req.http.Fastly-Cachetype = "ERROR";
-    set beresp.ttl = 1s;
-    set beresp.grace = 5s;
-    if (beresp.http.Fastly-Backend-Name ~ "^mirror") {
-      error 503 "Error page";
-    }
-    return (deliver);
   }
 
   if (beresp.http.Expires || beresp.http.Surrogate-Control ~ "max-age" || beresp.http.Cache-Control ~"(s-maxage|max-age)") {

--- a/spec/test-outputs/mirror-staging.out.vcl
+++ b/spec/test-outputs/mirror-staging.out.vcl
@@ -394,6 +394,30 @@ sub vcl_fetch {
     set beresp.http.Fastly-Restarts = req.restarts;
   }
 
+  # The only valid status from our mirrors is a 200. They cannot return e.g.
+  # a 301 status code. All errors from the mirrors are set to 503 as they
+  # cannot know whether or not a page actually exists (e.g. /search is a valid
+  # URL but the mirror cannot return it). It should be noted that the 503 is
+  # set only when the last mirror has been attempted.
+  if (beresp.status != 200 && beresp.http.Fastly-Backend-Name ~ "^mirror") {
+    if (req.restarts < 3 ){
+      set beresp.saintmode = 5s;
+      return (restart);
+    } else {
+      set beresp.status = 503;
+    }
+  }
+
+  if (beresp.status >= 500 && beresp.status <= 599) {
+    set req.http.Fastly-Cachetype = "ERROR";
+    set beresp.ttl = 1s;
+    set beresp.grace = 5s;
+    if (beresp.http.Fastly-Backend-Name ~ "^mirror") {
+      error 503 "Error page";
+    }
+    return (deliver);
+  }
+
   if (beresp.http.Cache-Control ~ "private") {
     set req.http.Fastly-Cachetype = "PRIVATE";
     return (pass);
@@ -405,24 +429,6 @@ sub vcl_fetch {
 
   if (beresp.http.Cache-Control ~ "no-(store|cache)") {
     return (pass);
-  }
-
-  # The only valid status from our mirrors is a 200. They cannot return e.g.
-  # a 301 status code. All errors from the mirrors are set to 503 as they
-  # cannot know whether or not a page actually exists (e.g. /search is a valid
-  # URL but the mirror cannot return it).
-  if (beresp.status != 200 && beresp.http.Fastly-Backend-Name ~ "^mirror") {
-    set beresp.status = 503;
-  }
-
-  if (beresp.status >= 500 && beresp.status <= 599) {
-    set req.http.Fastly-Cachetype = "ERROR";
-    set beresp.ttl = 1s;
-    set beresp.grace = 5s;
-    if (beresp.http.Fastly-Backend-Name ~ "^mirror") {
-      error 503 "Error page";
-    }
-    return (deliver);
   }
 
   if (beresp.http.Expires || beresp.http.Surrogate-Control ~ "max-age" || beresp.http.Cache-Control ~"(s-maxage|max-age)") {

--- a/spec/test-outputs/www-integration.out.vcl
+++ b/spec/test-outputs/www-integration.out.vcl
@@ -235,6 +235,30 @@ sub vcl_fetch {
     set beresp.http.Fastly-Restarts = req.restarts;
   }
 
+  # The only valid status from our mirrors is a 200. They cannot return e.g.
+  # a 301 status code. All errors from the mirrors are set to 503 as they
+  # cannot know whether or not a page actually exists (e.g. /search is a valid
+  # URL but the mirror cannot return it). It should be noted that the 503 is 
+  # set only when the last mirror has been attempted.
+  if (beresp.status != 200 && beresp.http.Fastly-Backend-Name ~ "^mirror") {
+    if (req.restarts < 3 ){
+      set beresp.saintmode = 5s;
+      return (restart);
+    } else {
+      set beresp.status = 503;
+    }
+  }
+
+  if (beresp.status >= 500 && beresp.status <= 599) {
+    set req.http.Fastly-Cachetype = "ERROR";
+    set beresp.ttl = 1s;
+    set beresp.grace = 5s;
+    if (beresp.http.Fastly-Backend-Name ~ "^mirror") {
+      error 503 "Error page";
+    }
+    return (deliver);
+  }
+
   if (beresp.http.Cache-Control ~ "private") {
     set req.http.Fastly-Cachetype = "PRIVATE";
     return (pass);
@@ -246,24 +270,6 @@ sub vcl_fetch {
 
   if (beresp.http.Cache-Control ~ "no-(store|cache)") {
     return (pass);
-  }
-
-  # The only valid status from our mirrors is a 200. They cannot return e.g.
-  # a 301 status code. All errors from the mirrors are set to 503 as they
-  # cannot know whether or not a page actually exists (e.g. /search is a valid
-  # URL but the mirror cannot return it).
-  if (beresp.status != 200 && beresp.http.Fastly-Backend-Name ~ "^mirror") {
-    set beresp.status = 503;
-  }
-
-  if (beresp.status >= 500 && beresp.status <= 599) {
-    set req.http.Fastly-Cachetype = "ERROR";
-    set beresp.ttl = 1s;
-    set beresp.grace = 5s;
-    if (beresp.http.Fastly-Backend-Name ~ "^mirror") {
-      error 503 "Error page";
-    }
-    return (deliver);
   }
 
   if (beresp.http.Expires || beresp.http.Surrogate-Control ~ "max-age" || beresp.http.Cache-Control ~"(s-maxage|max-age)") {

--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -393,6 +393,30 @@ sub vcl_fetch {
     set beresp.http.Fastly-Restarts = req.restarts;
   }
 
+  # The only valid status from our mirrors is a 200. They cannot return e.g.
+  # a 301 status code. All errors from the mirrors are set to 503 as they
+  # cannot know whether or not a page actually exists (e.g. /search is a valid
+  # URL but the mirror cannot return it). It should be noted that the 503 is 
+  # set only when the last mirror has been attempted.
+  if (beresp.status != 200 && beresp.http.Fastly-Backend-Name ~ "^mirror") {
+    if (req.restarts < 3 ){
+      set beresp.saintmode = 5s;
+      return (restart);
+    } else {
+      set beresp.status = 503;
+    }
+  }
+
+  if (beresp.status >= 500 && beresp.status <= 599) {
+    set req.http.Fastly-Cachetype = "ERROR";
+    set beresp.ttl = 1s;
+    set beresp.grace = 5s;
+    if (beresp.http.Fastly-Backend-Name ~ "^mirror") {
+      error 503 "Error page";
+    }
+    return (deliver);
+  }
+
   if (beresp.http.Cache-Control ~ "private") {
     set req.http.Fastly-Cachetype = "PRIVATE";
     return (pass);
@@ -404,24 +428,6 @@ sub vcl_fetch {
 
   if (beresp.http.Cache-Control ~ "no-(store|cache)") {
     return (pass);
-  }
-
-  # The only valid status from our mirrors is a 200. They cannot return e.g.
-  # a 301 status code. All errors from the mirrors are set to 503 as they
-  # cannot know whether or not a page actually exists (e.g. /search is a valid
-  # URL but the mirror cannot return it).
-  if (beresp.status != 200 && beresp.http.Fastly-Backend-Name ~ "^mirror") {
-    set beresp.status = 503;
-  }
-
-  if (beresp.status >= 500 && beresp.status <= 599) {
-    set req.http.Fastly-Cachetype = "ERROR";
-    set beresp.ttl = 1s;
-    set beresp.grace = 5s;
-    if (beresp.http.Fastly-Backend-Name ~ "^mirror") {
-      error 503 "Error page";
-    }
-    return (deliver);
   }
 
   if (beresp.http.Expires || beresp.http.Surrogate-Control ~ "max-age" || beresp.http.Cache-Control ~"(s-maxage|max-age)") {

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -402,6 +402,30 @@ sub vcl_fetch {
     set beresp.http.Fastly-Restarts = req.restarts;
   }
 
+  # The only valid status from our mirrors is a 200. They cannot return e.g.
+  # a 301 status code. All errors from the mirrors are set to 503 as they
+  # cannot know whether or not a page actually exists (e.g. /search is a valid
+  # URL but the mirror cannot return it). It should be noted that the 503 is 
+  # set only when the last mirror has been attempted.
+  if (beresp.status != 200 && beresp.http.Fastly-Backend-Name ~ "^mirror") {
+    if (req.restarts < 3 ){
+      set beresp.saintmode = 5s;
+      return (restart);
+    } else {
+      set beresp.status = 503;
+    }
+  }
+
+  if (beresp.status >= 500 && beresp.status <= 599) {
+    set req.http.Fastly-Cachetype = "ERROR";
+    set beresp.ttl = 1s;
+    set beresp.grace = 5s;
+    if (beresp.http.Fastly-Backend-Name ~ "^mirror") {
+      error 503 "Error page";
+    }
+    return (deliver);
+  }
+
   if (beresp.http.Cache-Control ~ "private") {
     set req.http.Fastly-Cachetype = "PRIVATE";
     return (pass);
@@ -413,24 +437,6 @@ sub vcl_fetch {
 
   if (beresp.http.Cache-Control ~ "no-(store|cache)") {
     return (pass);
-  }
-
-  # The only valid status from our mirrors is a 200. They cannot return e.g.
-  # a 301 status code. All errors from the mirrors are set to 503 as they
-  # cannot know whether or not a page actually exists (e.g. /search is a valid
-  # URL but the mirror cannot return it).
-  if (beresp.status != 200 && beresp.http.Fastly-Backend-Name ~ "^mirror") {
-    set beresp.status = 503;
-  }
-
-  if (beresp.status >= 500 && beresp.status <= 599) {
-    set req.http.Fastly-Cachetype = "ERROR";
-    set beresp.ttl = 1s;
-    set beresp.grace = 5s;
-    if (beresp.http.Fastly-Backend-Name ~ "^mirror") {
-      error 503 "Error page";
-    }
-    return (deliver);
   }
 
   if (beresp.http.Expires || beresp.http.Surrogate-Control ~ "max-age" || beresp.http.Cache-Control ~"(s-maxage|max-age)") {

--- a/vcl_templates/mirror.vcl.erb
+++ b/vcl_templates/mirror.vcl.erb
@@ -334,6 +334,30 @@ sub vcl_fetch {
     set beresp.http.Fastly-Restarts = req.restarts;
   }
 
+  # The only valid status from our mirrors is a 200. They cannot return e.g.
+  # a 301 status code. All errors from the mirrors are set to 503 as they
+  # cannot know whether or not a page actually exists (e.g. /search is a valid
+  # URL but the mirror cannot return it). It should be noted that the 503 is
+  # set only when the last mirror has been attempted.
+  if (beresp.status != 200 && beresp.http.Fastly-Backend-Name ~ "^mirror") {
+    if (req.restarts < 3 ){
+      set beresp.saintmode = 5s;
+      return (restart);
+    } else {
+      set beresp.status = 503;
+    }
+  }
+
+  if (beresp.status >= 500 && beresp.status <= 599) {
+    set req.http.Fastly-Cachetype = "ERROR";
+    set beresp.ttl = 1s;
+    set beresp.grace = 5s;
+    if (beresp.http.Fastly-Backend-Name ~ "^mirror") {
+      error 503 "Error page";
+    }
+    return (deliver);
+  }
+
   if (beresp.http.Cache-Control ~ "private") {
     set req.http.Fastly-Cachetype = "PRIVATE";
     return (pass);
@@ -345,24 +369,6 @@ sub vcl_fetch {
 
   if (beresp.http.Cache-Control ~ "no-(store|cache)") {
     return (pass);
-  }
-
-  # The only valid status from our mirrors is a 200. They cannot return e.g.
-  # a 301 status code. All errors from the mirrors are set to 503 as they
-  # cannot know whether or not a page actually exists (e.g. /search is a valid
-  # URL but the mirror cannot return it).
-  if (beresp.status != 200 && beresp.http.Fastly-Backend-Name ~ "^mirror") {
-    set beresp.status = 503;
-  }
-
-  if (beresp.status >= 500 && beresp.status <= 599) {
-    set req.http.Fastly-Cachetype = "ERROR";
-    set beresp.ttl = 1s;
-    set beresp.grace = 5s;
-    if (beresp.http.Fastly-Backend-Name ~ "^mirror") {
-      error 503 "Error page";
-    }
-    return (deliver);
   }
 
   if (beresp.http.Expires || beresp.http.Surrogate-Control ~ "max-age" || beresp.http.Cache-Control ~"(s-maxage|max-age)") {

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -342,6 +342,30 @@ sub vcl_fetch {
     set beresp.http.Fastly-Restarts = req.restarts;
   }
 
+  # The only valid status from our mirrors is a 200. They cannot return e.g.
+  # a 301 status code. All errors from the mirrors are set to 503 as they
+  # cannot know whether or not a page actually exists (e.g. /search is a valid
+  # URL but the mirror cannot return it). It should be noted that the 503 is 
+  # set only when the last mirror has been attempted.
+  if (beresp.status != 200 && beresp.http.Fastly-Backend-Name ~ "^mirror") {
+    if (req.restarts < 3 ){
+      set beresp.saintmode = 5s;
+      return (restart);
+    } else {
+      set beresp.status = 503;
+    }
+  }
+
+  if (beresp.status >= 500 && beresp.status <= 599) {
+    set req.http.Fastly-Cachetype = "ERROR";
+    set beresp.ttl = 1s;
+    set beresp.grace = 5s;
+    if (beresp.http.Fastly-Backend-Name ~ "^mirror") {
+      error 503 "Error page";
+    }
+    return (deliver);
+  }
+
   if (beresp.http.Cache-Control ~ "private") {
     set req.http.Fastly-Cachetype = "PRIVATE";
     return (pass);
@@ -353,24 +377,6 @@ sub vcl_fetch {
 
   if (beresp.http.Cache-Control ~ "no-(store|cache)") {
     return (pass);
-  }
-
-  # The only valid status from our mirrors is a 200. They cannot return e.g.
-  # a 301 status code. All errors from the mirrors are set to 503 as they
-  # cannot know whether or not a page actually exists (e.g. /search is a valid
-  # URL but the mirror cannot return it).
-  if (beresp.status != 200 && beresp.http.Fastly-Backend-Name ~ "^mirror") {
-    set beresp.status = 503;
-  }
-
-  if (beresp.status >= 500 && beresp.status <= 599) {
-    set req.http.Fastly-Cachetype = "ERROR";
-    set beresp.ttl = 1s;
-    set beresp.grace = 5s;
-    if (beresp.http.Fastly-Backend-Name ~ "^mirror") {
-      error 503 "Error page";
-    }
-    return (deliver);
   }
 
   if (beresp.http.Expires || beresp.http.Surrogate-Control ~ "max-age" || beresp.http.Cache-Control ~"(s-maxage|max-age)") {


### PR DESCRIPTION
# Context

When the origin application is sick, the fastly fetches the content from the first mirror. If the first mirror does not find it, we go through the other mirrors. If the last mirror, does not have it, fastly should return a custom 503 govuk error. Unfortunately, fastly is returning a 404 `not found` if the first mirror does not have it.

This is due to the fact that the code for checking mirror response http code is too late in the order of things in vcl_fetch, needs to go higher up

# Decisions
1. move the code block to check response code of mirrors to higher up in vcl_fetch to get the behaviour that we want
2. modify that code block to try all mirrors before erroring.