### PR TITLE
Correct test name

### DIFF
--- a/configs/dictionaries/ab_test_expiries.yaml
+++ b/configs/dictionaries/ab_test_expiries.yaml
@@ -8,4 +8,4 @@
 Example: 86400
 ViewDrivingLicence: 259200
 FinderAnswerABTest: 3628800 # 6 Weeks
-SearchClusterABTest: 86400 # 1 day
+SearchClusterQueryABTest: 86400 # 1 day


### PR DESCRIPTION
We've launched a new test, and the name needs to be updated here.