### PR TITLE
Remove setting TLSversion cookie

### DIFF
--- a/spec/test-outputs/mirror-integration.out.vcl
+++ b/spec/test-outputs/mirror-integration.out.vcl
@@ -201,13 +201,6 @@ sub vcl_miss {
 }
 
 sub vcl_deliver {
-  # Set the TLS version session cookie with the raw protocol version from
-  # Fastly only if it isn't already set. We also check for a null TLS value,
-  # which can occur when trying to access over HTTP (http>https upgrading).
-  if (tls.client.protocol && req.http.Cookie !~ "TLSversion") {
-    add resp.http.Set-Cookie = "TLSversion=" tls.client.protocol "; secure";
-  }
-
 #FASTLY deliver
 }
 

--- a/spec/test-outputs/mirror-production.out.vcl
+++ b/spec/test-outputs/mirror-production.out.vcl
@@ -363,13 +363,6 @@ sub vcl_miss {
 }
 
 sub vcl_deliver {
-  # Set the TLS version session cookie with the raw protocol version from
-  # Fastly only if it isn't already set. We also check for a null TLS value,
-  # which can occur when trying to access over HTTP (http>https upgrading).
-  if (tls.client.protocol && req.http.Cookie !~ "TLSversion") {
-    add resp.http.Set-Cookie = "TLSversion=" tls.client.protocol "; secure";
-  }
-
 #FASTLY deliver
 }
 

--- a/spec/test-outputs/mirror-staging.out.vcl
+++ b/spec/test-outputs/mirror-staging.out.vcl
@@ -363,13 +363,6 @@ sub vcl_miss {
 }
 
 sub vcl_deliver {
-  # Set the TLS version session cookie with the raw protocol version from
-  # Fastly only if it isn't already set. We also check for a null TLS value,
-  # which can occur when trying to access over HTTP (http>https upgrading).
-  if (tls.client.protocol && req.http.Cookie !~ "TLSversion") {
-    add resp.http.Set-Cookie = "TLSversion=" tls.client.protocol "; secure";
-  }
-
 #FASTLY deliver
 }
 

--- a/spec/test-outputs/www-integration.out.vcl
+++ b/spec/test-outputs/www-integration.out.vcl
@@ -305,13 +305,6 @@ sub vcl_deliver {
   }
   # End dynamic section
 
-  # Set the TLS version session cookie with the raw protocol version from
-  # Fastly only if it isn't already set. We also check for a null TLS value,
-  # which can occur when trying to access over HTTP (http>https upgrading).
-  if (tls.client.protocol && req.http.Cookie !~ "TLSversion") {
-    add resp.http.Set-Cookie = "TLSversion=" tls.client.protocol "; secure";
-  }
-
 #FASTLY deliver
 }
 

--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -459,13 +459,6 @@ sub vcl_deliver {
   }
   # End dynamic section
 
-  # Set the TLS version session cookie with the raw protocol version from
-  # Fastly only if it isn't already set. We also check for a null TLS value,
-  # which can occur when trying to access over HTTP (http>https upgrading).
-  if (tls.client.protocol && req.http.Cookie !~ "TLSversion") {
-    add resp.http.Set-Cookie = "TLSversion=" tls.client.protocol "; secure";
-  }
-
 #FASTLY deliver
 }
 

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -468,13 +468,6 @@ sub vcl_deliver {
   }
   # End dynamic section
 
-  # Set the TLS version session cookie with the raw protocol version from
-  # Fastly only if it isn't already set. We also check for a null TLS value,
-  # which can occur when trying to access over HTTP (http>https upgrading).
-  if (tls.client.protocol && req.http.Cookie !~ "TLSversion") {
-    add resp.http.Set-Cookie = "TLSversion=" tls.client.protocol "; secure";
-  }
-
 #FASTLY deliver
 }
 

--- a/vcl_templates/mirror.vcl.erb
+++ b/vcl_templates/mirror.vcl.erb
@@ -400,13 +400,6 @@ sub vcl_miss {
 }
 
 sub vcl_deliver {
-  # Set the TLS version session cookie with the raw protocol version from
-  # Fastly only if it isn't already set. We also check for a null TLS value,
-  # which can occur when trying to access over HTTP (http>https upgrading).
-  if (tls.client.protocol && req.http.Cookie !~ "TLSversion") {
-    add resp.http.Set-Cookie = "TLSversion=" tls.client.protocol "; secure";
-  }
-
 #FASTLY deliver
 }
 

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -452,13 +452,6 @@ sub vcl_deliver {
 <% end # if -%>
   # End dynamic section
 
-  # Set the TLS version session cookie with the raw protocol version from
-  # Fastly only if it isn't already set. We also check for a null TLS value,
-  # which can occur when trying to access over HTTP (http>https upgrading).
-  if (tls.client.protocol && req.http.Cookie !~ "TLSversion") {
-    add resp.http.Set-Cookie = "TLSversion=" tls.client.protocol "; secure";
-  }
-
 #FASTLY deliver
 }
 


### PR DESCRIPTION
This was set so that we can more easily track TLS version support in GA. The number of users who have interacted with the related banner we set in static is down to 0.02% of total users, and down from 19,664 to only 4,272 in one year.