### PR TITLE
Change apt backend connection port from 80 to 443

### DIFF
--- a/spec/test-outputs/apt-integration.out.vcl
+++ b/spec/test-outputs/apt-integration.out.vcl
@@ -2,7 +2,7 @@
 backend F_apt {
     .connect_timeout = 1s;
     .dynamic = true;
-    .port = "80";
+    .port = "443";
     .host = "foo";
     .first_byte_timeout = 15s;
     .max_connections = 200;

--- a/spec/test-outputs/apt-production.out.vcl
+++ b/spec/test-outputs/apt-production.out.vcl
@@ -2,7 +2,7 @@
 backend F_apt {
     .connect_timeout = 1s;
     .dynamic = true;
-    .port = "80";
+    .port = "443";
     .host = "foo";
     .first_byte_timeout = 15s;
     .max_connections = 200;

--- a/spec/test-outputs/apt-staging.out.vcl
+++ b/spec/test-outputs/apt-staging.out.vcl
@@ -2,7 +2,7 @@
 backend F_apt {
     .connect_timeout = 1s;
     .dynamic = true;
-    .port = "80";
+    .port = "443";
     .host = "foo";
     .first_byte_timeout = 15s;
     .max_connections = 200;

--- a/vcl_templates/apt.vcl.erb
+++ b/vcl_templates/apt.vcl.erb
@@ -2,7 +2,7 @@
 backend F_apt {
     .connect_timeout = 1s;
     .dynamic = true;
-    .port = "<%= config.fetch('apt_port', 80) %>";
+    .port = "<%= config.fetch('apt_port', 443) %>";
     .host = "<%= config.fetch('apt_hostname') %>";
     .first_byte_timeout = 15s;
     .max_connections = 200;


### PR DESCRIPTION
For the migration to AWS we're going to use https to connect to
the apt LB.