### PR TITLE
remove carrenza assets cdn route

### DIFF
--- a/spec/test-outputs/assets-integration.out.vcl
+++ b/spec/test-outputs/assets-integration.out.vcl
@@ -1,34 +1,3 @@
-backend F_carrenzaorigin {
-    .connect_timeout = 5s;
-    .dynamic = true;
-    .port = "443";
-    .host = "foo";
-    .first_byte_timeout = 15s;
-    .max_connections = 200;
-    .between_bytes_timeout = 10s;
-    .share_key = "123";
-
-    .ssl = true;
-    .ssl_check_cert = always;
-    .min_tls_version = "1.2";
-    .ssl_cert_hostname = "foo";
-    .ssl_sni_hostname = "foo";
-
-    .probe = {
-        .request =
-            "HEAD /__canary__ HTTP/1.1"
-            "Host: foo"
-            "User-Agent: Fastly healthcheck (git version: )"
-
-            "Connection: close";
-        .threshold = 1;
-        .window = 2;
-        .timeout = 5s;
-        .initial = 1;
-        .expected_response = 200;
-        .interval = 10s;
-      }
-}
 backend F_awsorigin {
     .connect_timeout = 5s;
     .dynamic = true;
@@ -111,17 +80,6 @@ sub vcl_recv {
   set req.backend = F_awsorigin;
   set req.http.Fastly-Backend-Name = "awsorigin";
   set req.http.host = "foo";
-
-  if (req.url ~ "^/asset-manager" ||
-      req.url ~ "^/government/uploads" ||
-      req.url ~ "^/media" ||
-      req.url ~ "^/government/assets" ||
-      req.url ~ "^/government/placeholder"
-      ) {
-      set req.backend = F_carrenzaorigin;
-      set req.http.Fastly-Backend-Name = "carrenzaorigin";
-      set req.http.host = "foo";
-  }
 
   
 

--- a/spec/test-outputs/assets-production.out.vcl
+++ b/spec/test-outputs/assets-production.out.vcl
@@ -1,34 +1,3 @@
-backend F_carrenzaorigin {
-    .connect_timeout = 5s;
-    .dynamic = true;
-    .port = "443";
-    .host = "foo";
-    .first_byte_timeout = 15s;
-    .max_connections = 200;
-    .between_bytes_timeout = 10s;
-    .share_key = "123";
-
-    .ssl = true;
-    .ssl_check_cert = always;
-    .min_tls_version = "1.2";
-    .ssl_cert_hostname = "foo";
-    .ssl_sni_hostname = "foo";
-
-    .probe = {
-        .request =
-            "HEAD /__canary__ HTTP/1.1"
-            "Host: foo"
-            "User-Agent: Fastly healthcheck (git version: )"
-
-            "Connection: close";
-        .threshold = 1;
-        .window = 2;
-        .timeout = 5s;
-        .initial = 1;
-        .expected_response = 200;
-        .interval = 10s;
-      }
-}
 backend F_awsorigin {
     .connect_timeout = 5s;
     .dynamic = true;
@@ -212,17 +181,6 @@ sub vcl_recv {
   set req.backend = F_awsorigin;
   set req.http.Fastly-Backend-Name = "awsorigin";
   set req.http.host = "foo";
-
-  if (req.url ~ "^/asset-manager" ||
-      req.url ~ "^/government/uploads" ||
-      req.url ~ "^/media" ||
-      req.url ~ "^/government/assets" ||
-      req.url ~ "^/government/placeholder"
-      ) {
-      set req.backend = F_carrenzaorigin;
-      set req.http.Fastly-Backend-Name = "carrenzaorigin";
-      set req.http.host = "foo";
-  }
 
   
 

--- a/spec/test-outputs/assets-staging.out.vcl
+++ b/spec/test-outputs/assets-staging.out.vcl
@@ -1,34 +1,3 @@
-backend F_carrenzaorigin {
-    .connect_timeout = 5s;
-    .dynamic = true;
-    .port = "443";
-    .host = "foo";
-    .first_byte_timeout = 15s;
-    .max_connections = 200;
-    .between_bytes_timeout = 10s;
-    .share_key = "123";
-
-    .ssl = true;
-    .ssl_check_cert = always;
-    .min_tls_version = "1.2";
-    .ssl_cert_hostname = "foo";
-    .ssl_sni_hostname = "foo";
-
-    .probe = {
-        .request =
-            "HEAD /__canary__ HTTP/1.1"
-            "Host: foo"
-            "User-Agent: Fastly healthcheck (git version: )"
-
-            "Connection: close";
-        .threshold = 1;
-        .window = 2;
-        .timeout = 5s;
-        .initial = 1;
-        .expected_response = 200;
-        .interval = 10s;
-      }
-}
 backend F_awsorigin {
     .connect_timeout = 5s;
     .dynamic = true;
@@ -212,17 +181,6 @@ sub vcl_recv {
   set req.backend = F_awsorigin;
   set req.http.Fastly-Backend-Name = "awsorigin";
   set req.http.host = "foo";
-
-  if (req.url ~ "^/asset-manager" ||
-      req.url ~ "^/government/uploads" ||
-      req.url ~ "^/media" ||
-      req.url ~ "^/government/assets" ||
-      req.url ~ "^/government/placeholder"
-      ) {
-      set req.backend = F_carrenzaorigin;
-      set req.http.Fastly-Backend-Name = "carrenzaorigin";
-      set req.http.host = "foo";
-  }
 
   
 

--- a/spec/vcl_generation_spec.rb
+++ b/spec/vcl_generation_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe "VCL generation" do
   config = {
     "origin_hostname" => "foo",
     "aws_origin_hostname" => "foo",
-    "carrenza_origin_hostname" => "foo",
     "service_id" => "123",
     "provider1_mirror_hostname" => "foo",
     "s3_mirror_hostname" => "bar",

--- a/vcl_templates/assets.vcl.erb
+++ b/vcl_templates/assets.vcl.erb
@@ -1,39 +1,3 @@
-backend F_carrenzaorigin {
-    .connect_timeout = 5s;
-    .dynamic = true;
-    .port = "<%= config.fetch('carrenza_origin_port', '443') %>";
-    .host = "<%= config.fetch('carrenza_origin_hostname') %>";
-    .first_byte_timeout = 15s;
-    .max_connections = 200;
-    .between_bytes_timeout = 10s;
-    .share_key = "<%= config.fetch('service_id') %>";
-
-    .ssl = true;
-    .ssl_check_cert = <%= config['disable_tls_validation'] ? 'never' : 'always' %>;
-    .min_tls_version = "<%= config.fetch('min_tls_version', '1.2') %>";
-    <%- if config['ssl_ciphers'] -%>
-    .ssl_ciphers = "<%= config['ssl_ciphers'] -%>";
-    <%- end -%>
-    .ssl_cert_hostname = "<%= config.fetch('ssl_cert_hostname', config.fetch('carrenza_origin_hostname')) %>";
-    .ssl_sni_hostname = "<%= config.fetch('ssl_sni_hostname', config.fetch('carrenza_origin_hostname')) %>";
-
-    .probe = {
-        .request =
-            "HEAD /__canary__ HTTP/1.1"
-            "Host: <%= config.fetch('carrenza_origin_hostname') %>"
-            "User-Agent: Fastly healthcheck (git version: <%= config['git_version'] %>)"
-<% if config['rate_limit_token'] %>
-            "Rate-Limit-Token: <%= config['rate_limit_token'] %>"
-<% end %>
-            "Connection: close";
-        .threshold = 1;
-        .window = 2;
-        .timeout = 5s;
-        .initial = 1;
-        .expected_response = 200;
-        .interval = 10s;
-      }
-}
 backend F_awsorigin {
     .connect_timeout = 5s;
     .dynamic = true;
@@ -236,17 +200,6 @@ sub vcl_recv {
   set req.backend = F_awsorigin;
   set req.http.Fastly-Backend-Name = "awsorigin";
   set req.http.host = "<%= config.fetch('aws_origin_hostname') %>";
-
-  if (req.url ~ "^/asset-manager" ||
-      req.url ~ "^/government/uploads" ||
-      req.url ~ "^/media" ||
-      req.url ~ "^/government/assets" ||
-      req.url ~ "^/government/placeholder"
-      ) {
-      set req.backend = F_carrenzaorigin;
-      set req.http.Fastly-Backend-Name = "carrenzaorigin";
-      set req.http.host = "<%= config.fetch('carrenza_origin_hostname') %>";
-  }
 
   <% if %w(staging production).include?(environment) %>
 


### PR DESCRIPTION
**PLEASE TEST THIS IN STAGING THOROUGHLY BEFORE MOVING TO PRODUCTION**

now that asset-manager lives in AWS and all assets are in AWS,
we need to route all assets to AWS without any exception.

Associated [PR](https://github.com/alphagov/govuk-cdn-config-secrets/pull/111)