### PR TITLE
Update Fastly IPs

### DIFF
--- a/spec/test-outputs/assets-integration.out.vcl
+++ b/spec/test-outputs/assets-integration.out.vcl
@@ -81,6 +81,10 @@ acl purge_ip_whitelist {
   "199.232.0.0"/16;   # Fastly cache node
   "202.21.128.0"/24;  # Fastly cache node
   "203.57.145.0"/24;  # Fastly cache node
+  "167.82.0.0"/17;    # Fastly cache node
+  "167.82.128.0"/20;  # Fastly cache node
+  "167.82.160.0"/20;  # Fastly cache node
+  "167.82.224.0"/20;  # Fastly cache node
 }
 
 sub vcl_recv {

--- a/spec/test-outputs/assets-production.out.vcl
+++ b/spec/test-outputs/assets-production.out.vcl
@@ -182,6 +182,10 @@ acl purge_ip_whitelist {
   "199.232.0.0"/16;   # Fastly cache node
   "202.21.128.0"/24;  # Fastly cache node
   "203.57.145.0"/24;  # Fastly cache node
+  "167.82.0.0"/17;    # Fastly cache node
+  "167.82.128.0"/20;  # Fastly cache node
+  "167.82.160.0"/20;  # Fastly cache node
+  "167.82.224.0"/20;  # Fastly cache node
 }
 
 sub vcl_recv {

--- a/spec/test-outputs/assets-staging.out.vcl
+++ b/spec/test-outputs/assets-staging.out.vcl
@@ -182,6 +182,10 @@ acl purge_ip_whitelist {
   "199.232.0.0"/16;   # Fastly cache node
   "202.21.128.0"/24;  # Fastly cache node
   "203.57.145.0"/24;  # Fastly cache node
+  "167.82.0.0"/17;    # Fastly cache node
+  "167.82.128.0"/20;  # Fastly cache node
+  "167.82.160.0"/20;  # Fastly cache node
+  "167.82.224.0"/20;  # Fastly cache node
 }
 
 sub vcl_recv {

--- a/spec/test-outputs/mirror-integration.out.vcl
+++ b/spec/test-outputs/mirror-integration.out.vcl
@@ -49,6 +49,10 @@ acl purge_ip_whitelist {
   "199.232.0.0"/16;   # Fastly cache node
   "202.21.128.0"/24;  # Fastly cache node
   "203.57.145.0"/24;  # Fastly cache node
+  "167.82.0.0"/17;    # Fastly cache node
+  "167.82.128.0"/20;  # Fastly cache node
+  "167.82.160.0"/20;  # Fastly cache node
+  "167.82.224.0"/20;  # Fastly cache node
 }
 
 acl allowed_ip_addresses {

--- a/spec/test-outputs/mirror-production.out.vcl
+++ b/spec/test-outputs/mirror-production.out.vcl
@@ -150,6 +150,10 @@ acl purge_ip_whitelist {
   "199.232.0.0"/16;   # Fastly cache node
   "202.21.128.0"/24;  # Fastly cache node
   "203.57.145.0"/24;  # Fastly cache node
+  "167.82.0.0"/17;    # Fastly cache node
+  "167.82.128.0"/20;  # Fastly cache node
+  "167.82.160.0"/20;  # Fastly cache node
+  "167.82.224.0"/20;  # Fastly cache node
 }
 
 acl allowed_ip_addresses {

--- a/spec/test-outputs/mirror-staging.out.vcl
+++ b/spec/test-outputs/mirror-staging.out.vcl
@@ -150,6 +150,10 @@ acl purge_ip_whitelist {
   "199.232.0.0"/16;   # Fastly cache node
   "202.21.128.0"/24;  # Fastly cache node
   "203.57.145.0"/24;  # Fastly cache node
+  "167.82.0.0"/17;    # Fastly cache node
+  "167.82.128.0"/20;  # Fastly cache node
+  "167.82.160.0"/20;  # Fastly cache node
+  "167.82.224.0"/20;  # Fastly cache node
 }
 
 acl allowed_ip_addresses {

--- a/spec/test-outputs/performanceplatform-integration.out.vcl
+++ b/spec/test-outputs/performanceplatform-integration.out.vcl
@@ -57,6 +57,10 @@ acl purge_ip_whitelist {
   "199.232.0.0"/16;   # Fastly cache node
   "202.21.128.0"/24;  # Fastly cache node
   "203.57.145.0"/24;  # Fastly cache node
+  "167.82.0.0"/17;    # Fastly cache node
+  "167.82.128.0"/20;  # Fastly cache node
+  "167.82.160.0"/20;  # Fastly cache node
+  "167.82.224.0"/20;  # Fastly cache node
 }
 
 sub vcl_recv {

--- a/spec/test-outputs/performanceplatform-production.out.vcl
+++ b/spec/test-outputs/performanceplatform-production.out.vcl
@@ -57,6 +57,10 @@ acl purge_ip_whitelist {
   "199.232.0.0"/16;   # Fastly cache node
   "202.21.128.0"/24;  # Fastly cache node
   "203.57.145.0"/24;  # Fastly cache node
+  "167.82.0.0"/17;    # Fastly cache node
+  "167.82.128.0"/20;  # Fastly cache node
+  "167.82.160.0"/20;  # Fastly cache node
+  "167.82.224.0"/20;  # Fastly cache node
 }
 
 sub vcl_recv {

--- a/spec/test-outputs/performanceplatform-staging.out.vcl
+++ b/spec/test-outputs/performanceplatform-staging.out.vcl
@@ -57,6 +57,10 @@ acl purge_ip_whitelist {
   "199.232.0.0"/16;   # Fastly cache node
   "202.21.128.0"/24;  # Fastly cache node
   "203.57.145.0"/24;  # Fastly cache node
+  "167.82.0.0"/17;    # Fastly cache node
+  "167.82.128.0"/20;  # Fastly cache node
+  "167.82.160.0"/20;  # Fastly cache node
+  "167.82.224.0"/20;  # Fastly cache node
 }
 
 sub vcl_recv {

--- a/spec/test-outputs/www-integration.out.vcl
+++ b/spec/test-outputs/www-integration.out.vcl
@@ -53,6 +53,10 @@ acl purge_ip_whitelist {
   "199.232.0.0"/16;   # Fastly cache node
   "202.21.128.0"/24;  # Fastly cache node
   "203.57.145.0"/24;  # Fastly cache node
+  "167.82.0.0"/17;    # Fastly cache node
+  "167.82.128.0"/20;  # Fastly cache node
+  "167.82.160.0"/20;  # Fastly cache node
+  "167.82.224.0"/20;  # Fastly cache node
 }
 
 
@@ -270,7 +274,7 @@ sub vcl_fetch {
   # The only valid status from our mirrors is a 200. They cannot return e.g.
   # a 301 status code. All errors from the mirrors are set to 503 as they
   # cannot know whether or not a page actually exists (e.g. /search is a valid
-  # URL but the mirror cannot return it). It should be noted that the 503 is 
+  # URL but the mirror cannot return it). It should be noted that the 503 is
   # set only when the last mirror has been attempted.
   if (beresp.status != 200 && beresp.http.Fastly-Backend-Name ~ "^mirror") {
     if (req.restarts < 3 ){

--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -150,6 +150,10 @@ acl purge_ip_whitelist {
   "199.232.0.0"/16;   # Fastly cache node
   "202.21.128.0"/24;  # Fastly cache node
   "203.57.145.0"/24;  # Fastly cache node
+  "167.82.0.0"/17;    # Fastly cache node
+  "167.82.128.0"/20;  # Fastly cache node
+  "167.82.160.0"/20;  # Fastly cache node
+  "167.82.224.0"/20;  # Fastly cache node
 }
 
 
@@ -424,7 +428,7 @@ sub vcl_fetch {
   # The only valid status from our mirrors is a 200. They cannot return e.g.
   # a 301 status code. All errors from the mirrors are set to 503 as they
   # cannot know whether or not a page actually exists (e.g. /search is a valid
-  # URL but the mirror cannot return it). It should be noted that the 503 is 
+  # URL but the mirror cannot return it). It should be noted that the 503 is
   # set only when the last mirror has been attempted.
   if (beresp.status != 200 && beresp.http.Fastly-Backend-Name ~ "^mirror") {
     if (req.restarts < 3 ){

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -150,6 +150,10 @@ acl purge_ip_whitelist {
   "199.232.0.0"/16;   # Fastly cache node
   "202.21.128.0"/24;  # Fastly cache node
   "203.57.145.0"/24;  # Fastly cache node
+  "167.82.0.0"/17;    # Fastly cache node
+  "167.82.128.0"/20;  # Fastly cache node
+  "167.82.160.0"/20;  # Fastly cache node
+  "167.82.224.0"/20;  # Fastly cache node
 }
 
 
@@ -433,7 +437,7 @@ sub vcl_fetch {
   # The only valid status from our mirrors is a 200. They cannot return e.g.
   # a 301 status code. All errors from the mirrors are set to 503 as they
   # cannot know whether or not a page actually exists (e.g. /search is a valid
-  # URL but the mirror cannot return it). It should be noted that the 503 is 
+  # URL but the mirror cannot return it). It should be noted that the 503 is
   # set only when the last mirror has been attempted.
   if (beresp.status != 200 && beresp.http.Fastly-Backend-Name ~ "^mirror") {
     if (req.restarts < 3 ){

--- a/vcl_templates/assets.vcl.erb
+++ b/vcl_templates/assets.vcl.erb
@@ -206,6 +206,10 @@ acl purge_ip_whitelist {
   "199.232.0.0"/16;   # Fastly cache node
   "202.21.128.0"/24;  # Fastly cache node
   "203.57.145.0"/24;  # Fastly cache node
+  "167.82.0.0"/17;    # Fastly cache node
+  "167.82.128.0"/20;  # Fastly cache node
+  "167.82.160.0"/20;  # Fastly cache node
+  "167.82.224.0"/20;  # Fastly cache node
 }
 
 sub vcl_recv {

--- a/vcl_templates/mirror.vcl.erb
+++ b/vcl_templates/mirror.vcl.erb
@@ -173,6 +173,10 @@ acl purge_ip_whitelist {
   "199.232.0.0"/16;   # Fastly cache node
   "202.21.128.0"/24;  # Fastly cache node
   "203.57.145.0"/24;  # Fastly cache node
+  "167.82.0.0"/17;    # Fastly cache node
+  "167.82.128.0"/20;  # Fastly cache node
+  "167.82.160.0"/20;  # Fastly cache node
+  "167.82.224.0"/20;  # Fastly cache node
 }
 
 acl allowed_ip_addresses {

--- a/vcl_templates/performanceplatform.vcl.erb
+++ b/vcl_templates/performanceplatform.vcl.erb
@@ -62,6 +62,10 @@ acl purge_ip_whitelist {
   "199.232.0.0"/16;   # Fastly cache node
   "202.21.128.0"/24;  # Fastly cache node
   "203.57.145.0"/24;  # Fastly cache node
+  "167.82.0.0"/17;    # Fastly cache node
+  "167.82.128.0"/20;  # Fastly cache node
+  "167.82.160.0"/20;  # Fastly cache node
+  "167.82.224.0"/20;  # Fastly cache node
 }
 
 sub vcl_recv {

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -177,6 +177,10 @@ acl purge_ip_whitelist {
   "199.232.0.0"/16;   # Fastly cache node
   "202.21.128.0"/24;  # Fastly cache node
   "203.57.145.0"/24;  # Fastly cache node
+  "167.82.0.0"/17;    # Fastly cache node
+  "167.82.128.0"/20;  # Fastly cache node
+  "167.82.160.0"/20;  # Fastly cache node
+  "167.82.224.0"/20;  # Fastly cache node
 }
 
 <% if %w(staging integration).include?(environment) %>
@@ -345,7 +349,7 @@ sub vcl_fetch {
   # The only valid status from our mirrors is a 200. They cannot return e.g.
   # a 301 status code. All errors from the mirrors are set to 503 as they
   # cannot know whether or not a page actually exists (e.g. /search is a valid
-  # URL but the mirror cannot return it). It should be noted that the 503 is 
+  # URL but the mirror cannot return it). It should be noted that the 503 is
   # set only when the last mirror has been attempted.
   if (beresp.status != 200 && beresp.http.Fastly-Backend-Name ~ "^mirror") {
     if (req.restarts < 3 ){


### PR DESCRIPTION
It looks like Fastly have updated their IP addresses: https://deploy.publishing.service.gov.uk/job/Check_CDN_IP_Ranges/1444/console