### PR TITLE
Make landing page AB test active

### DIFF
--- a/configs/dictionaries/active_ab_tests.yaml
+++ b/configs/dictionaries/active_ab_tests.yaml
@@ -7,4 +7,4 @@ Example: true
 ViewDrivingLicence: false
 FinderAnswerABTest: true
 SearchClusterQueryABTest: true
-LandingPageTest: false
+LandingPageTest: true


### PR DESCRIPTION
This PR sets the landing page test to active, which I think is needed to deploy and be able to check it has been set up properly.

Traffic won't actually start being sent to any variants until we've implemented the logic in Collections and have adjusted the percentages to direct a proportion of traffic to B.