### PR TITLE
Remove VCL code for caching non-GET/HEAD requests

### DIFF
--- a/spec/test-outputs/www-integration.out.vcl
+++ b/spec/test-outputs/www-integration.out.vcl
@@ -121,6 +121,10 @@ sub vcl_recv {
 
 #FASTLY recv
 
+  if (req.request != "HEAD" && req.request != "GET" && req.request != "FASTLYPURGE") {
+    return(pass);
+  }
+
     # Begin dynamic section
 if (table.lookup(active_ab_tests, "Example") == "true") {
   if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
@@ -226,18 +230,6 @@ sub vcl_fetch {
     if (beresp.http.Fastly-Backend-Name ~ "^mirror") {
       set beresp.ttl = 900s;
       set beresp.http.Cache-Control = "max-age=900";
-    }
-  }
-
-  # Cache non-GET/HEAD/FASTLYPURGE requests if they return a 404 or 405
-  if (!(req.request == "GET" || req.request == "HEAD" || req.request == "FASTLYPURGE")) {
-    if (http_status_matches(beresp.status, "404,405")) {
-      # Cache these 404/405 responses
-      set beresp.ttl = 5000s;
-      set beresp.cacheable = true;
-    } else {
-      # Don't cache these responses.
-      set beresp.cacheable = false;
     }
   }
 
@@ -361,21 +353,5 @@ sub vcl_pass {
 }
 
 sub vcl_hash {
-  # include request method
-  set req.hash += req.request;
-
-  # support caching non-GET/HEAD requests
-  if (!(req.request == "GET" || req.request == "HEAD" || req.request == "FASTLYPURGE") && req.postbody) {
-    set req.hash += req.postbody;
-  }
-
-  # if handling GET/HEAD requests, fall back to normal
-  {
-    set req.hash += req.url;
-    set req.hash += req.http.host;
-    set req.hash += "#####GENERATION#####";
-    return (hash);
-  }
-
 #FASTLY hash
 }

--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -275,6 +275,10 @@ sub vcl_recv {
 
 #FASTLY recv
 
+  if (req.request != "HEAD" && req.request != "GET" && req.request != "FASTLYPURGE") {
+    return(pass);
+  }
+
     # Begin dynamic section
 if (table.lookup(active_ab_tests, "Example") == "true") {
   if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
@@ -380,18 +384,6 @@ sub vcl_fetch {
     if (beresp.http.Fastly-Backend-Name ~ "^mirror") {
       set beresp.ttl = 900s;
       set beresp.http.Cache-Control = "max-age=900";
-    }
-  }
-
-  # Cache non-GET/HEAD/FASTLYPURGE requests if they return a 404 or 405
-  if (!(req.request == "GET" || req.request == "HEAD" || req.request == "FASTLYPURGE")) {
-    if (http_status_matches(beresp.status, "404,405")) {
-      # Cache these 404/405 responses
-      set beresp.ttl = 5000s;
-      set beresp.cacheable = true;
-    } else {
-      # Don't cache these responses.
-      set beresp.cacheable = false;
     }
   }
 
@@ -515,21 +507,5 @@ sub vcl_pass {
 }
 
 sub vcl_hash {
-  # include request method
-  set req.hash += req.request;
-
-  # support caching non-GET/HEAD requests
-  if (!(req.request == "GET" || req.request == "HEAD" || req.request == "FASTLYPURGE") && req.postbody) {
-    set req.hash += req.postbody;
-  }
-
-  # if handling GET/HEAD requests, fall back to normal
-  {
-    set req.hash += req.url;
-    set req.hash += req.http.host;
-    set req.hash += "#####GENERATION#####";
-    return (hash);
-  }
-
 #FASTLY hash
 }

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -325,6 +325,10 @@ sub vcl_recv {
 
 #FASTLY recv
 
+  if (req.request != "HEAD" && req.request != "GET" && req.request != "FASTLYPURGE") {
+    return(pass);
+  }
+
   <% template_path = File.join(File.dirname(__FILE__), "vcl_templates/_multivariate_tests.vcl.erb") -%>
   <%= ERB.new(File.new(template_path).read, nil, "-", "_erbout2").result(binding) %>
 
@@ -397,18 +401,6 @@ sub vcl_fetch {
     if (beresp.http.Fastly-Backend-Name ~ "^mirror") {
       set beresp.ttl = 900s;
       set beresp.http.Cache-Control = "max-age=900";
-    }
-  }
-
-  # Cache non-GET/HEAD/FASTLYPURGE requests if they return a 404 or 405
-  if (!(req.request == "GET" || req.request == "HEAD" || req.request == "FASTLYPURGE")) {
-    if (http_status_matches(beresp.status, "404,405")) {
-      # Cache these 404/405 responses
-      set beresp.ttl = <%= config.fetch('default_ttl') %>s;
-      set beresp.cacheable = true;
-    } else {
-      # Don't cache these responses.
-      set beresp.cacheable = false;
     }
   }
 
@@ -552,21 +544,5 @@ sub vcl_pass {
 }
 
 sub vcl_hash {
-  # include request method
-  set req.hash += req.request;
-
-  # support caching non-GET/HEAD requests
-  if (!(req.request == "GET" || req.request == "HEAD" || req.request == "FASTLYPURGE") && req.postbody) {
-    set req.hash += req.postbody;
-  }
-
-  # if handling GET/HEAD requests, fall back to normal
-  {
-    set req.hash += req.url;
-    set req.hash += req.http.host;
-    set req.hash += "#####GENERATION#####";
-    return (hash);
-  }
-
 #FASTLY hash
 }


### PR DESCRIPTION
This reverts commit 689fe7eb4c800ac9fb4393c150133d1c3285389a.

We found a bug in this code that prevents FASTLYPURGE requests
from working as expected. In the vcl_hash we include the request
method in the hash key we use to store and lookup objects in the cache.
This works fine for GET/HEAD/POST requests because we can cache
the responses to these requests as separate objects (a post response
might be different to a get response).

However, it means that FASTLYPURGE requests lookup items in the cache
using FASTLYPURGE as part of the hash, preventing purges from working
as expected.

Rather than attempting to patch this by adding more complexity to the
VCL, we've decided to approach the problem we were trying to solve in
a different way.

Thanks to @kevindew for working on this with me.

https://trello.com/c/7jFNfgr6/1346