### PR TITLE
Disable A/B tests if the user has not consented to analytics

### DIFF
--- a/spec/fixtures/_multivariate_tests.vcl.erb.out
+++ b/spec/fixtures/_multivariate_tests.vcl.erb.out
@@ -1,89 +1,93 @@
 # Begin dynamic section
-if (table.lookup(active_ab_tests, "MyTest") == "true") {
-  if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
-    set req.http.GOVUK-ABTest-MyTest = "foo";
-  } else if (req.url ~ "[\?\&]ABTest-MyTest=foo(&|$)") {
-    # Some users, such as remote testers, will be given a URL with a query string
-    # to place them into a specific bucket.
-    set req.http.GOVUK-ABTest-MyTest = "foo";
-  } else if (req.url ~ "[\?\&]ABTest-MyTest=bar(&|$)") {
-    # Some users, such as remote testers, will be given a URL with a query string
-    # to place them into a specific bucket.
-    set req.http.GOVUK-ABTest-MyTest = "bar";
-  } else if (req.http.Cookie ~ "ABTest-MyTest") {
-    # Set the value of the header to whatever decision was previously made
-    set req.http.GOVUK-ABTest-MyTest = req.http.Cookie:ABTest-MyTest;
-  } else {
-    declare local var.denominator_MyTest INTEGER;
-    declare local var.denominator_MyTest_foo INTEGER;
-    declare local var.nominator_MyTest_foo INTEGER;
-    set var.nominator_MyTest_foo = std.atoi(table.lookup(mytest_percentages, "foo"));
-    set var.denominator_MyTest += var.nominator_MyTest_foo;
-    declare local var.denominator_MyTest_bar INTEGER;
-    declare local var.nominator_MyTest_bar INTEGER;
-    set var.nominator_MyTest_bar = std.atoi(table.lookup(mytest_percentages, "bar"));
-    set var.denominator_MyTest += var.nominator_MyTest_bar;
-    set var.denominator_MyTest_foo = var.denominator_MyTest;
-    if (randombool(var.nominator_MyTest_foo, var.denominator_MyTest_foo)) {
-      set req.http.GOVUK-ABTest-MyTest = "foo";
-    } else {
-      set req.http.GOVUK-ABTest-MyTest = "bar";
+if (req.http.Cookie ~ "cookies_policy") {
+  if (req.http.Cookie:cookies_policy ~ "%22usage%22:true") {
+    if (table.lookup(active_ab_tests, "MyTest") == "true") {
+      if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
+        set req.http.GOVUK-ABTest-MyTest = "foo";
+      } else if (req.url ~ "[\?\&]ABTest-MyTest=foo(&|$)") {
+        # Some users, such as remote testers, will be given a URL with a query string
+        # to place them into a specific bucket.
+        set req.http.GOVUK-ABTest-MyTest = "foo";
+      } else if (req.url ~ "[\?\&]ABTest-MyTest=bar(&|$)") {
+        # Some users, such as remote testers, will be given a URL with a query string
+        # to place them into a specific bucket.
+        set req.http.GOVUK-ABTest-MyTest = "bar";
+      } else if (req.http.Cookie ~ "ABTest-MyTest") {
+        # Set the value of the header to whatever decision was previously made
+        set req.http.GOVUK-ABTest-MyTest = req.http.Cookie:ABTest-MyTest;
+      } else {
+        declare local var.denominator_MyTest INTEGER;
+        declare local var.denominator_MyTest_foo INTEGER;
+        declare local var.nominator_MyTest_foo INTEGER;
+        set var.nominator_MyTest_foo = std.atoi(table.lookup(mytest_percentages, "foo"));
+        set var.denominator_MyTest += var.nominator_MyTest_foo;
+        declare local var.denominator_MyTest_bar INTEGER;
+        declare local var.nominator_MyTest_bar INTEGER;
+        set var.nominator_MyTest_bar = std.atoi(table.lookup(mytest_percentages, "bar"));
+        set var.denominator_MyTest += var.nominator_MyTest_bar;
+        set var.denominator_MyTest_foo = var.denominator_MyTest;
+        if (randombool(var.nominator_MyTest_foo, var.denominator_MyTest_foo)) {
+          set req.http.GOVUK-ABTest-MyTest = "foo";
+        } else {
+          set req.http.GOVUK-ABTest-MyTest = "bar";
+        }
+      }
     }
-  }
-}
-if (table.lookup(active_ab_tests, "YourTest") == "true") {
-  if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
-    set req.http.GOVUK-ABTest-YourTest = "variant1";
-  } else if (req.url ~ "[\?\&]ABTest-YourTest=variant1(&|$)") {
-    # Some users, such as remote testers, will be given a URL with a query string
-    # to place them into a specific bucket.
-    set req.http.GOVUK-ABTest-YourTest = "variant1";
-  } else if (req.url ~ "[\?\&]ABTest-YourTest=variant2(&|$)") {
-    # Some users, such as remote testers, will be given a URL with a query string
-    # to place them into a specific bucket.
-    set req.http.GOVUK-ABTest-YourTest = "variant2";
-  } else if (req.url ~ "[\?\&]ABTest-YourTest=variant3(&|$)") {
-    # Some users, such as remote testers, will be given a URL with a query string
-    # to place them into a specific bucket.
-    set req.http.GOVUK-ABTest-YourTest = "variant3";
-  } else if (req.url ~ "[\?\&]ABTest-YourTest=variant4(&|$)") {
-    # Some users, such as remote testers, will be given a URL with a query string
-    # to place them into a specific bucket.
-    set req.http.GOVUK-ABTest-YourTest = "variant4";
-  } else if (req.http.Cookie ~ "ABTest-YourTest") {
-    # Set the value of the header to whatever decision was previously made
-    set req.http.GOVUK-ABTest-YourTest = req.http.Cookie:ABTest-YourTest;
-  } else {
-    declare local var.denominator_YourTest INTEGER;
-    declare local var.denominator_YourTest_variant1 INTEGER;
-    declare local var.nominator_YourTest_variant1 INTEGER;
-    set var.nominator_YourTest_variant1 = std.atoi(table.lookup(yourtest_percentages, "variant1"));
-    set var.denominator_YourTest += var.nominator_YourTest_variant1;
-    declare local var.denominator_YourTest_variant2 INTEGER;
-    declare local var.nominator_YourTest_variant2 INTEGER;
-    set var.nominator_YourTest_variant2 = std.atoi(table.lookup(yourtest_percentages, "variant2"));
-    set var.denominator_YourTest += var.nominator_YourTest_variant2;
-    declare local var.denominator_YourTest_variant3 INTEGER;
-    declare local var.nominator_YourTest_variant3 INTEGER;
-    set var.nominator_YourTest_variant3 = std.atoi(table.lookup(yourtest_percentages, "variant3"));
-    set var.denominator_YourTest += var.nominator_YourTest_variant3;
-    declare local var.denominator_YourTest_variant4 INTEGER;
-    declare local var.nominator_YourTest_variant4 INTEGER;
-    set var.nominator_YourTest_variant4 = std.atoi(table.lookup(yourtest_percentages, "variant4"));
-    set var.denominator_YourTest += var.nominator_YourTest_variant4;
-    set var.denominator_YourTest_variant1 = var.denominator_YourTest;
-    set var.denominator_YourTest_variant2 = var.denominator_YourTest_variant1;
-    set var.denominator_YourTest_variant2 -= var.nominator_YourTest_variant1;
-    set var.denominator_YourTest_variant3 = var.denominator_YourTest_variant2;
-    set var.denominator_YourTest_variant3 -= var.nominator_YourTest_variant2;
-    if (randombool(var.nominator_YourTest_variant1, var.denominator_YourTest_variant1)) {
-      set req.http.GOVUK-ABTest-YourTest = "variant1";
-    } else if (randombool(var.nominator_YourTest_variant2, var.denominator_YourTest_variant2)) {
-      set req.http.GOVUK-ABTest-YourTest = "variant2";
-    } else if (randombool(var.nominator_YourTest_variant3, var.denominator_YourTest_variant3)) {
-      set req.http.GOVUK-ABTest-YourTest = "variant3";
-    } else {
-      set req.http.GOVUK-ABTest-YourTest = "variant4";
+    if (table.lookup(active_ab_tests, "YourTest") == "true") {
+      if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
+        set req.http.GOVUK-ABTest-YourTest = "variant1";
+      } else if (req.url ~ "[\?\&]ABTest-YourTest=variant1(&|$)") {
+        # Some users, such as remote testers, will be given a URL with a query string
+        # to place them into a specific bucket.
+        set req.http.GOVUK-ABTest-YourTest = "variant1";
+      } else if (req.url ~ "[\?\&]ABTest-YourTest=variant2(&|$)") {
+        # Some users, such as remote testers, will be given a URL with a query string
+        # to place them into a specific bucket.
+        set req.http.GOVUK-ABTest-YourTest = "variant2";
+      } else if (req.url ~ "[\?\&]ABTest-YourTest=variant3(&|$)") {
+        # Some users, such as remote testers, will be given a URL with a query string
+        # to place them into a specific bucket.
+        set req.http.GOVUK-ABTest-YourTest = "variant3";
+      } else if (req.url ~ "[\?\&]ABTest-YourTest=variant4(&|$)") {
+        # Some users, such as remote testers, will be given a URL with a query string
+        # to place them into a specific bucket.
+        set req.http.GOVUK-ABTest-YourTest = "variant4";
+      } else if (req.http.Cookie ~ "ABTest-YourTest") {
+        # Set the value of the header to whatever decision was previously made
+        set req.http.GOVUK-ABTest-YourTest = req.http.Cookie:ABTest-YourTest;
+      } else {
+        declare local var.denominator_YourTest INTEGER;
+        declare local var.denominator_YourTest_variant1 INTEGER;
+        declare local var.nominator_YourTest_variant1 INTEGER;
+        set var.nominator_YourTest_variant1 = std.atoi(table.lookup(yourtest_percentages, "variant1"));
+        set var.denominator_YourTest += var.nominator_YourTest_variant1;
+        declare local var.denominator_YourTest_variant2 INTEGER;
+        declare local var.nominator_YourTest_variant2 INTEGER;
+        set var.nominator_YourTest_variant2 = std.atoi(table.lookup(yourtest_percentages, "variant2"));
+        set var.denominator_YourTest += var.nominator_YourTest_variant2;
+        declare local var.denominator_YourTest_variant3 INTEGER;
+        declare local var.nominator_YourTest_variant3 INTEGER;
+        set var.nominator_YourTest_variant3 = std.atoi(table.lookup(yourtest_percentages, "variant3"));
+        set var.denominator_YourTest += var.nominator_YourTest_variant3;
+        declare local var.denominator_YourTest_variant4 INTEGER;
+        declare local var.nominator_YourTest_variant4 INTEGER;
+        set var.nominator_YourTest_variant4 = std.atoi(table.lookup(yourtest_percentages, "variant4"));
+        set var.denominator_YourTest += var.nominator_YourTest_variant4;
+        set var.denominator_YourTest_variant1 = var.denominator_YourTest;
+        set var.denominator_YourTest_variant2 = var.denominator_YourTest_variant1;
+        set var.denominator_YourTest_variant2 -= var.nominator_YourTest_variant1;
+        set var.denominator_YourTest_variant3 = var.denominator_YourTest_variant2;
+        set var.denominator_YourTest_variant3 -= var.nominator_YourTest_variant2;
+        if (randombool(var.nominator_YourTest_variant1, var.denominator_YourTest_variant1)) {
+          set req.http.GOVUK-ABTest-YourTest = "variant1";
+        } else if (randombool(var.nominator_YourTest_variant2, var.denominator_YourTest_variant2)) {
+          set req.http.GOVUK-ABTest-YourTest = "variant2";
+        } else if (randombool(var.nominator_YourTest_variant3, var.denominator_YourTest_variant3)) {
+          set req.http.GOVUK-ABTest-YourTest = "variant3";
+        } else {
+          set req.http.GOVUK-ABTest-YourTest = "variant4";
+        }
+      }
     }
   }
 }

--- a/spec/test-outputs/www-integration.out.vcl
+++ b/spec/test-outputs/www-integration.out.vcl
@@ -126,35 +126,39 @@ sub vcl_recv {
   }
 
     # Begin dynamic section
-if (table.lookup(active_ab_tests, "Example") == "true") {
-  if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
-    set req.http.GOVUK-ABTest-Example = "A";
-  } else if (req.url ~ "[\?\&]ABTest-Example=A(&|$)") {
-    # Some users, such as remote testers, will be given a URL with a query string
-    # to place them into a specific bucket.
-    set req.http.GOVUK-ABTest-Example = "A";
-  } else if (req.url ~ "[\?\&]ABTest-Example=B(&|$)") {
-    # Some users, such as remote testers, will be given a URL with a query string
-    # to place them into a specific bucket.
-    set req.http.GOVUK-ABTest-Example = "B";
-  } else if (req.http.Cookie ~ "ABTest-Example") {
-    # Set the value of the header to whatever decision was previously made
-    set req.http.GOVUK-ABTest-Example = req.http.Cookie:ABTest-Example;
-  } else {
-    declare local var.denominator_Example INTEGER;
-    declare local var.denominator_Example_A INTEGER;
-    declare local var.nominator_Example_A INTEGER;
-    set var.nominator_Example_A = std.atoi(table.lookup(example_percentages, "A"));
-    set var.denominator_Example += var.nominator_Example_A;
-    declare local var.denominator_Example_B INTEGER;
-    declare local var.nominator_Example_B INTEGER;
-    set var.nominator_Example_B = std.atoi(table.lookup(example_percentages, "B"));
-    set var.denominator_Example += var.nominator_Example_B;
-    set var.denominator_Example_A = var.denominator_Example;
-    if (randombool(var.nominator_Example_A, var.denominator_Example_A)) {
-      set req.http.GOVUK-ABTest-Example = "A";
-    } else {
-      set req.http.GOVUK-ABTest-Example = "B";
+if (req.http.Cookie ~ "cookies_policy") {
+  if (req.http.Cookie:cookies_policy ~ "%22usage%22:true") {
+    if (table.lookup(active_ab_tests, "Example") == "true") {
+      if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
+        set req.http.GOVUK-ABTest-Example = "A";
+      } else if (req.url ~ "[\?\&]ABTest-Example=A(&|$)") {
+        # Some users, such as remote testers, will be given a URL with a query string
+        # to place them into a specific bucket.
+        set req.http.GOVUK-ABTest-Example = "A";
+      } else if (req.url ~ "[\?\&]ABTest-Example=B(&|$)") {
+        # Some users, such as remote testers, will be given a URL with a query string
+        # to place them into a specific bucket.
+        set req.http.GOVUK-ABTest-Example = "B";
+      } else if (req.http.Cookie ~ "ABTest-Example") {
+        # Set the value of the header to whatever decision was previously made
+        set req.http.GOVUK-ABTest-Example = req.http.Cookie:ABTest-Example;
+      } else {
+        declare local var.denominator_Example INTEGER;
+        declare local var.denominator_Example_A INTEGER;
+        declare local var.nominator_Example_A INTEGER;
+        set var.nominator_Example_A = std.atoi(table.lookup(example_percentages, "A"));
+        set var.denominator_Example += var.nominator_Example_A;
+        declare local var.denominator_Example_B INTEGER;
+        declare local var.nominator_Example_B INTEGER;
+        set var.nominator_Example_B = std.atoi(table.lookup(example_percentages, "B"));
+        set var.denominator_Example += var.nominator_Example_B;
+        set var.denominator_Example_A = var.denominator_Example;
+        if (randombool(var.nominator_Example_A, var.denominator_Example_A)) {
+          set req.http.GOVUK-ABTest-Example = "A";
+        } else {
+          set req.http.GOVUK-ABTest-Example = "B";
+        }
+      }
     }
   }
 }

--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -280,35 +280,39 @@ sub vcl_recv {
   }
 
     # Begin dynamic section
-if (table.lookup(active_ab_tests, "Example") == "true") {
-  if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
-    set req.http.GOVUK-ABTest-Example = "A";
-  } else if (req.url ~ "[\?\&]ABTest-Example=A(&|$)") {
-    # Some users, such as remote testers, will be given a URL with a query string
-    # to place them into a specific bucket.
-    set req.http.GOVUK-ABTest-Example = "A";
-  } else if (req.url ~ "[\?\&]ABTest-Example=B(&|$)") {
-    # Some users, such as remote testers, will be given a URL with a query string
-    # to place them into a specific bucket.
-    set req.http.GOVUK-ABTest-Example = "B";
-  } else if (req.http.Cookie ~ "ABTest-Example") {
-    # Set the value of the header to whatever decision was previously made
-    set req.http.GOVUK-ABTest-Example = req.http.Cookie:ABTest-Example;
-  } else {
-    declare local var.denominator_Example INTEGER;
-    declare local var.denominator_Example_A INTEGER;
-    declare local var.nominator_Example_A INTEGER;
-    set var.nominator_Example_A = std.atoi(table.lookup(example_percentages, "A"));
-    set var.denominator_Example += var.nominator_Example_A;
-    declare local var.denominator_Example_B INTEGER;
-    declare local var.nominator_Example_B INTEGER;
-    set var.nominator_Example_B = std.atoi(table.lookup(example_percentages, "B"));
-    set var.denominator_Example += var.nominator_Example_B;
-    set var.denominator_Example_A = var.denominator_Example;
-    if (randombool(var.nominator_Example_A, var.denominator_Example_A)) {
-      set req.http.GOVUK-ABTest-Example = "A";
-    } else {
-      set req.http.GOVUK-ABTest-Example = "B";
+if (req.http.Cookie ~ "cookies_policy") {
+  if (req.http.Cookie:cookies_policy ~ "%22usage%22:true") {
+    if (table.lookup(active_ab_tests, "Example") == "true") {
+      if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
+        set req.http.GOVUK-ABTest-Example = "A";
+      } else if (req.url ~ "[\?\&]ABTest-Example=A(&|$)") {
+        # Some users, such as remote testers, will be given a URL with a query string
+        # to place them into a specific bucket.
+        set req.http.GOVUK-ABTest-Example = "A";
+      } else if (req.url ~ "[\?\&]ABTest-Example=B(&|$)") {
+        # Some users, such as remote testers, will be given a URL with a query string
+        # to place them into a specific bucket.
+        set req.http.GOVUK-ABTest-Example = "B";
+      } else if (req.http.Cookie ~ "ABTest-Example") {
+        # Set the value of the header to whatever decision was previously made
+        set req.http.GOVUK-ABTest-Example = req.http.Cookie:ABTest-Example;
+      } else {
+        declare local var.denominator_Example INTEGER;
+        declare local var.denominator_Example_A INTEGER;
+        declare local var.nominator_Example_A INTEGER;
+        set var.nominator_Example_A = std.atoi(table.lookup(example_percentages, "A"));
+        set var.denominator_Example += var.nominator_Example_A;
+        declare local var.denominator_Example_B INTEGER;
+        declare local var.nominator_Example_B INTEGER;
+        set var.nominator_Example_B = std.atoi(table.lookup(example_percentages, "B"));
+        set var.denominator_Example += var.nominator_Example_B;
+        set var.denominator_Example_A = var.denominator_Example;
+        if (randombool(var.nominator_Example_A, var.denominator_Example_A)) {
+          set req.http.GOVUK-ABTest-Example = "A";
+        } else {
+          set req.http.GOVUK-ABTest-Example = "B";
+        }
+      }
     }
   }
 }

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -289,35 +289,39 @@ sub vcl_recv {
   }
 
     # Begin dynamic section
-if (table.lookup(active_ab_tests, "Example") == "true") {
-  if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
-    set req.http.GOVUK-ABTest-Example = "A";
-  } else if (req.url ~ "[\?\&]ABTest-Example=A(&|$)") {
-    # Some users, such as remote testers, will be given a URL with a query string
-    # to place them into a specific bucket.
-    set req.http.GOVUK-ABTest-Example = "A";
-  } else if (req.url ~ "[\?\&]ABTest-Example=B(&|$)") {
-    # Some users, such as remote testers, will be given a URL with a query string
-    # to place them into a specific bucket.
-    set req.http.GOVUK-ABTest-Example = "B";
-  } else if (req.http.Cookie ~ "ABTest-Example") {
-    # Set the value of the header to whatever decision was previously made
-    set req.http.GOVUK-ABTest-Example = req.http.Cookie:ABTest-Example;
-  } else {
-    declare local var.denominator_Example INTEGER;
-    declare local var.denominator_Example_A INTEGER;
-    declare local var.nominator_Example_A INTEGER;
-    set var.nominator_Example_A = std.atoi(table.lookup(example_percentages, "A"));
-    set var.denominator_Example += var.nominator_Example_A;
-    declare local var.denominator_Example_B INTEGER;
-    declare local var.nominator_Example_B INTEGER;
-    set var.nominator_Example_B = std.atoi(table.lookup(example_percentages, "B"));
-    set var.denominator_Example += var.nominator_Example_B;
-    set var.denominator_Example_A = var.denominator_Example;
-    if (randombool(var.nominator_Example_A, var.denominator_Example_A)) {
-      set req.http.GOVUK-ABTest-Example = "A";
-    } else {
-      set req.http.GOVUK-ABTest-Example = "B";
+if (req.http.Cookie ~ "cookies_policy") {
+  if (req.http.Cookie:cookies_policy ~ "%22usage%22:true") {
+    if (table.lookup(active_ab_tests, "Example") == "true") {
+      if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
+        set req.http.GOVUK-ABTest-Example = "A";
+      } else if (req.url ~ "[\?\&]ABTest-Example=A(&|$)") {
+        # Some users, such as remote testers, will be given a URL with a query string
+        # to place them into a specific bucket.
+        set req.http.GOVUK-ABTest-Example = "A";
+      } else if (req.url ~ "[\?\&]ABTest-Example=B(&|$)") {
+        # Some users, such as remote testers, will be given a URL with a query string
+        # to place them into a specific bucket.
+        set req.http.GOVUK-ABTest-Example = "B";
+      } else if (req.http.Cookie ~ "ABTest-Example") {
+        # Set the value of the header to whatever decision was previously made
+        set req.http.GOVUK-ABTest-Example = req.http.Cookie:ABTest-Example;
+      } else {
+        declare local var.denominator_Example INTEGER;
+        declare local var.denominator_Example_A INTEGER;
+        declare local var.nominator_Example_A INTEGER;
+        set var.nominator_Example_A = std.atoi(table.lookup(example_percentages, "A"));
+        set var.denominator_Example += var.nominator_Example_A;
+        declare local var.denominator_Example_B INTEGER;
+        declare local var.nominator_Example_B INTEGER;
+        set var.nominator_Example_B = std.atoi(table.lookup(example_percentages, "B"));
+        set var.denominator_Example += var.nominator_Example_B;
+        set var.denominator_Example_A = var.denominator_Example;
+        if (randombool(var.nominator_Example_A, var.denominator_Example_A)) {
+          set req.http.GOVUK-ABTest-Example = "A";
+        } else {
+          set req.http.GOVUK-ABTest-Example = "B";
+        }
+      }
     }
   }
 }

--- a/vcl_templates/_multivariate_tests.vcl.erb
+++ b/vcl_templates/_multivariate_tests.vcl.erb
@@ -4,54 +4,58 @@
 -%>
 # Begin dynamic section
 <% if ab_tests -%>
+if (req.http.Cookie ~ "cookies_policy") {
+  if (req.http.Cookie:cookies_policy ~ "%22usage%22:true") {
 <% ab_tests.each do |test_config| -%>
 <%# test_config is a hash like { "MyTest" => ['foo', 'bar', 'baz'] } -%>
 <% test_config.each do |test, variants| -%>
-if (table.lookup(active_ab_tests, "<%= test %>") == "true") {
-  if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
-    set req.http.GOVUK-ABTest-<%= test %> = "<%= variants.first %>";
+    if (table.lookup(active_ab_tests, "<%= test %>") == "true") {
+      if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
+        set req.http.GOVUK-ABTest-<%= test %> = "<%= variants.first %>";
 <% variants.each do |variant| -%>
-  } else if (req.url ~ "[\?\&]ABTest-<%= test %>=<%= variant %>(&|$)") {
-    # Some users, such as remote testers, will be given a URL with a query string
-    # to place them into a specific bucket.
-    set req.http.GOVUK-ABTest-<%= test %> = "<%= variant %>";
+      } else if (req.url ~ "[\?\&]ABTest-<%= test %>=<%= variant %>(&|$)") {
+        # Some users, such as remote testers, will be given a URL with a query string
+        # to place them into a specific bucket.
+        set req.http.GOVUK-ABTest-<%= test %> = "<%= variant %>";
 <% end -%>
-  } else if (req.http.Cookie ~ "ABTest-<%= test %>") {
-    # Set the value of the header to whatever decision was previously made
-    set req.http.GOVUK-ABTest-<%= test %> = req.http.Cookie:ABTest-<%= test %>;
-  } else {
-    declare local var.denominator_<%= test %> INTEGER;
+      } else if (req.http.Cookie ~ "ABTest-<%= test %>") {
+        # Set the value of the header to whatever decision was previously made
+        set req.http.GOVUK-ABTest-<%= test %> = req.http.Cookie:ABTest-<%= test %>;
+      } else {
+        declare local var.denominator_<%= test %> INTEGER;
 <% variants.each do |variant| -%>
-    declare local var.denominator_<%= test %>_<%= variant %> INTEGER;
-    declare local var.nominator_<%= test %>_<%= variant %> INTEGER;
-    set var.nominator_<%= test %>_<%= variant %> = std.atoi(table.lookup(<%= test.downcase %>_percentages, "<%= variant %>"));
-    set var.denominator_<%= test %> += var.nominator_<%= test %>_<%= variant %>;
+        declare local var.denominator_<%= test %>_<%= variant %> INTEGER;
+        declare local var.nominator_<%= test %>_<%= variant %> INTEGER;
+        set var.nominator_<%= test %>_<%= variant %> = std.atoi(table.lookup(<%= test.downcase %>_percentages, "<%= variant %>"));
+        set var.denominator_<%= test %> += var.nominator_<%= test %>_<%= variant %>;
 <% end -%>
 <% variants.each_with_index do |variant, idx| -%>
 <% if variant == variants.first -%>
-    set var.denominator_<%= test %>_<%= variant %> = var.denominator_<%= test %>;
+        set var.denominator_<%= test %>_<%= variant %> = var.denominator_<%= test %>;
 <% elsif variant != variants.last -%>
 <% previous_variant = variants[idx - 1] -%>
-    set var.denominator_<%= test %>_<%= variant %> = var.denominator_<%= test %>_<%= previous_variant %>;
-    set var.denominator_<%= test %>_<%= variant %> -= var.nominator_<%= test %>_<%= previous_variant %>;
+        set var.denominator_<%= test %>_<%= variant %> = var.denominator_<%= test %>_<%= previous_variant %>;
+        set var.denominator_<%= test %>_<%= variant %> -= var.nominator_<%= test %>_<%= previous_variant %>;
 <% end # if -%>
 <% end # variants.each_with_index -%>
 <% variants.each do |variant| -%>
 <% if variant == variants.first -%>
-    if (randombool(var.nominator_<%= test %>_<%= variant %>, var.denominator_<%= test %>_<%= variant %>)) {
-      set req.http.GOVUK-ABTest-<%= test %> = "<%= variant %>";
+        if (randombool(var.nominator_<%= test %>_<%= variant %>, var.denominator_<%= test %>_<%= variant %>)) {
+          set req.http.GOVUK-ABTest-<%= test %> = "<%= variant %>";
 <% elsif variant != variants.first && variant != variants.last -%>
-    } else if (randombool(var.nominator_<%= test %>_<%= variant %>, var.denominator_<%= test %>_<%= variant %>)) {
-      set req.http.GOVUK-ABTest-<%= test %> = "<%= variant %>";
+        } else if (randombool(var.nominator_<%= test %>_<%= variant %>, var.denominator_<%= test %>_<%= variant %>)) {
+          set req.http.GOVUK-ABTest-<%= test %> = "<%= variant %>";
 <% else -%>
-    } else {
-      set req.http.GOVUK-ABTest-<%= test %> = "<%= variant %>";
-    }
+        } else {
+          set req.http.GOVUK-ABTest-<%= test %> = "<%= variant %>";
+        }
 <% end -%>
 <% end # variants.each-%>
-  }
-}
+      }
+    }
 <% end # test_config.each -%>
 <% end # ab_tests.each -%>
+  }
+}
 <% end # if ab_tests -%>
 # End dynamic section

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -436,10 +436,14 @@ sub vcl_deliver {
 <% ab_tests.each do |test_config| -%>
 <% test_config.each do |test, _| -%>
 <% unless test == "Example" -%>
-  if (table.lookup(active_ab_tests, "<%= test %>") == "true") {
-    if (req.http.Cookie !~ "ABTest-<%= test %>" || req.url ~ "[\?\&]ABTest-<%= test %>" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
-      set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "<%= test %>"))));
-      add resp.http.Set-Cookie = "ABTest-<%= test %>=" req.http.GOVUK-ABTest-<%= test %> "; secure; expires=" var.expiry "; path=/";
+  if (req.http.Cookie ~ "cookies_policy") {
+    if (req.http.Cookie:cookies_policy ~ "%22usage%22:true") {
+      if (table.lookup(active_ab_tests, "<%= test %>") == "true") {
+        if (req.http.Cookie !~ "ABTest-<%= test %>" || req.url ~ "[\?\&]ABTest-<%= test %>" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
+          set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "<%= test %>"))));
+          add resp.http.Set-Cookie = "ABTest-<%= test %>=" req.http.GOVUK-ABTest-<%= test %> "; secure; expires=" var.expiry "; path=/";
+        }
+      }
     }
   }
 <% end # unless -%>


### PR DESCRIPTION
There are two parts to this:

1. Don't set the A/B header (which assigns them to a bucket)
2. Don't set the A/B cookie (which keeps them in the same bucket)

I think step 1 is strictly speaking unnecessary, as it doesn't involve cookies.  But we probably don't want people to get a random bucket on every page view, so it's good to do.

If someone consents, then on their next page load they'll be bucketed for each active A/B test.

---

[Trello card](https://trello.com/c/FOxkorss/1356-update-a-b-testing-to-work-with-new-cookies-policy)

