### PR TITLE
Add Learning To Rank Model AB Test

### DIFF
--- a/ab_tests/ab_tests.yaml
+++ b/ab_tests/ab_tests.yaml
@@ -4,3 +4,7 @@
 - Example:
   - A
   - B
+- LearningToRankModelABTest:
+  - unchanged
+  - hippo
+  - elephant

--- a/configs/dictionaries/ab_test_expiries.yaml
+++ b/configs/dictionaries/ab_test_expiries.yaml
@@ -6,3 +6,4 @@
 # ExampleTest: 86400
 ---
 Example: 86400
+LearningToRankModelABTest: 600 # 10 Minutes

--- a/configs/dictionaries/active_ab_tests.yaml
+++ b/configs/dictionaries/active_ab_tests.yaml
@@ -4,3 +4,4 @@
 # bucket allocations. See example_percentages.yaml for format.
 ---
 Example: true
+LearningToRankModelABTest: true

--- a/configs/dictionaries/learning_to_rank_model_ab_test_percentages.yaml
+++ b/configs/dictionaries/learning_to_rank_model_ab_test_percentages.yaml
@@ -1,0 +1,4 @@
+---
+unchanged: 40
+hippo: 30
+elephant: 30

--- a/spec/test-outputs/www-integration.out.vcl
+++ b/spec/test-outputs/www-integration.out.vcl
@@ -99,10 +99,6 @@ sub vcl_recv {
   set req.backend = F_origin;
   set req.http.Fastly-Backend-Name = "origin";
 
-  # Set header to use the search reranker. This is to be used
-  # as a rollback mechanism should we ever need to stop using the reranker.
-  set req.http.Govuk-Use-Search-Reranker = "true";
-
   # Set header to show recommended related links for Whitehall content. This is to be used
   # as a rollback mechanism should we ever need to stop showing these links.
   set req.http.Govuk-Use-Recommended-Related-Links = "true";
@@ -157,6 +153,50 @@ if (req.http.Cookie ~ "cookies_policy") {
           set req.http.GOVUK-ABTest-Example = "A";
         } else {
           set req.http.GOVUK-ABTest-Example = "B";
+        }
+      }
+    }
+    if (table.lookup(active_ab_tests, "LearningToRankModelABTest") == "true") {
+      if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
+        set req.http.GOVUK-ABTest-LearningToRankModelABTest = "unchanged";
+      } else if (req.url ~ "[\?\&]ABTest-LearningToRankModelABTest=unchanged(&|$)") {
+        # Some users, such as remote testers, will be given a URL with a query string
+        # to place them into a specific bucket.
+        set req.http.GOVUK-ABTest-LearningToRankModelABTest = "unchanged";
+      } else if (req.url ~ "[\?\&]ABTest-LearningToRankModelABTest=hippo(&|$)") {
+        # Some users, such as remote testers, will be given a URL with a query string
+        # to place them into a specific bucket.
+        set req.http.GOVUK-ABTest-LearningToRankModelABTest = "hippo";
+      } else if (req.url ~ "[\?\&]ABTest-LearningToRankModelABTest=elephant(&|$)") {
+        # Some users, such as remote testers, will be given a URL with a query string
+        # to place them into a specific bucket.
+        set req.http.GOVUK-ABTest-LearningToRankModelABTest = "elephant";
+      } else if (req.http.Cookie ~ "ABTest-LearningToRankModelABTest") {
+        # Set the value of the header to whatever decision was previously made
+        set req.http.GOVUK-ABTest-LearningToRankModelABTest = req.http.Cookie:ABTest-LearningToRankModelABTest;
+      } else {
+        declare local var.denominator_LearningToRankModelABTest INTEGER;
+        declare local var.denominator_LearningToRankModelABTest_unchanged INTEGER;
+        declare local var.nominator_LearningToRankModelABTest_unchanged INTEGER;
+        set var.nominator_LearningToRankModelABTest_unchanged = std.atoi(table.lookup(learningtorankmodelabtest_percentages, "unchanged"));
+        set var.denominator_LearningToRankModelABTest += var.nominator_LearningToRankModelABTest_unchanged;
+        declare local var.denominator_LearningToRankModelABTest_hippo INTEGER;
+        declare local var.nominator_LearningToRankModelABTest_hippo INTEGER;
+        set var.nominator_LearningToRankModelABTest_hippo = std.atoi(table.lookup(learningtorankmodelabtest_percentages, "hippo"));
+        set var.denominator_LearningToRankModelABTest += var.nominator_LearningToRankModelABTest_hippo;
+        declare local var.denominator_LearningToRankModelABTest_elephant INTEGER;
+        declare local var.nominator_LearningToRankModelABTest_elephant INTEGER;
+        set var.nominator_LearningToRankModelABTest_elephant = std.atoi(table.lookup(learningtorankmodelabtest_percentages, "elephant"));
+        set var.denominator_LearningToRankModelABTest += var.nominator_LearningToRankModelABTest_elephant;
+        set var.denominator_LearningToRankModelABTest_unchanged = var.denominator_LearningToRankModelABTest;
+        set var.denominator_LearningToRankModelABTest_hippo = var.denominator_LearningToRankModelABTest_unchanged;
+        set var.denominator_LearningToRankModelABTest_hippo -= var.nominator_LearningToRankModelABTest_unchanged;
+        if (randombool(var.nominator_LearningToRankModelABTest_unchanged, var.denominator_LearningToRankModelABTest_unchanged)) {
+          set req.http.GOVUK-ABTest-LearningToRankModelABTest = "unchanged";
+        } else if (randombool(var.nominator_LearningToRankModelABTest_hippo, var.denominator_LearningToRankModelABTest_hippo)) {
+          set req.http.GOVUK-ABTest-LearningToRankModelABTest = "hippo";
+        } else {
+          set req.http.GOVUK-ABTest-LearningToRankModelABTest = "elephant";
         }
       }
     }
@@ -265,6 +305,16 @@ sub vcl_deliver {
 
   # Begin dynamic section
   declare local var.expiry TIME;
+  if (req.http.Cookie ~ "cookies_policy") {
+    if (req.http.Cookie:cookies_policy ~ "%22usage%22:true") {
+      if (table.lookup(active_ab_tests, "LearningToRankModelABTest") == "true") {
+        if (req.http.Cookie !~ "ABTest-LearningToRankModelABTest" || req.url ~ "[\?\&]ABTest-LearningToRankModelABTest" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
+          set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "LearningToRankModelABTest"))));
+          add resp.http.Set-Cookie = "ABTest-LearningToRankModelABTest=" req.http.GOVUK-ABTest-LearningToRankModelABTest "; secure; expires=" var.expiry "; path=/";
+        }
+      }
+    }
+  }
   # End dynamic section
 
 #FASTLY deliver

--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -192,10 +192,6 @@ sub vcl_recv {
   set req.backend = F_origin;
   set req.http.Fastly-Backend-Name = "origin";
 
-  # Set header to use the search reranker. This is to be used
-  # as a rollback mechanism should we ever need to stop using the reranker.
-  set req.http.Govuk-Use-Search-Reranker = "true";
-
   # Set header to show recommended related links for Whitehall content. This is to be used
   # as a rollback mechanism should we ever need to stop showing these links.
   set req.http.Govuk-Use-Recommended-Related-Links = "true";
@@ -314,6 +310,50 @@ if (req.http.Cookie ~ "cookies_policy") {
         }
       }
     }
+    if (table.lookup(active_ab_tests, "LearningToRankModelABTest") == "true") {
+      if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
+        set req.http.GOVUK-ABTest-LearningToRankModelABTest = "unchanged";
+      } else if (req.url ~ "[\?\&]ABTest-LearningToRankModelABTest=unchanged(&|$)") {
+        # Some users, such as remote testers, will be given a URL with a query string
+        # to place them into a specific bucket.
+        set req.http.GOVUK-ABTest-LearningToRankModelABTest = "unchanged";
+      } else if (req.url ~ "[\?\&]ABTest-LearningToRankModelABTest=hippo(&|$)") {
+        # Some users, such as remote testers, will be given a URL with a query string
+        # to place them into a specific bucket.
+        set req.http.GOVUK-ABTest-LearningToRankModelABTest = "hippo";
+      } else if (req.url ~ "[\?\&]ABTest-LearningToRankModelABTest=elephant(&|$)") {
+        # Some users, such as remote testers, will be given a URL with a query string
+        # to place them into a specific bucket.
+        set req.http.GOVUK-ABTest-LearningToRankModelABTest = "elephant";
+      } else if (req.http.Cookie ~ "ABTest-LearningToRankModelABTest") {
+        # Set the value of the header to whatever decision was previously made
+        set req.http.GOVUK-ABTest-LearningToRankModelABTest = req.http.Cookie:ABTest-LearningToRankModelABTest;
+      } else {
+        declare local var.denominator_LearningToRankModelABTest INTEGER;
+        declare local var.denominator_LearningToRankModelABTest_unchanged INTEGER;
+        declare local var.nominator_LearningToRankModelABTest_unchanged INTEGER;
+        set var.nominator_LearningToRankModelABTest_unchanged = std.atoi(table.lookup(learningtorankmodelabtest_percentages, "unchanged"));
+        set var.denominator_LearningToRankModelABTest += var.nominator_LearningToRankModelABTest_unchanged;
+        declare local var.denominator_LearningToRankModelABTest_hippo INTEGER;
+        declare local var.nominator_LearningToRankModelABTest_hippo INTEGER;
+        set var.nominator_LearningToRankModelABTest_hippo = std.atoi(table.lookup(learningtorankmodelabtest_percentages, "hippo"));
+        set var.denominator_LearningToRankModelABTest += var.nominator_LearningToRankModelABTest_hippo;
+        declare local var.denominator_LearningToRankModelABTest_elephant INTEGER;
+        declare local var.nominator_LearningToRankModelABTest_elephant INTEGER;
+        set var.nominator_LearningToRankModelABTest_elephant = std.atoi(table.lookup(learningtorankmodelabtest_percentages, "elephant"));
+        set var.denominator_LearningToRankModelABTest += var.nominator_LearningToRankModelABTest_elephant;
+        set var.denominator_LearningToRankModelABTest_unchanged = var.denominator_LearningToRankModelABTest;
+        set var.denominator_LearningToRankModelABTest_hippo = var.denominator_LearningToRankModelABTest_unchanged;
+        set var.denominator_LearningToRankModelABTest_hippo -= var.nominator_LearningToRankModelABTest_unchanged;
+        if (randombool(var.nominator_LearningToRankModelABTest_unchanged, var.denominator_LearningToRankModelABTest_unchanged)) {
+          set req.http.GOVUK-ABTest-LearningToRankModelABTest = "unchanged";
+        } else if (randombool(var.nominator_LearningToRankModelABTest_hippo, var.denominator_LearningToRankModelABTest_hippo)) {
+          set req.http.GOVUK-ABTest-LearningToRankModelABTest = "hippo";
+        } else {
+          set req.http.GOVUK-ABTest-LearningToRankModelABTest = "elephant";
+        }
+      }
+    }
   }
 }
 # End dynamic section
@@ -419,6 +459,16 @@ sub vcl_deliver {
 
   # Begin dynamic section
   declare local var.expiry TIME;
+  if (req.http.Cookie ~ "cookies_policy") {
+    if (req.http.Cookie:cookies_policy ~ "%22usage%22:true") {
+      if (table.lookup(active_ab_tests, "LearningToRankModelABTest") == "true") {
+        if (req.http.Cookie !~ "ABTest-LearningToRankModelABTest" || req.url ~ "[\?\&]ABTest-LearningToRankModelABTest" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
+          set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "LearningToRankModelABTest"))));
+          add resp.http.Set-Cookie = "ABTest-LearningToRankModelABTest=" req.http.GOVUK-ABTest-LearningToRankModelABTest "; secure; expires=" var.expiry "; path=/";
+        }
+      }
+    }
+  }
   # End dynamic section
 
 #FASTLY deliver

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -201,10 +201,6 @@ sub vcl_recv {
   set req.backend = F_origin;
   set req.http.Fastly-Backend-Name = "origin";
 
-  # Set header to use the search reranker. This is to be used
-  # as a rollback mechanism should we ever need to stop using the reranker.
-  set req.http.Govuk-Use-Search-Reranker = "true";
-
   # Set header to show recommended related links for Whitehall content. This is to be used
   # as a rollback mechanism should we ever need to stop showing these links.
   set req.http.Govuk-Use-Recommended-Related-Links = "true";
@@ -323,6 +319,50 @@ if (req.http.Cookie ~ "cookies_policy") {
         }
       }
     }
+    if (table.lookup(active_ab_tests, "LearningToRankModelABTest") == "true") {
+      if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
+        set req.http.GOVUK-ABTest-LearningToRankModelABTest = "unchanged";
+      } else if (req.url ~ "[\?\&]ABTest-LearningToRankModelABTest=unchanged(&|$)") {
+        # Some users, such as remote testers, will be given a URL with a query string
+        # to place them into a specific bucket.
+        set req.http.GOVUK-ABTest-LearningToRankModelABTest = "unchanged";
+      } else if (req.url ~ "[\?\&]ABTest-LearningToRankModelABTest=hippo(&|$)") {
+        # Some users, such as remote testers, will be given a URL with a query string
+        # to place them into a specific bucket.
+        set req.http.GOVUK-ABTest-LearningToRankModelABTest = "hippo";
+      } else if (req.url ~ "[\?\&]ABTest-LearningToRankModelABTest=elephant(&|$)") {
+        # Some users, such as remote testers, will be given a URL with a query string
+        # to place them into a specific bucket.
+        set req.http.GOVUK-ABTest-LearningToRankModelABTest = "elephant";
+      } else if (req.http.Cookie ~ "ABTest-LearningToRankModelABTest") {
+        # Set the value of the header to whatever decision was previously made
+        set req.http.GOVUK-ABTest-LearningToRankModelABTest = req.http.Cookie:ABTest-LearningToRankModelABTest;
+      } else {
+        declare local var.denominator_LearningToRankModelABTest INTEGER;
+        declare local var.denominator_LearningToRankModelABTest_unchanged INTEGER;
+        declare local var.nominator_LearningToRankModelABTest_unchanged INTEGER;
+        set var.nominator_LearningToRankModelABTest_unchanged = std.atoi(table.lookup(learningtorankmodelabtest_percentages, "unchanged"));
+        set var.denominator_LearningToRankModelABTest += var.nominator_LearningToRankModelABTest_unchanged;
+        declare local var.denominator_LearningToRankModelABTest_hippo INTEGER;
+        declare local var.nominator_LearningToRankModelABTest_hippo INTEGER;
+        set var.nominator_LearningToRankModelABTest_hippo = std.atoi(table.lookup(learningtorankmodelabtest_percentages, "hippo"));
+        set var.denominator_LearningToRankModelABTest += var.nominator_LearningToRankModelABTest_hippo;
+        declare local var.denominator_LearningToRankModelABTest_elephant INTEGER;
+        declare local var.nominator_LearningToRankModelABTest_elephant INTEGER;
+        set var.nominator_LearningToRankModelABTest_elephant = std.atoi(table.lookup(learningtorankmodelabtest_percentages, "elephant"));
+        set var.denominator_LearningToRankModelABTest += var.nominator_LearningToRankModelABTest_elephant;
+        set var.denominator_LearningToRankModelABTest_unchanged = var.denominator_LearningToRankModelABTest;
+        set var.denominator_LearningToRankModelABTest_hippo = var.denominator_LearningToRankModelABTest_unchanged;
+        set var.denominator_LearningToRankModelABTest_hippo -= var.nominator_LearningToRankModelABTest_unchanged;
+        if (randombool(var.nominator_LearningToRankModelABTest_unchanged, var.denominator_LearningToRankModelABTest_unchanged)) {
+          set req.http.GOVUK-ABTest-LearningToRankModelABTest = "unchanged";
+        } else if (randombool(var.nominator_LearningToRankModelABTest_hippo, var.denominator_LearningToRankModelABTest_hippo)) {
+          set req.http.GOVUK-ABTest-LearningToRankModelABTest = "hippo";
+        } else {
+          set req.http.GOVUK-ABTest-LearningToRankModelABTest = "elephant";
+        }
+      }
+    }
   }
 }
 # End dynamic section
@@ -428,6 +468,16 @@ sub vcl_deliver {
 
   # Begin dynamic section
   declare local var.expiry TIME;
+  if (req.http.Cookie ~ "cookies_policy") {
+    if (req.http.Cookie:cookies_policy ~ "%22usage%22:true") {
+      if (table.lookup(active_ab_tests, "LearningToRankModelABTest") == "true") {
+        if (req.http.Cookie !~ "ABTest-LearningToRankModelABTest" || req.url ~ "[\?\&]ABTest-LearningToRankModelABTest" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
+          set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "LearningToRankModelABTest"))));
+          add resp.http.Set-Cookie = "ABTest-LearningToRankModelABTest=" req.http.GOVUK-ABTest-LearningToRankModelABTest "; secure; expires=" var.expiry "; path=/";
+        }
+      }
+    }
+  }
   # End dynamic section
 
 #FASTLY deliver

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -237,10 +237,6 @@ sub vcl_recv {
   set req.backend = F_origin;
   set req.http.Fastly-Backend-Name = "origin";
 
-  # Set header to use the search reranker. This is to be used
-  # as a rollback mechanism should we ever need to stop using the reranker.
-  set req.http.Govuk-Use-Search-Reranker = "true";
-
   # Set header to show recommended related links for Whitehall content. This is to be used
   # as a rollback mechanism should we ever need to stop showing these links.
   set req.http.Govuk-Use-Recommended-Related-Links = "true";


### PR DESCRIPTION
This replaces the finder-frontend reranker feature flag with an AB test for comparing reranker models.

Should be merged and deployed after search-api and finder-frontend.

https://trello.com/c/1EjO05Dj/1333