### PR TITLE
Stop special treatment of register-to-vote

### DIFF
--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -203,10 +203,6 @@ sub vcl_recv {
     set req.http.original-url = req.url;
   }
 
-  if (req.url.path ~ "(?i)^/register-to-vote(-armed-forces|-crown-servants-british-council-employees)?") {
-    set req.url = std.tolower(re.group.0);
-  }
-
   # Common config when failover to mirror buckets
   if (req.restarts > 0) {
     set req.url = req.http.original-url;

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -212,10 +212,6 @@ sub vcl_recv {
     set req.http.original-url = req.url;
   }
 
-  if (req.url.path ~ "(?i)^/register-to-vote(-armed-forces|-crown-servants-british-council-employees)?") {
-    set req.url = std.tolower(re.group.0);
-  }
-
   # Common config when failover to mirror buckets
   if (req.restarts > 0) {
     set req.url = req.http.original-url;

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -248,10 +248,6 @@ sub vcl_recv {
     set req.http.original-url = req.url;
   }
 
-  if (req.url.path ~ "(?i)^/register-to-vote(-armed-forces|-crown-servants-british-council-employees)?") {
-    set req.url = std.tolower(re.group.0);
-  }
-
   # Common config when failover to mirror buckets
   if (req.restarts > 0) {
     set req.url = req.http.original-url;


### PR DESCRIPTION
This reverts commit f90abeaba4fd91ebf117b05c5984d5bebf4f8713.

This allows things like cache-busting strings to work again and removes some "weird" from the world.