### PR TITLE
Remove querystrings and sub paths from register-to-vote

### DIFF
--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -203,6 +203,10 @@ sub vcl_recv {
     set req.http.original-url = req.url;
   }
 
+  if (req.url.path ~ "(?i)^/register-to-vote(-armed-forces|-crown-servants-british-council-employees)?") {
+    set req.url = std.tolower(re.group.0);
+  }
+
   # Common config when failover to mirror buckets
   if (req.restarts > 0) {
     set req.url = req.http.original-url;

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -212,6 +212,10 @@ sub vcl_recv {
     set req.http.original-url = req.url;
   }
 
+  if (req.url.path ~ "(?i)^/register-to-vote(-armed-forces|-crown-servants-british-council-employees)?") {
+    set req.url = std.tolower(re.group.0);
+  }
+
   # Common config when failover to mirror buckets
   if (req.restarts > 0) {
     set req.url = req.http.original-url;

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -248,6 +248,10 @@ sub vcl_recv {
     set req.http.original-url = req.url;
   }
 
+  if (req.url.path ~ "(?i)^/register-to-vote(-armed-forces|-crown-servants-british-council-employees)?") {
+    set req.url = std.tolower(re.group.0);
+  }
+
   # Common config when failover to mirror buckets
   if (req.restarts > 0) {
     set req.url = req.http.original-url;


### PR DESCRIPTION
Any paths under our three `register-to-vote` base paths are not
neccessary and we can safely normalise to the base path.

Similarly, we don't need the querystrings on these paths and allowing
them just leads to more needless requests to origin.

[Trello](https://trello.com/c/cpi5iw7T/846-temporarily-strip-cache-bust-string-on-register-to-vote-in-our-vcl)