### PR TITLE
[spike] Adopt varnishtest for testing VCL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 coverage
+_.ok

--- a/spec/fixtures/_multivariate_tests.vcl.erb.out
+++ b/spec/fixtures/_multivariate_tests.vcl.erb.out
@@ -1,7 +1,8 @@
 # Begin dynamic section
 if (req.http.Cookie ~ "cookies_policy") {
-  if (req.http.Cookie:cookies_policy ~ "%22usage%22:true") {
-    if (table.lookup(active_ab_tests, "MyTest") == "true") {
+  if (req.http.Cookie ~ "cookies_policy=%22usage%22:true") {
+
+    # if (table.lookup(active_ab_tests, "MyTest") == "true") {
       if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
         set req.http.GOVUK-ABTest-MyTest = "foo";
       } else if (req.url ~ "[\?\&]ABTest-MyTest=foo(&|$)") {
@@ -14,26 +15,33 @@ if (req.http.Cookie ~ "cookies_policy") {
         set req.http.GOVUK-ABTest-MyTest = "bar";
       } else if (req.http.Cookie ~ "ABTest-MyTest") {
         # Set the value of the header to whatever decision was previously made
-        set req.http.GOVUK-ABTest-MyTest = req.http.Cookie:ABTest-MyTest;
-      } else {
-        declare local var.denominator_MyTest INTEGER;
-        declare local var.denominator_MyTest_foo INTEGER;
-        declare local var.nominator_MyTest_foo INTEGER;
-        set var.nominator_MyTest_foo = std.atoi(table.lookup(mytest_percentages, "foo"));
-        set var.denominator_MyTest += var.nominator_MyTest_foo;
-        declare local var.denominator_MyTest_bar INTEGER;
-        declare local var.nominator_MyTest_bar INTEGER;
-        set var.nominator_MyTest_bar = std.atoi(table.lookup(mytest_percentages, "bar"));
-        set var.denominator_MyTest += var.nominator_MyTest_bar;
-        set var.denominator_MyTest_foo = var.denominator_MyTest;
-        if (randombool(var.nominator_MyTest_foo, var.denominator_MyTest_foo)) {
+        # and is still a known variant
+        if (req.http.Cookie ~ "ABTest-MyTest=foo") {
           set req.http.GOVUK-ABTest-MyTest = "foo";
-        } else {
+        }
+        if (req.http.Cookie ~ "ABTest-MyTest=bar") {
           set req.http.GOVUK-ABTest-MyTest = "bar";
         }
+      } else {
+        # declare local var.denominator_MyTest INTEGER;
+        # declare local var.denominator_MyTest_foo INTEGER;
+        # declare local var.nominator_MyTest_foo INTEGER;
+        # set var.nominator_MyTest_foo = std.atoi(table.lookup(mytest_percentages, "foo"));
+        # set var.denominator_MyTest += var.nominator_MyTest_foo;
+        # declare local var.denominator_MyTest_bar INTEGER;
+        # declare local var.nominator_MyTest_bar INTEGER;
+        # set var.nominator_MyTest_bar = std.atoi(table.lookup(mytest_percentages, "bar"));
+        # set var.denominator_MyTest += var.nominator_MyTest_bar;
+        # set var.denominator_MyTest_foo = var.denominator_MyTest;
+        # if (randombool(var.nominator_MyTest_foo, var.denominator_MyTest_foo)) {
+        #   set req.http.GOVUK-ABTest-MyTest = "foo";
+        # } else {
+        #   set req.http.GOVUK-ABTest-MyTest = "bar";
+        # }
       }
-    }
-    if (table.lookup(active_ab_tests, "YourTest") == "true") {
+    # }
+
+    # if (table.lookup(active_ab_tests, "YourTest") == "true") {
       if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
         set req.http.GOVUK-ABTest-YourTest = "variant1";
       } else if (req.url ~ "[\?\&]ABTest-YourTest=variant1(&|$)") {
@@ -54,41 +62,53 @@ if (req.http.Cookie ~ "cookies_policy") {
         set req.http.GOVUK-ABTest-YourTest = "variant4";
       } else if (req.http.Cookie ~ "ABTest-YourTest") {
         # Set the value of the header to whatever decision was previously made
-        set req.http.GOVUK-ABTest-YourTest = req.http.Cookie:ABTest-YourTest;
-      } else {
-        declare local var.denominator_YourTest INTEGER;
-        declare local var.denominator_YourTest_variant1 INTEGER;
-        declare local var.nominator_YourTest_variant1 INTEGER;
-        set var.nominator_YourTest_variant1 = std.atoi(table.lookup(yourtest_percentages, "variant1"));
-        set var.denominator_YourTest += var.nominator_YourTest_variant1;
-        declare local var.denominator_YourTest_variant2 INTEGER;
-        declare local var.nominator_YourTest_variant2 INTEGER;
-        set var.nominator_YourTest_variant2 = std.atoi(table.lookup(yourtest_percentages, "variant2"));
-        set var.denominator_YourTest += var.nominator_YourTest_variant2;
-        declare local var.denominator_YourTest_variant3 INTEGER;
-        declare local var.nominator_YourTest_variant3 INTEGER;
-        set var.nominator_YourTest_variant3 = std.atoi(table.lookup(yourtest_percentages, "variant3"));
-        set var.denominator_YourTest += var.nominator_YourTest_variant3;
-        declare local var.denominator_YourTest_variant4 INTEGER;
-        declare local var.nominator_YourTest_variant4 INTEGER;
-        set var.nominator_YourTest_variant4 = std.atoi(table.lookup(yourtest_percentages, "variant4"));
-        set var.denominator_YourTest += var.nominator_YourTest_variant4;
-        set var.denominator_YourTest_variant1 = var.denominator_YourTest;
-        set var.denominator_YourTest_variant2 = var.denominator_YourTest_variant1;
-        set var.denominator_YourTest_variant2 -= var.nominator_YourTest_variant1;
-        set var.denominator_YourTest_variant3 = var.denominator_YourTest_variant2;
-        set var.denominator_YourTest_variant3 -= var.nominator_YourTest_variant2;
-        if (randombool(var.nominator_YourTest_variant1, var.denominator_YourTest_variant1)) {
+        # and is still a known variant
+        if (req.http.Cookie ~ "ABTest-YourTest=variant1") {
           set req.http.GOVUK-ABTest-YourTest = "variant1";
-        } else if (randombool(var.nominator_YourTest_variant2, var.denominator_YourTest_variant2)) {
+        }
+        if (req.http.Cookie ~ "ABTest-YourTest=variant2") {
           set req.http.GOVUK-ABTest-YourTest = "variant2";
-        } else if (randombool(var.nominator_YourTest_variant3, var.denominator_YourTest_variant3)) {
+        }
+        if (req.http.Cookie ~ "ABTest-YourTest=variant3") {
           set req.http.GOVUK-ABTest-YourTest = "variant3";
-        } else {
+        }
+        if (req.http.Cookie ~ "ABTest-YourTest=variant4") {
           set req.http.GOVUK-ABTest-YourTest = "variant4";
         }
+      } else {
+        # declare local var.denominator_YourTest INTEGER;
+        # declare local var.denominator_YourTest_variant1 INTEGER;
+        # declare local var.nominator_YourTest_variant1 INTEGER;
+        # set var.nominator_YourTest_variant1 = std.atoi(table.lookup(yourtest_percentages, "variant1"));
+        # set var.denominator_YourTest += var.nominator_YourTest_variant1;
+        # declare local var.denominator_YourTest_variant2 INTEGER;
+        # declare local var.nominator_YourTest_variant2 INTEGER;
+        # set var.nominator_YourTest_variant2 = std.atoi(table.lookup(yourtest_percentages, "variant2"));
+        # set var.denominator_YourTest += var.nominator_YourTest_variant2;
+        # declare local var.denominator_YourTest_variant3 INTEGER;
+        # declare local var.nominator_YourTest_variant3 INTEGER;
+        # set var.nominator_YourTest_variant3 = std.atoi(table.lookup(yourtest_percentages, "variant3"));
+        # set var.denominator_YourTest += var.nominator_YourTest_variant3;
+        # declare local var.denominator_YourTest_variant4 INTEGER;
+        # declare local var.nominator_YourTest_variant4 INTEGER;
+        # set var.nominator_YourTest_variant4 = std.atoi(table.lookup(yourtest_percentages, "variant4"));
+        # set var.denominator_YourTest += var.nominator_YourTest_variant4;
+        # set var.denominator_YourTest_variant1 = var.denominator_YourTest;
+        # set var.denominator_YourTest_variant2 = var.denominator_YourTest_variant1;
+        # set var.denominator_YourTest_variant2 -= var.nominator_YourTest_variant1;
+        # set var.denominator_YourTest_variant3 = var.denominator_YourTest_variant2;
+        # set var.denominator_YourTest_variant3 -= var.nominator_YourTest_variant2;
+        # if (randombool(var.nominator_YourTest_variant1, var.denominator_YourTest_variant1)) {
+        #   set req.http.GOVUK-ABTest-YourTest = "variant1";
+        # } else if (randombool(var.nominator_YourTest_variant2, var.denominator_YourTest_variant2)) {
+        #   set req.http.GOVUK-ABTest-YourTest = "variant2";
+        # } else if (randombool(var.nominator_YourTest_variant3, var.denominator_YourTest_variant3)) {
+        #   set req.http.GOVUK-ABTest-YourTest = "variant3";
+        # } else {
+        #   set req.http.GOVUK-ABTest-YourTest = "variant4";
+        # }
       }
-    }
+    # }
   }
 }
 # End dynamic section

--- a/spec/test-outputs/apt-integration.out.vcl
+++ b/spec/test-outputs/apt-integration.out.vcl
@@ -3,7 +3,7 @@ backend F_apt {
     .connect_timeout = 1s;
     .dynamic = true;
     .port = "443";
-    .host = "foo";
+    .host = "127.0.0.1";
     .first_byte_timeout = 15s;
     .max_connections = 200;
     .between_bytes_timeout = 10s;
@@ -12,7 +12,7 @@ backend F_apt {
     .probe = {
         .request =
           "HEAD / HTTP/1.1"
-          "Host: foo"
+          "Host: 127.0.0.1"
           "Connection: close";
         .window = 5;
         .threshold = 1;

--- a/spec/test-outputs/apt-production.out.vcl
+++ b/spec/test-outputs/apt-production.out.vcl
@@ -3,7 +3,7 @@ backend F_apt {
     .connect_timeout = 1s;
     .dynamic = true;
     .port = "443";
-    .host = "foo";
+    .host = "127.0.0.1";
     .first_byte_timeout = 15s;
     .max_connections = 200;
     .between_bytes_timeout = 10s;
@@ -12,7 +12,7 @@ backend F_apt {
     .probe = {
         .request =
           "HEAD / HTTP/1.1"
-          "Host: foo"
+          "Host: 127.0.0.1"
           "Connection: close";
         .window = 5;
         .threshold = 1;

--- a/spec/test-outputs/apt-staging.out.vcl
+++ b/spec/test-outputs/apt-staging.out.vcl
@@ -3,7 +3,7 @@ backend F_apt {
     .connect_timeout = 1s;
     .dynamic = true;
     .port = "443";
-    .host = "foo";
+    .host = "127.0.0.1";
     .first_byte_timeout = 15s;
     .max_connections = 200;
     .between_bytes_timeout = 10s;
@@ -12,7 +12,7 @@ backend F_apt {
     .probe = {
         .request =
           "HEAD / HTTP/1.1"
-          "Host: foo"
+          "Host: 127.0.0.1"
           "Connection: close";
         .window = 5;
         .threshold = 1;

--- a/spec/test-outputs/assets-integration.out.vcl
+++ b/spec/test-outputs/assets-integration.out.vcl
@@ -2,7 +2,7 @@ backend F_awsorigin {
     .connect_timeout = 5s;
     .dynamic = true;
     .port = "443";
-    .host = "foo";
+    .host = "127.0.0.1";
     .first_byte_timeout = 15s;
     .max_connections = 200;
     .between_bytes_timeout = 10s;
@@ -11,13 +11,13 @@ backend F_awsorigin {
     .ssl = true;
     .ssl_check_cert = always;
     .min_tls_version = "1.2";
-    .ssl_cert_hostname = "foo";
-    .ssl_sni_hostname = "foo";
+    .ssl_cert_hostname = "127.0.0.1";
+    .ssl_sni_hostname = "127.0.0.1";
 
     .probe = {
         .request =
             "HEAD /__canary__ HTTP/1.1"
-            "Host: foo"
+            "Host: 127.0.0.1"
             "User-Agent: Fastly healthcheck (git version: )"
 
             "Connection: close";
@@ -79,7 +79,7 @@ sub vcl_recv {
   # Default backend.
   set req.backend = F_awsorigin;
   set req.http.Fastly-Backend-Name = "awsorigin";
-  set req.http.host = "foo";
+  set req.http.host = "127.0.0.1";
 
   
 

--- a/spec/test-outputs/assets-production.out.vcl
+++ b/spec/test-outputs/assets-production.out.vcl
@@ -2,7 +2,7 @@ backend F_awsorigin {
     .connect_timeout = 5s;
     .dynamic = true;
     .port = "443";
-    .host = "foo";
+    .host = "127.0.0.1";
     .first_byte_timeout = 15s;
     .max_connections = 200;
     .between_bytes_timeout = 10s;
@@ -11,13 +11,13 @@ backend F_awsorigin {
     .ssl = true;
     .ssl_check_cert = always;
     .min_tls_version = "1.2";
-    .ssl_cert_hostname = "foo";
-    .ssl_sni_hostname = "foo";
+    .ssl_cert_hostname = "127.0.0.1";
+    .ssl_sni_hostname = "127.0.0.1";
 
     .probe = {
         .request =
             "HEAD /__canary__ HTTP/1.1"
-            "Host: foo"
+            "Host: 127.0.0.1"
             "User-Agent: Fastly healthcheck (git version: )"
 
             "Connection: close";
@@ -36,7 +36,7 @@ backend F_mirrorS3 {
     .connect_timeout = 1s;
     .dynamic = true;
     .port = "443";
-    .host = "bar";
+    .host = "127.0.0.1";
     .first_byte_timeout = 15s;
     .max_connections = 200;
     .between_bytes_timeout = 10s;
@@ -45,13 +45,13 @@ backend F_mirrorS3 {
     .ssl = true;
     .ssl_check_cert = always;
     .min_tls_version = "1.2";
-    .ssl_cert_hostname = "bar";
-    .ssl_sni_hostname = "bar";
+    .ssl_cert_hostname = "127.0.0.1";
+    .ssl_sni_hostname = "127.0.0.1";
 
     .probe = {
         .request =
             "HEAD / HTTP/1.1"
-            "Host: bar"
+            "Host: 127.0.0.1"
             "User-Agent: Fastly healthcheck (git version: )"
             "Connection: close";
         .threshold = 1;
@@ -180,7 +180,7 @@ sub vcl_recv {
   # Default backend.
   set req.backend = F_awsorigin;
   set req.http.Fastly-Backend-Name = "awsorigin";
-  set req.http.host = "foo";
+  set req.http.host = "127.0.0.1";
 
   
 
@@ -204,7 +204,7 @@ sub vcl_recv {
   # Failover to primary s3 mirror.
   if (req.restarts == 1) {
       set req.backend = F_mirrorS3;
-      set req.http.host = "bar";
+      set req.http.host = "127.0.0.1";
       set req.http.Fastly-Backend-Name = "mirrorS3";
 
       # Add bucket directory prefix to all the requests

--- a/spec/test-outputs/assets-staging.out.vcl
+++ b/spec/test-outputs/assets-staging.out.vcl
@@ -2,7 +2,7 @@ backend F_awsorigin {
     .connect_timeout = 5s;
     .dynamic = true;
     .port = "443";
-    .host = "foo";
+    .host = "127.0.0.1";
     .first_byte_timeout = 15s;
     .max_connections = 200;
     .between_bytes_timeout = 10s;
@@ -11,13 +11,13 @@ backend F_awsorigin {
     .ssl = true;
     .ssl_check_cert = always;
     .min_tls_version = "1.2";
-    .ssl_cert_hostname = "foo";
-    .ssl_sni_hostname = "foo";
+    .ssl_cert_hostname = "127.0.0.1";
+    .ssl_sni_hostname = "127.0.0.1";
 
     .probe = {
         .request =
             "HEAD /__canary__ HTTP/1.1"
-            "Host: foo"
+            "Host: 127.0.0.1"
             "User-Agent: Fastly healthcheck (git version: )"
 
             "Connection: close";
@@ -36,7 +36,7 @@ backend F_mirrorS3 {
     .connect_timeout = 1s;
     .dynamic = true;
     .port = "443";
-    .host = "bar";
+    .host = "127.0.0.1";
     .first_byte_timeout = 15s;
     .max_connections = 200;
     .between_bytes_timeout = 10s;
@@ -45,13 +45,13 @@ backend F_mirrorS3 {
     .ssl = true;
     .ssl_check_cert = always;
     .min_tls_version = "1.2";
-    .ssl_cert_hostname = "bar";
-    .ssl_sni_hostname = "bar";
+    .ssl_cert_hostname = "127.0.0.1";
+    .ssl_sni_hostname = "127.0.0.1";
 
     .probe = {
         .request =
             "HEAD / HTTP/1.1"
-            "Host: bar"
+            "Host: 127.0.0.1"
             "User-Agent: Fastly healthcheck (git version: )"
             "Connection: close";
         .threshold = 1;
@@ -180,7 +180,7 @@ sub vcl_recv {
   # Default backend.
   set req.backend = F_awsorigin;
   set req.http.Fastly-Backend-Name = "awsorigin";
-  set req.http.host = "foo";
+  set req.http.host = "127.0.0.1";
 
   
 
@@ -204,7 +204,7 @@ sub vcl_recv {
   # Failover to primary s3 mirror.
   if (req.restarts == 1) {
       set req.backend = F_mirrorS3;
-      set req.http.host = "bar";
+      set req.http.host = "127.0.0.1";
       set req.http.Fastly-Backend-Name = "mirrorS3";
 
       # Add bucket directory prefix to all the requests

--- a/spec/test-outputs/mirror-integration.out.vcl
+++ b/spec/test-outputs/mirror-integration.out.vcl
@@ -2,7 +2,7 @@ backend F_origin {
     .connect_timeout = 5s;
     .dynamic = true;
     .port = "443";
-    .host = "foo";
+    .host = "127.0.0.1";
     .first_byte_timeout = 15s;
     .max_connections = 200;
     .between_bytes_timeout = 10s;
@@ -11,13 +11,13 @@ backend F_origin {
     .ssl = true;
     .ssl_check_cert = always;
     .min_tls_version = "1.2";
-    .ssl_cert_hostname = "foo";
-    .ssl_sni_hostname = "foo";
+    .ssl_cert_hostname = "127.0.0.1";
+    .ssl_sni_hostname = "127.0.0.1";
 
     .probe = {
         .request =
             "HEAD / HTTP/1.1"
-            "Host: foo"
+            "Host: 127.0.0.1"
             "User-Agent: Fastly healthcheck (git version: )"
             "Connection: close";
         .threshold = 1;

--- a/spec/test-outputs/mirror-production.out.vcl
+++ b/spec/test-outputs/mirror-production.out.vcl
@@ -2,7 +2,7 @@ backend F_origin {
     .connect_timeout = 5s;
     .dynamic = true;
     .port = "443";
-    .host = "foo";
+    .host = "127.0.0.1";
     .first_byte_timeout = 15s;
     .max_connections = 200;
     .between_bytes_timeout = 10s;
@@ -11,13 +11,13 @@ backend F_origin {
     .ssl = true;
     .ssl_check_cert = always;
     .min_tls_version = "1.2";
-    .ssl_cert_hostname = "foo";
-    .ssl_sni_hostname = "foo";
+    .ssl_cert_hostname = "127.0.0.1";
+    .ssl_sni_hostname = "127.0.0.1";
 
     .probe = {
         .request =
             "HEAD / HTTP/1.1"
-            "Host: foo"
+            "Host: 127.0.0.1"
             "User-Agent: Fastly healthcheck (git version: )"
             "Connection: close";
         .threshold = 1;
@@ -35,7 +35,7 @@ backend F_mirrorS3 {
     .connect_timeout = 1s;
     .dynamic = true;
     .port = "443";
-    .host = "bar";
+    .host = "127.0.0.1";
     .first_byte_timeout = 15s;
     .max_connections = 200;
     .between_bytes_timeout = 10s;
@@ -44,13 +44,13 @@ backend F_mirrorS3 {
     .ssl = true;
     .ssl_check_cert = always;
     .min_tls_version = "1.2";
-    .ssl_cert_hostname = "bar";
-    .ssl_sni_hostname = "bar";
+    .ssl_cert_hostname = "127.0.0.1";
+    .ssl_sni_hostname = "127.0.0.1";
 
     .probe = {
         .request =
             "HEAD / HTTP/1.1"
-            "Host: bar"
+            "Host: 127.0.0.1"
             "User-Agent: Fastly healthcheck (git version: )"
             "Connection: close";
         .threshold = 1;
@@ -229,7 +229,7 @@ sub vcl_recv {
   # Failover to primary s3 mirror.
   if (req.restarts == 1) {
       set req.backend = F_mirrorS3;
-      set req.http.host = "bar";
+      set req.http.host = "127.0.0.1";
       set req.http.Fastly-Backend-Name = "mirrorS3";
 
       # Add bucket directory prefix to all the requests

--- a/spec/test-outputs/mirror-staging.out.vcl
+++ b/spec/test-outputs/mirror-staging.out.vcl
@@ -2,7 +2,7 @@ backend F_origin {
     .connect_timeout = 5s;
     .dynamic = true;
     .port = "443";
-    .host = "foo";
+    .host = "127.0.0.1";
     .first_byte_timeout = 15s;
     .max_connections = 200;
     .between_bytes_timeout = 10s;
@@ -11,13 +11,13 @@ backend F_origin {
     .ssl = true;
     .ssl_check_cert = always;
     .min_tls_version = "1.2";
-    .ssl_cert_hostname = "foo";
-    .ssl_sni_hostname = "foo";
+    .ssl_cert_hostname = "127.0.0.1";
+    .ssl_sni_hostname = "127.0.0.1";
 
     .probe = {
         .request =
             "HEAD / HTTP/1.1"
-            "Host: foo"
+            "Host: 127.0.0.1"
             "User-Agent: Fastly healthcheck (git version: )"
             "Connection: close";
         .threshold = 1;
@@ -35,7 +35,7 @@ backend F_mirrorS3 {
     .connect_timeout = 1s;
     .dynamic = true;
     .port = "443";
-    .host = "bar";
+    .host = "127.0.0.1";
     .first_byte_timeout = 15s;
     .max_connections = 200;
     .between_bytes_timeout = 10s;
@@ -44,13 +44,13 @@ backend F_mirrorS3 {
     .ssl = true;
     .ssl_check_cert = always;
     .min_tls_version = "1.2";
-    .ssl_cert_hostname = "bar";
-    .ssl_sni_hostname = "bar";
+    .ssl_cert_hostname = "127.0.0.1";
+    .ssl_sni_hostname = "127.0.0.1";
 
     .probe = {
         .request =
             "HEAD / HTTP/1.1"
-            "Host: bar"
+            "Host: 127.0.0.1"
             "User-Agent: Fastly healthcheck (git version: )"
             "Connection: close";
         .threshold = 1;
@@ -229,7 +229,7 @@ sub vcl_recv {
   # Failover to primary s3 mirror.
   if (req.restarts == 1) {
       set req.backend = F_mirrorS3;
-      set req.http.host = "bar";
+      set req.http.host = "127.0.0.1";
       set req.http.Fastly-Backend-Name = "mirrorS3";
 
       # Add bucket directory prefix to all the requests

--- a/spec/test-outputs/performanceplatform-integration.out.vcl
+++ b/spec/test-outputs/performanceplatform-integration.out.vcl
@@ -2,7 +2,7 @@ backend F_origin {
     .connect_timeout = 5s;
     .dynamic = true;
     .port = "443";
-    .host = "foo";
+    .host = "127.0.0.1";
     .first_byte_timeout = 15s;
     .max_connections = 200;
     .between_bytes_timeout = 10s;
@@ -11,13 +11,13 @@ backend F_origin {
     .ssl = true;
     .ssl_check_cert = always;
     .min_tls_version = "1.2";
-    .ssl_cert_hostname = "foo";
-    .ssl_sni_hostname = "foo";
+    .ssl_cert_hostname = "127.0.0.1";
+    .ssl_sni_hostname = "127.0.0.1";
 
     .probe = {
         .request =
             "HEAD / HTTP/1.1"
-            "Host: foo"
+            "Host: 127.0.0.1"
             "User-Agent: Fastly healthcheck (git version: )"
 
             "Connection: close";

--- a/spec/test-outputs/performanceplatform-production.out.vcl
+++ b/spec/test-outputs/performanceplatform-production.out.vcl
@@ -2,7 +2,7 @@ backend F_origin {
     .connect_timeout = 5s;
     .dynamic = true;
     .port = "443";
-    .host = "foo";
+    .host = "127.0.0.1";
     .first_byte_timeout = 15s;
     .max_connections = 200;
     .between_bytes_timeout = 10s;
@@ -11,13 +11,13 @@ backend F_origin {
     .ssl = true;
     .ssl_check_cert = always;
     .min_tls_version = "1.2";
-    .ssl_cert_hostname = "foo";
-    .ssl_sni_hostname = "foo";
+    .ssl_cert_hostname = "127.0.0.1";
+    .ssl_sni_hostname = "127.0.0.1";
 
     .probe = {
         .request =
             "HEAD / HTTP/1.1"
-            "Host: foo"
+            "Host: 127.0.0.1"
             "User-Agent: Fastly healthcheck (git version: )"
 
             "Connection: close";

--- a/spec/test-outputs/performanceplatform-staging.out.vcl
+++ b/spec/test-outputs/performanceplatform-staging.out.vcl
@@ -2,7 +2,7 @@ backend F_origin {
     .connect_timeout = 5s;
     .dynamic = true;
     .port = "443";
-    .host = "foo";
+    .host = "127.0.0.1";
     .first_byte_timeout = 15s;
     .max_connections = 200;
     .between_bytes_timeout = 10s;
@@ -11,13 +11,13 @@ backend F_origin {
     .ssl = true;
     .ssl_check_cert = always;
     .min_tls_version = "1.2";
-    .ssl_cert_hostname = "foo";
-    .ssl_sni_hostname = "foo";
+    .ssl_cert_hostname = "127.0.0.1";
+    .ssl_sni_hostname = "127.0.0.1";
 
     .probe = {
         .request =
             "HEAD / HTTP/1.1"
-            "Host: foo"
+            "Host: 127.0.0.1"
             "User-Agent: Fastly healthcheck (git version: )"
 
             "Connection: close";

--- a/spec/test-outputs/www-integration.out.vcl
+++ b/spec/test-outputs/www-integration.out.vcl
@@ -75,9 +75,7 @@ sub vcl_recv {
   
 
   # Force SSL.
-  if (!req.http.Fastly-SSL) {
-     error 801 "Force SSL";
-  }
+  # TODO: Wrap this in a for_fastly? if statement
 
   # Serve a 404 Not Found response if request URL matches "/autodiscover/autodiscover.xml"
   if (req.url ~ "(?i)/autodiscover/autodiscover.xml$") {
@@ -91,6 +89,10 @@ sub vcl_recv {
   # chosen
   set req.backend = F_origin;
   set req.http.Fastly-Backend-Name = "origin";
+
+  # TODO: wrap in if statement for test mode %>
+  # uses the default test backend
+  set req.backend = s1;
 
   # Set header to show recommended related links for Whitehall content. This is to be used
   # as a rollback mechanism should we ever need to stop showing these links.

--- a/spec/test-outputs/www-integration.out.vcl
+++ b/spec/test-outputs/www-integration.out.vcl
@@ -1,23 +1,14 @@
 backend F_origin {
     .connect_timeout = 5s;
-    .dynamic = true;
     .port = "443";
-    .host = "foo";
+    .host = "127.0.0.1";
     .first_byte_timeout = 15s;
     .max_connections = 200;
     .between_bytes_timeout = 10s;
-    .share_key = "123";
-
-    .ssl = true;
-    .ssl_check_cert = always;
-    .min_tls_version = "1.2";
-    .ssl_cert_hostname = "foo";
-    .ssl_sni_hostname = "foo";
-
     .probe = {
         .request =
             "HEAD / HTTP/1.1"
-            "Host: foo"
+            "Host: 127.0.0.1"
             "User-Agent: Fastly healthcheck (git version: )"
             "Connection: close";
         .threshold = 1;
@@ -59,23 +50,25 @@ acl purge_ip_whitelist {
   "167.82.224.0"/20;  # Fastly cache node
 }
 
-
-acl allowed_ip_addresses {
-  
+# TODO: Inject ip_address_blacklist at build time dependent on environment
+acl ip_address_blacklist {
 }
+
+
+# acl allowed_ip_addresses {}
 
 
 sub vcl_recv {
 
   # Require authentication for FASTLYPURGE requests unless from IP in ACL
-  if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_whitelist) {
+  if (req.request == "FASTLYPURGE" && !(client.ip ~ purge_ip_whitelist)) {
     set req.http.Fastly-Purge-Requires-Auth = "1";
   }
 
   
 
   # Check whether the remote IP address is in the list of blocked IPs
-  if (table.lookup(ip_address_blacklist, client.ip)) {
+  if (client.ip ~ ip_address_blacklist) {
     error 403 "Forbidden";
   }
 
@@ -87,7 +80,7 @@ sub vcl_recv {
   }
 
   # Serve a 404 Not Found response if request URL matches "/autodiscover/autodiscover.xml"
-  if (req.url.path ~ "(?i)/autodiscover/autodiscover.xml$") {
+  if (req.url ~ "(?i)/autodiscover/autodiscover.xml$") {
     error 804 "Not Found";
   }
 
@@ -111,7 +104,7 @@ sub vcl_recv {
   # Set a TLSversion request header for requests going to the Licensify application
   # This is used to block unsecure requests at the application level for payment security reasons and an absence of caching in Licensify
   if (req.url ~ "^/apply-for-a-licence/.*") {
-    set req.http.TLSversion = tls.client.protocol;
+    # set req.http.TLSversion = tls.client.protocol;
   }
 
 
@@ -123,8 +116,9 @@ sub vcl_recv {
 
     # Begin dynamic section
 if (req.http.Cookie ~ "cookies_policy") {
-  if (req.http.Cookie:cookies_policy ~ "%22usage%22:true") {
-    if (table.lookup(active_ab_tests, "Example") == "true") {
+  if (req.http.Cookie ~ "cookies_policy=%22usage%22:true") {
+
+    # if (table.lookup(active_ab_tests, "Example") == "true") {
       if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
         set req.http.GOVUK-ABTest-Example = "A";
       } else if (req.url ~ "[\?\&]ABTest-Example=A(&|$)") {
@@ -137,26 +131,33 @@ if (req.http.Cookie ~ "cookies_policy") {
         set req.http.GOVUK-ABTest-Example = "B";
       } else if (req.http.Cookie ~ "ABTest-Example") {
         # Set the value of the header to whatever decision was previously made
-        set req.http.GOVUK-ABTest-Example = req.http.Cookie:ABTest-Example;
-      } else {
-        declare local var.denominator_Example INTEGER;
-        declare local var.denominator_Example_A INTEGER;
-        declare local var.nominator_Example_A INTEGER;
-        set var.nominator_Example_A = std.atoi(table.lookup(example_percentages, "A"));
-        set var.denominator_Example += var.nominator_Example_A;
-        declare local var.denominator_Example_B INTEGER;
-        declare local var.nominator_Example_B INTEGER;
-        set var.nominator_Example_B = std.atoi(table.lookup(example_percentages, "B"));
-        set var.denominator_Example += var.nominator_Example_B;
-        set var.denominator_Example_A = var.denominator_Example;
-        if (randombool(var.nominator_Example_A, var.denominator_Example_A)) {
+        # and is still a known variant
+        if (req.http.Cookie ~ "ABTest-Example=A") {
           set req.http.GOVUK-ABTest-Example = "A";
-        } else {
+        }
+        if (req.http.Cookie ~ "ABTest-Example=B") {
           set req.http.GOVUK-ABTest-Example = "B";
         }
+      } else {
+        # declare local var.denominator_Example INTEGER;
+        # declare local var.denominator_Example_A INTEGER;
+        # declare local var.nominator_Example_A INTEGER;
+        # set var.nominator_Example_A = std.atoi(table.lookup(example_percentages, "A"));
+        # set var.denominator_Example += var.nominator_Example_A;
+        # declare local var.denominator_Example_B INTEGER;
+        # declare local var.nominator_Example_B INTEGER;
+        # set var.nominator_Example_B = std.atoi(table.lookup(example_percentages, "B"));
+        # set var.denominator_Example += var.nominator_Example_B;
+        # set var.denominator_Example_A = var.denominator_Example;
+        # if (randombool(var.nominator_Example_A, var.denominator_Example_A)) {
+        #   set req.http.GOVUK-ABTest-Example = "A";
+        # } else {
+        #   set req.http.GOVUK-ABTest-Example = "B";
+        # }
       }
-    }
-    if (table.lookup(active_ab_tests, "LearningToRankModelABTest") == "true") {
+    # }
+
+    # if (table.lookup(active_ab_tests, "LearningToRankModelABTest") == "true") {
       if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
         set req.http.GOVUK-ABTest-LearningToRankModelABTest = "unchanged";
       } else if (req.url ~ "[\?\&]ABTest-LearningToRankModelABTest=unchanged(&|$)") {
@@ -173,33 +174,42 @@ if (req.http.Cookie ~ "cookies_policy") {
         set req.http.GOVUK-ABTest-LearningToRankModelABTest = "elephant";
       } else if (req.http.Cookie ~ "ABTest-LearningToRankModelABTest") {
         # Set the value of the header to whatever decision was previously made
-        set req.http.GOVUK-ABTest-LearningToRankModelABTest = req.http.Cookie:ABTest-LearningToRankModelABTest;
-      } else {
-        declare local var.denominator_LearningToRankModelABTest INTEGER;
-        declare local var.denominator_LearningToRankModelABTest_unchanged INTEGER;
-        declare local var.nominator_LearningToRankModelABTest_unchanged INTEGER;
-        set var.nominator_LearningToRankModelABTest_unchanged = std.atoi(table.lookup(learningtorankmodelabtest_percentages, "unchanged"));
-        set var.denominator_LearningToRankModelABTest += var.nominator_LearningToRankModelABTest_unchanged;
-        declare local var.denominator_LearningToRankModelABTest_hippo INTEGER;
-        declare local var.nominator_LearningToRankModelABTest_hippo INTEGER;
-        set var.nominator_LearningToRankModelABTest_hippo = std.atoi(table.lookup(learningtorankmodelabtest_percentages, "hippo"));
-        set var.denominator_LearningToRankModelABTest += var.nominator_LearningToRankModelABTest_hippo;
-        declare local var.denominator_LearningToRankModelABTest_elephant INTEGER;
-        declare local var.nominator_LearningToRankModelABTest_elephant INTEGER;
-        set var.nominator_LearningToRankModelABTest_elephant = std.atoi(table.lookup(learningtorankmodelabtest_percentages, "elephant"));
-        set var.denominator_LearningToRankModelABTest += var.nominator_LearningToRankModelABTest_elephant;
-        set var.denominator_LearningToRankModelABTest_unchanged = var.denominator_LearningToRankModelABTest;
-        set var.denominator_LearningToRankModelABTest_hippo = var.denominator_LearningToRankModelABTest_unchanged;
-        set var.denominator_LearningToRankModelABTest_hippo -= var.nominator_LearningToRankModelABTest_unchanged;
-        if (randombool(var.nominator_LearningToRankModelABTest_unchanged, var.denominator_LearningToRankModelABTest_unchanged)) {
+        # and is still a known variant
+        if (req.http.Cookie ~ "ABTest-LearningToRankModelABTest=unchanged") {
           set req.http.GOVUK-ABTest-LearningToRankModelABTest = "unchanged";
-        } else if (randombool(var.nominator_LearningToRankModelABTest_hippo, var.denominator_LearningToRankModelABTest_hippo)) {
+        }
+        if (req.http.Cookie ~ "ABTest-LearningToRankModelABTest=hippo") {
           set req.http.GOVUK-ABTest-LearningToRankModelABTest = "hippo";
-        } else {
+        }
+        if (req.http.Cookie ~ "ABTest-LearningToRankModelABTest=elephant") {
           set req.http.GOVUK-ABTest-LearningToRankModelABTest = "elephant";
         }
+      } else {
+        # declare local var.denominator_LearningToRankModelABTest INTEGER;
+        # declare local var.denominator_LearningToRankModelABTest_unchanged INTEGER;
+        # declare local var.nominator_LearningToRankModelABTest_unchanged INTEGER;
+        # set var.nominator_LearningToRankModelABTest_unchanged = std.atoi(table.lookup(learningtorankmodelabtest_percentages, "unchanged"));
+        # set var.denominator_LearningToRankModelABTest += var.nominator_LearningToRankModelABTest_unchanged;
+        # declare local var.denominator_LearningToRankModelABTest_hippo INTEGER;
+        # declare local var.nominator_LearningToRankModelABTest_hippo INTEGER;
+        # set var.nominator_LearningToRankModelABTest_hippo = std.atoi(table.lookup(learningtorankmodelabtest_percentages, "hippo"));
+        # set var.denominator_LearningToRankModelABTest += var.nominator_LearningToRankModelABTest_hippo;
+        # declare local var.denominator_LearningToRankModelABTest_elephant INTEGER;
+        # declare local var.nominator_LearningToRankModelABTest_elephant INTEGER;
+        # set var.nominator_LearningToRankModelABTest_elephant = std.atoi(table.lookup(learningtorankmodelabtest_percentages, "elephant"));
+        # set var.denominator_LearningToRankModelABTest += var.nominator_LearningToRankModelABTest_elephant;
+        # set var.denominator_LearningToRankModelABTest_unchanged = var.denominator_LearningToRankModelABTest;
+        # set var.denominator_LearningToRankModelABTest_hippo = var.denominator_LearningToRankModelABTest_unchanged;
+        # set var.denominator_LearningToRankModelABTest_hippo -= var.nominator_LearningToRankModelABTest_unchanged;
+        # if (randombool(var.nominator_LearningToRankModelABTest_unchanged, var.denominator_LearningToRankModelABTest_unchanged)) {
+        #   set req.http.GOVUK-ABTest-LearningToRankModelABTest = "unchanged";
+        # } else if (randombool(var.nominator_LearningToRankModelABTest_hippo, var.denominator_LearningToRankModelABTest_hippo)) {
+        #   set req.http.GOVUK-ABTest-LearningToRankModelABTest = "hippo";
+        # } else {
+        #   set req.http.GOVUK-ABTest-LearningToRankModelABTest = "elephant";
+        # }
       }
-    }
+    # }
   }
 }
 # End dynamic section
@@ -297,24 +307,24 @@ sub vcl_deliver {
   # ensures that most visitors to the site aren't assigned an irrelevant test
   # cookie.
   if (req.url ~ "^/help/ab-testing"
-    && req.http.User-Agent !~ "^GOV\.UK Crawler Worker"
-    && req.http.Cookie !~ "ABTest-Example") {
+    && !(req.http.User-Agent ~ "^GOV\.UK Crawler Worker")
+    && !(req.http.Cookie ~ "ABTest-Example")) {
     # Set a fairly short cookie expiry because this is just an A/B test demo.
-    add resp.http.Set-Cookie = "ABTest-Example=" req.http.GOVUK-ABTest-Example "; secure; expires=" now + 1d;
+    # add resp.http.Set-Cookie = "ABTest-Example=" req.http.GOVUK-ABTest-Example "; secure; expires=" now + 1d;
   }
 
   # Begin dynamic section
-  declare local var.expiry TIME;
-  if (req.http.Cookie ~ "cookies_policy") {
-    if (req.http.Cookie:cookies_policy ~ "%22usage%22:true") {
-      if (table.lookup(active_ab_tests, "LearningToRankModelABTest") == "true") {
-        if (req.http.Cookie !~ "ABTest-LearningToRankModelABTest" || req.url ~ "[\?\&]ABTest-LearningToRankModelABTest" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
-          set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "LearningToRankModelABTest"))));
-          add resp.http.Set-Cookie = "ABTest-LearningToRankModelABTest=" req.http.GOVUK-ABTest-LearningToRankModelABTest "; secure; expires=" var.expiry "; path=/";
-        }
-      }
-    }
-  }
+  # declare local var.expiry TIME;
+  # if (req.http.Cookie ~ "cookies_policy") {
+    # if (req.http.Cookie ~ "cookies_policy=%22usage%22:true") {
+      # if (table.lookup(active_ab_tests, "LearningToRankModelABTest") == "true") {
+      #   if (!(req.http.Cookie ~ "ABTest-LearningToRankModelABTest") || req.url ~ "[\?\&]ABTest-LearningToRankModelABTest" && !(req.http.User-Agent ~ "^GOV\.UK Crawler Worker")) {
+      #     set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "LearningToRankModelABTest"))));
+      #     add resp.http.Set-Cookie = "ABTest-LearningToRankModelABTest=" req.http.GOVUK-ABTest-LearningToRankModelABTest "; secure; expires=" var.expiry "; path=/";
+      #   }
+      # }
+    # }
+  # }
   # End dynamic section
 
 #FASTLY deliver
@@ -364,9 +374,11 @@ sub vcl_error {
   # of serving stale only when the backend is the origin.
   if ((req.restarts == 0) && (obj.status >= 500 && obj.status < 600)) {
     /* deliver stale object if it is available */
-    if (stale.exists) {
-      return(deliver_stale);
-    }
+    # Possibly replaceable with custom VCL logic
+    # https://varnish-cache.org/docs/trunk/users-guide/vcl-grace.html#misbehaving-servers
+    # if (stale.exists) {
+    #   return(deliver_stale);
+    # }
   }
 
   # Assume we've hit vcl_error() because the backend is unavailable

--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -1,23 +1,14 @@
 backend F_origin {
     .connect_timeout = 5s;
-    .dynamic = true;
     .port = "443";
-    .host = "foo";
+    .host = "127.0.0.1";
     .first_byte_timeout = 15s;
     .max_connections = 200;
     .between_bytes_timeout = 10s;
-    .share_key = "123";
-
-    .ssl = true;
-    .ssl_check_cert = always;
-    .min_tls_version = "1.2";
-    .ssl_cert_hostname = "foo";
-    .ssl_sni_hostname = "foo";
-
     .probe = {
         .request =
             "HEAD / HTTP/1.1"
-            "Host: foo"
+            "Host: 127.0.0.1"
             "User-Agent: Fastly healthcheck (git version: )"
             "Connection: close";
         .threshold = 1;
@@ -33,24 +24,15 @@ backend F_origin {
 # Mirror backend for S3
 backend F_mirrorS3 {
     .connect_timeout = 1s;
-    .dynamic = true;
     .port = "443";
-    .host = "bar";
+    .host = "127.0.0.1";
     .first_byte_timeout = 15s;
     .max_connections = 200;
     .between_bytes_timeout = 10s;
-    .share_key = "123";
-
-    .ssl = true;
-    .ssl_check_cert = always;
-    .min_tls_version = "1.2";
-    .ssl_cert_hostname = "bar";
-    .ssl_sni_hostname = "bar";
-
     .probe = {
         .request =
             "HEAD / HTTP/1.1"
-            "Host: bar"
+            "Host: 127.0.0.1"
             "User-Agent: Fastly healthcheck (git version: )"
             "Connection: close";
         .threshold = 1;
@@ -65,20 +47,11 @@ backend F_mirrorS3 {
 # Mirror backend for S3 replica
 backend F_mirrorS3Replica {
     .connect_timeout = 1s;
-    .dynamic = true;
     .port = "443";
     .host = "s3-mirror-replica.aws.com";
     .first_byte_timeout = 15s;
     .max_connections = 200;
     .between_bytes_timeout = 10s;
-    .share_key = "123";
-
-    .ssl = true;
-    .ssl_check_cert = always;
-    .min_tls_version = "1.2";
-    .ssl_cert_hostname = "s3-mirror-replica.aws.com";
-    .ssl_sni_hostname = "s3-mirror-replica.aws.com";
-
     .probe = {
         .request =
             "HEAD / HTTP/1.1"
@@ -97,20 +70,11 @@ backend F_mirrorS3Replica {
 # Mirror backend for GCS
 backend F_mirrorGCS {
     .connect_timeout = 1s;
-    .dynamic = true;
     .port = "443";
     .host = "gcs-mirror.google.com";
     .first_byte_timeout = 15s;
     .max_connections = 200;
     .between_bytes_timeout = 10s;
-    .share_key = "123";
-
-    .ssl = true;
-    .ssl_check_cert = always;
-    .min_tls_version = "1.2";
-    .ssl_cert_hostname = "gcs-mirror.google.com";
-    .ssl_sni_hostname = "gcs-mirror.google.com";
-
     .probe = {
         .request =
             "HEAD / HTTP/1.1"
@@ -156,19 +120,25 @@ acl purge_ip_whitelist {
   "167.82.224.0"/20;  # Fastly cache node
 }
 
+# TODO: Inject ip_address_blacklist at build time dependent on environment
+acl ip_address_blacklist {
+}
+
+
+# acl allowed_ip_addresses {}
 
 
 sub vcl_recv {
 
   # Require authentication for FASTLYPURGE requests unless from IP in ACL
-  if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_whitelist) {
+  if (req.request == "FASTLYPURGE" && !(client.ip ~ purge_ip_whitelist)) {
     set req.http.Fastly-Purge-Requires-Auth = "1";
   }
 
   
 
   # Check whether the remote IP address is in the list of blocked IPs
-  if (table.lookup(ip_address_blacklist, client.ip)) {
+  if (client.ip ~ ip_address_blacklist) {
     error 403 "Forbidden";
   }
 
@@ -180,7 +150,7 @@ sub vcl_recv {
   }
 
   # Serve a 404 Not Found response if request URL matches "/autodiscover/autodiscover.xml"
-  if (req.url.path ~ "(?i)/autodiscover/autodiscover.xml$") {
+  if (req.url ~ "(?i)/autodiscover/autodiscover.xml$") {
     error 804 "Not Found";
   }
 
@@ -220,7 +190,7 @@ sub vcl_recv {
     set req.url = regsuball(req.url, "([^:])//+", "\1/");
 
     # Requests without document extension, rewrite adding .html
-    if (req.url !~ "^([^#\?\s]+)\.(atom|chm|css|csv|diff|doc|docx|dot|dxf|eps|gif|gml|html|ico|ics|jpeg|jpg|JPG|js|json|kml|odp|ods|odt|pdf|PDF|png|ppt|pptx|ps|rdf|rtf|sch|txt|wsdl|xls|xlsm|xlsx|xlt|xml|xsd|xslt|zip)([\?#]+.*)?$") {
+    if (!(req.url ~ "^([^#\?\s]+)\.(atom|chm|css|csv|diff|doc|docx|dot|dxf|eps|gif|gml|html|ico|ics|jpeg|jpg|JPG|js|json|kml|odp|ods|odt|pdf|PDF|png|ppt|pptx|ps|rdf|rtf|sch|txt|wsdl|xls|xlsm|xlsx|xlt|xml|xsd|xslt|zip)([\?#]+.*)?$")) {
       set req.url = regsub(req.url, "^([^#\?\s]+)([\?#]+.*)?$", "\1.html\2");
     }
   }
@@ -228,7 +198,7 @@ sub vcl_recv {
   # Failover to primary s3 mirror.
   if (req.restarts == 1) {
       set req.backend = F_mirrorS3;
-      set req.http.host = "bar";
+      set req.http.host = "127.0.0.1";
       set req.http.Fastly-Backend-Name = "mirrorS3";
 
       # Add bucket directory prefix to all the requests
@@ -255,7 +225,7 @@ sub vcl_recv {
     set req.url = "/gcs-mirror" req.url;
 
     set req.http.Date = now;
-    set req.http.Authorization = "AWS gcs-mirror-access-id:" digest.hmac_sha1_base64("gcs-mirror-secret-key", "GET" LF LF LF now LF "/gcs-bucket" req.url.path);
+    set req.http.Authorization = "AWS gcs-mirror-access-id:" digest.hmac_sha1_base64("gcs-mirror-secret-key", "GET" LF LF LF now LF "/gcs-bucket" req.url);
   }
   
 
@@ -265,7 +235,7 @@ sub vcl_recv {
   # Set a TLSversion request header for requests going to the Licensify application
   # This is used to block unsecure requests at the application level for payment security reasons and an absence of caching in Licensify
   if (req.url ~ "^/apply-for-a-licence/.*") {
-    set req.http.TLSversion = tls.client.protocol;
+    # set req.http.TLSversion = tls.client.protocol;
   }
 
 
@@ -277,8 +247,9 @@ sub vcl_recv {
 
     # Begin dynamic section
 if (req.http.Cookie ~ "cookies_policy") {
-  if (req.http.Cookie:cookies_policy ~ "%22usage%22:true") {
-    if (table.lookup(active_ab_tests, "Example") == "true") {
+  if (req.http.Cookie ~ "cookies_policy=%22usage%22:true") {
+
+    # if (table.lookup(active_ab_tests, "Example") == "true") {
       if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
         set req.http.GOVUK-ABTest-Example = "A";
       } else if (req.url ~ "[\?\&]ABTest-Example=A(&|$)") {
@@ -291,26 +262,33 @@ if (req.http.Cookie ~ "cookies_policy") {
         set req.http.GOVUK-ABTest-Example = "B";
       } else if (req.http.Cookie ~ "ABTest-Example") {
         # Set the value of the header to whatever decision was previously made
-        set req.http.GOVUK-ABTest-Example = req.http.Cookie:ABTest-Example;
-      } else {
-        declare local var.denominator_Example INTEGER;
-        declare local var.denominator_Example_A INTEGER;
-        declare local var.nominator_Example_A INTEGER;
-        set var.nominator_Example_A = std.atoi(table.lookup(example_percentages, "A"));
-        set var.denominator_Example += var.nominator_Example_A;
-        declare local var.denominator_Example_B INTEGER;
-        declare local var.nominator_Example_B INTEGER;
-        set var.nominator_Example_B = std.atoi(table.lookup(example_percentages, "B"));
-        set var.denominator_Example += var.nominator_Example_B;
-        set var.denominator_Example_A = var.denominator_Example;
-        if (randombool(var.nominator_Example_A, var.denominator_Example_A)) {
+        # and is still a known variant
+        if (req.http.Cookie ~ "ABTest-Example=A") {
           set req.http.GOVUK-ABTest-Example = "A";
-        } else {
+        }
+        if (req.http.Cookie ~ "ABTest-Example=B") {
           set req.http.GOVUK-ABTest-Example = "B";
         }
+      } else {
+        # declare local var.denominator_Example INTEGER;
+        # declare local var.denominator_Example_A INTEGER;
+        # declare local var.nominator_Example_A INTEGER;
+        # set var.nominator_Example_A = std.atoi(table.lookup(example_percentages, "A"));
+        # set var.denominator_Example += var.nominator_Example_A;
+        # declare local var.denominator_Example_B INTEGER;
+        # declare local var.nominator_Example_B INTEGER;
+        # set var.nominator_Example_B = std.atoi(table.lookup(example_percentages, "B"));
+        # set var.denominator_Example += var.nominator_Example_B;
+        # set var.denominator_Example_A = var.denominator_Example;
+        # if (randombool(var.nominator_Example_A, var.denominator_Example_A)) {
+        #   set req.http.GOVUK-ABTest-Example = "A";
+        # } else {
+        #   set req.http.GOVUK-ABTest-Example = "B";
+        # }
       }
-    }
-    if (table.lookup(active_ab_tests, "LearningToRankModelABTest") == "true") {
+    # }
+
+    # if (table.lookup(active_ab_tests, "LearningToRankModelABTest") == "true") {
       if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
         set req.http.GOVUK-ABTest-LearningToRankModelABTest = "unchanged";
       } else if (req.url ~ "[\?\&]ABTest-LearningToRankModelABTest=unchanged(&|$)") {
@@ -327,33 +305,42 @@ if (req.http.Cookie ~ "cookies_policy") {
         set req.http.GOVUK-ABTest-LearningToRankModelABTest = "elephant";
       } else if (req.http.Cookie ~ "ABTest-LearningToRankModelABTest") {
         # Set the value of the header to whatever decision was previously made
-        set req.http.GOVUK-ABTest-LearningToRankModelABTest = req.http.Cookie:ABTest-LearningToRankModelABTest;
-      } else {
-        declare local var.denominator_LearningToRankModelABTest INTEGER;
-        declare local var.denominator_LearningToRankModelABTest_unchanged INTEGER;
-        declare local var.nominator_LearningToRankModelABTest_unchanged INTEGER;
-        set var.nominator_LearningToRankModelABTest_unchanged = std.atoi(table.lookup(learningtorankmodelabtest_percentages, "unchanged"));
-        set var.denominator_LearningToRankModelABTest += var.nominator_LearningToRankModelABTest_unchanged;
-        declare local var.denominator_LearningToRankModelABTest_hippo INTEGER;
-        declare local var.nominator_LearningToRankModelABTest_hippo INTEGER;
-        set var.nominator_LearningToRankModelABTest_hippo = std.atoi(table.lookup(learningtorankmodelabtest_percentages, "hippo"));
-        set var.denominator_LearningToRankModelABTest += var.nominator_LearningToRankModelABTest_hippo;
-        declare local var.denominator_LearningToRankModelABTest_elephant INTEGER;
-        declare local var.nominator_LearningToRankModelABTest_elephant INTEGER;
-        set var.nominator_LearningToRankModelABTest_elephant = std.atoi(table.lookup(learningtorankmodelabtest_percentages, "elephant"));
-        set var.denominator_LearningToRankModelABTest += var.nominator_LearningToRankModelABTest_elephant;
-        set var.denominator_LearningToRankModelABTest_unchanged = var.denominator_LearningToRankModelABTest;
-        set var.denominator_LearningToRankModelABTest_hippo = var.denominator_LearningToRankModelABTest_unchanged;
-        set var.denominator_LearningToRankModelABTest_hippo -= var.nominator_LearningToRankModelABTest_unchanged;
-        if (randombool(var.nominator_LearningToRankModelABTest_unchanged, var.denominator_LearningToRankModelABTest_unchanged)) {
+        # and is still a known variant
+        if (req.http.Cookie ~ "ABTest-LearningToRankModelABTest=unchanged") {
           set req.http.GOVUK-ABTest-LearningToRankModelABTest = "unchanged";
-        } else if (randombool(var.nominator_LearningToRankModelABTest_hippo, var.denominator_LearningToRankModelABTest_hippo)) {
+        }
+        if (req.http.Cookie ~ "ABTest-LearningToRankModelABTest=hippo") {
           set req.http.GOVUK-ABTest-LearningToRankModelABTest = "hippo";
-        } else {
+        }
+        if (req.http.Cookie ~ "ABTest-LearningToRankModelABTest=elephant") {
           set req.http.GOVUK-ABTest-LearningToRankModelABTest = "elephant";
         }
+      } else {
+        # declare local var.denominator_LearningToRankModelABTest INTEGER;
+        # declare local var.denominator_LearningToRankModelABTest_unchanged INTEGER;
+        # declare local var.nominator_LearningToRankModelABTest_unchanged INTEGER;
+        # set var.nominator_LearningToRankModelABTest_unchanged = std.atoi(table.lookup(learningtorankmodelabtest_percentages, "unchanged"));
+        # set var.denominator_LearningToRankModelABTest += var.nominator_LearningToRankModelABTest_unchanged;
+        # declare local var.denominator_LearningToRankModelABTest_hippo INTEGER;
+        # declare local var.nominator_LearningToRankModelABTest_hippo INTEGER;
+        # set var.nominator_LearningToRankModelABTest_hippo = std.atoi(table.lookup(learningtorankmodelabtest_percentages, "hippo"));
+        # set var.denominator_LearningToRankModelABTest += var.nominator_LearningToRankModelABTest_hippo;
+        # declare local var.denominator_LearningToRankModelABTest_elephant INTEGER;
+        # declare local var.nominator_LearningToRankModelABTest_elephant INTEGER;
+        # set var.nominator_LearningToRankModelABTest_elephant = std.atoi(table.lookup(learningtorankmodelabtest_percentages, "elephant"));
+        # set var.denominator_LearningToRankModelABTest += var.nominator_LearningToRankModelABTest_elephant;
+        # set var.denominator_LearningToRankModelABTest_unchanged = var.denominator_LearningToRankModelABTest;
+        # set var.denominator_LearningToRankModelABTest_hippo = var.denominator_LearningToRankModelABTest_unchanged;
+        # set var.denominator_LearningToRankModelABTest_hippo -= var.nominator_LearningToRankModelABTest_unchanged;
+        # if (randombool(var.nominator_LearningToRankModelABTest_unchanged, var.denominator_LearningToRankModelABTest_unchanged)) {
+        #   set req.http.GOVUK-ABTest-LearningToRankModelABTest = "unchanged";
+        # } else if (randombool(var.nominator_LearningToRankModelABTest_hippo, var.denominator_LearningToRankModelABTest_hippo)) {
+        #   set req.http.GOVUK-ABTest-LearningToRankModelABTest = "hippo";
+        # } else {
+        #   set req.http.GOVUK-ABTest-LearningToRankModelABTest = "elephant";
+        # }
       }
-    }
+    # }
   }
 }
 # End dynamic section
@@ -451,24 +438,24 @@ sub vcl_deliver {
   # ensures that most visitors to the site aren't assigned an irrelevant test
   # cookie.
   if (req.url ~ "^/help/ab-testing"
-    && req.http.User-Agent !~ "^GOV\.UK Crawler Worker"
-    && req.http.Cookie !~ "ABTest-Example") {
+    && !(req.http.User-Agent ~ "^GOV\.UK Crawler Worker")
+    && !(req.http.Cookie ~ "ABTest-Example")) {
     # Set a fairly short cookie expiry because this is just an A/B test demo.
-    add resp.http.Set-Cookie = "ABTest-Example=" req.http.GOVUK-ABTest-Example "; secure; expires=" now + 1d;
+    # add resp.http.Set-Cookie = "ABTest-Example=" req.http.GOVUK-ABTest-Example "; secure; expires=" now + 1d;
   }
 
   # Begin dynamic section
-  declare local var.expiry TIME;
-  if (req.http.Cookie ~ "cookies_policy") {
-    if (req.http.Cookie:cookies_policy ~ "%22usage%22:true") {
-      if (table.lookup(active_ab_tests, "LearningToRankModelABTest") == "true") {
-        if (req.http.Cookie !~ "ABTest-LearningToRankModelABTest" || req.url ~ "[\?\&]ABTest-LearningToRankModelABTest" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
-          set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "LearningToRankModelABTest"))));
-          add resp.http.Set-Cookie = "ABTest-LearningToRankModelABTest=" req.http.GOVUK-ABTest-LearningToRankModelABTest "; secure; expires=" var.expiry "; path=/";
-        }
-      }
-    }
-  }
+  # declare local var.expiry TIME;
+  # if (req.http.Cookie ~ "cookies_policy") {
+    # if (req.http.Cookie ~ "cookies_policy=%22usage%22:true") {
+      # if (table.lookup(active_ab_tests, "LearningToRankModelABTest") == "true") {
+      #   if (!(req.http.Cookie ~ "ABTest-LearningToRankModelABTest") || req.url ~ "[\?\&]ABTest-LearningToRankModelABTest" && !(req.http.User-Agent ~ "^GOV\.UK Crawler Worker")) {
+      #     set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "LearningToRankModelABTest"))));
+      #     add resp.http.Set-Cookie = "ABTest-LearningToRankModelABTest=" req.http.GOVUK-ABTest-LearningToRankModelABTest "; secure; expires=" var.expiry "; path=/";
+      #   }
+      # }
+    # }
+  # }
   # End dynamic section
 
 #FASTLY deliver
@@ -518,9 +505,11 @@ sub vcl_error {
   # of serving stale only when the backend is the origin.
   if ((req.restarts == 0) && (obj.status >= 500 && obj.status < 600)) {
     /* deliver stale object if it is available */
-    if (stale.exists) {
-      return(deliver_stale);
-    }
+    # Possibly replaceable with custom VCL logic
+    # https://varnish-cache.org/docs/trunk/users-guide/vcl-grace.html#misbehaving-servers
+    # if (stale.exists) {
+    #   return(deliver_stale);
+    # }
   }
 
   # Assume we've hit vcl_error() because the backend is unavailable

--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -145,9 +145,7 @@ sub vcl_recv {
   
 
   # Force SSL.
-  if (!req.http.Fastly-SSL) {
-     error 801 "Force SSL";
-  }
+  # TODO: Wrap this in a for_fastly? if statement
 
   # Serve a 404 Not Found response if request URL matches "/autodiscover/autodiscover.xml"
   if (req.url ~ "(?i)/autodiscover/autodiscover.xml$") {
@@ -161,6 +159,10 @@ sub vcl_recv {
   # chosen
   set req.backend = F_origin;
   set req.http.Fastly-Backend-Name = "origin";
+
+  # TODO: wrap in if statement for test mode %>
+  # uses the default test backend
+  set req.backend = s1;
 
   # Set header to show recommended related links for Whitehall content. This is to be used
   # as a rollback mechanism should we ever need to stop showing these links.

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -152,9 +152,7 @@ sub vcl_recv {
   
 
   # Force SSL.
-  if (!req.http.Fastly-SSL) {
-     error 801 "Force SSL";
-  }
+  # TODO: Wrap this in a for_fastly? if statement
 
   # Serve a 404 Not Found response if request URL matches "/autodiscover/autodiscover.xml"
   if (req.url ~ "(?i)/autodiscover/autodiscover.xml$") {
@@ -168,6 +166,10 @@ sub vcl_recv {
   # chosen
   set req.backend = F_origin;
   set req.http.Fastly-Backend-Name = "origin";
+
+  # TODO: wrap in if statement for test mode %>
+  # uses the default test backend
+  set req.backend = s1;
 
   # Set header to show recommended related links for Whitehall content. This is to be used
   # as a rollback mechanism should we ever need to stop showing these links.

--- a/spec/unit/homepage_test.vtc
+++ b/spec/unit/homepage_test.vtc
@@ -1,0 +1,31 @@
+### WWW unit tests!
+
+# ===========================================================================
+
+test "the body of a 200 response from origin is not modified"
+
+# representing an origin server, receives a request (req)
+server s1 {
+	rxreq
+	expect req.url == "/"
+	txresp -status 200 -body "Welcome to the GOV.UK homepage!"
+} -start
+
+varnish v1 -vcl+backend {
+  # VCL_PLACEHOLDER
+} -start
+
+# representing clients using GOV.UK, receives a response (resp)
+client c_homepage_loader {
+	# client requests the GOV.UK homepage
+	txreq -url "/" -req GET
+	rxresp
+	# client receives a response
+	expect resp.status == 200
+	expect resp.http.Fastly-Backend-Name == "origin"
+	expect resp.bodylen == 31
+}
+
+client c_homepage_loader -run
+
+# ===========================================================================

--- a/spec/unit/www_tests.vtc
+++ b/spec/unit/www_tests.vtc
@@ -1,0 +1,28 @@
+### WWW unit tests!
+
+# our origin server
+server s1 { rxreq; txresp } -start
+
+# Boilerplate - this gets filled in with our VCL automatically
+varnish v1 -vcl+backend {
+  # VCL_PLACEHOLDER
+} -start
+
+# ===========================================================================
+
+test "serve a 404 Not Found response if request URL matches /autodiscover/autodiscover.xml"
+
+# representing clients using GOV.UK, receives a response (resp)
+client c_eager_outlook_mailserver {
+	# client requests this outlook URL
+	txreq -url "/autodiscover/autodiscover.xml"
+	rxresp
+	# client receives a 404 message
+	expect resp.bodylen == 635
+	expect resp.http.Fastly-Backend-Name == "force_not_found"
+	expect resp.status == 404
+}
+
+client c_eager_outlook_mailserver -run
+
+# ===========================================================================

--- a/spec/vcl_generation_spec.rb
+++ b/spec/vcl_generation_spec.rb
@@ -2,11 +2,11 @@ RSpec.describe "VCL generation" do
   # Fill in the required test data. Normally this would come from
   # https://github.com/alphagov/govuk-cdn-config-secrets/blob/master/fastly/fastly.yaml
   config = {
-    "origin_hostname" => "foo",
-    "aws_origin_hostname" => "foo",
+    "origin_hostname" => "127.0.0.1",
+    "aws_origin_hostname" => "127.0.0.1",
     "service_id" => "123",
-    "provider1_mirror_hostname" => "foo",
-    "s3_mirror_hostname" => "bar",
+    "provider1_mirror_hostname" => "127.0.0.1",
+    "s3_mirror_hostname" => "127.0.0.1",
     "s3_mirror_prefix" => "foo_",
     "s3_mirror_replica_hostname" => "s3-mirror-replica.aws.com",
     "s3_mirror_replica_prefix" => "s3-mirror-replica",
@@ -16,7 +16,7 @@ RSpec.describe "VCL generation" do
     "gcs_mirror_secret_key" => "gcs-mirror-secret-key",
     "gcs_mirror_bucket_name" => "gcs-bucket",
     "default_ttl" => "5000",
-    "apt_hostname" => "foo",
+    "apt_hostname" => "127.0.0.1",
     "origin_domain_suffix" => "boo",
     "domain_suffix" => "boo",
   }

--- a/spec/www_vcl_erb_spec.rb
+++ b/spec/www_vcl_erb_spec.rb
@@ -6,10 +6,10 @@ RSpec.describe "VCL template" do
   # `ab_tests`, `config` and `environment` are binding vars needed by the www.vcl.erb template
   let!(:config) do
     {
-      "origin_hostname" => "foo",
+      "origin_hostname" => "127.0.0.1",
       "service_id" => "123",
-      "provider1_mirror_hostname" => "foo",
-      "s3_mirror_hostname" => "bar",
+      "provider1_mirror_hostname" => "127.0.0.1",
+      "s3_mirror_hostname" => "127.0.0.1",
       "s3_mirror_prefix" => "foo_",
       "default_ttl" => "5000",
     }

--- a/vcl_templates/_multivariate_tests.vcl.erb
+++ b/vcl_templates/_multivariate_tests.vcl.erb
@@ -5,11 +5,11 @@
 # Begin dynamic section
 <% if ab_tests -%>
 if (req.http.Cookie ~ "cookies_policy") {
-  if (req.http.Cookie:cookies_policy ~ "%22usage%22:true") {
+  if (req.http.Cookie ~ "cookies_policy=%22usage%22:true") {
 <% ab_tests.each do |test_config| -%>
-<%# test_config is a hash like { "MyTest" => ['foo', 'bar', 'baz'] } -%>
+<%# test_config is a hash like { "MyTest" => ['foo', 'bar', 'baz'] } - %>
 <% test_config.each do |test, variants| -%>
-    if (table.lookup(active_ab_tests, "<%= test %>") == "true") {
+    # if (table.lookup(active_ab_tests, "<%= test %>") == "true") {
       if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
         set req.http.GOVUK-ABTest-<%= test %> = "<%= variants.first %>";
 <% variants.each do |variant| -%>
@@ -20,39 +20,44 @@ if (req.http.Cookie ~ "cookies_policy") {
 <% end -%>
       } else if (req.http.Cookie ~ "ABTest-<%= test %>") {
         # Set the value of the header to whatever decision was previously made
-        set req.http.GOVUK-ABTest-<%= test %> = req.http.Cookie:ABTest-<%= test %>;
-      } else {
-        declare local var.denominator_<%= test %> INTEGER;
+        # and is still a known variant
 <% variants.each do |variant| -%>
-        declare local var.denominator_<%= test %>_<%= variant %> INTEGER;
-        declare local var.nominator_<%= test %>_<%= variant %> INTEGER;
-        set var.nominator_<%= test %>_<%= variant %> = std.atoi(table.lookup(<%= test.downcase %>_percentages, "<%= variant %>"));
-        set var.denominator_<%= test %> += var.nominator_<%= test %>_<%= variant %>;
+        if (req.http.Cookie ~ "ABTest-<%= test %>=<%= variant %>") {
+          set req.http.GOVUK-ABTest-<%= test %> = "<%= variant %>";
+        }
+<% end -%>
+      } else {
+        # declare local var.denominator_<%= test %> INTEGER;
+<% variants.each do |variant| -%>
+        # declare local var.denominator_<%= test %>_<%= variant %> INTEGER;
+        # declare local var.nominator_<%= test %>_<%= variant %> INTEGER;
+        # set var.nominator_<%= test %>_<%= variant %> = std.atoi(table.lookup(<%= test.downcase %>_percentages, "<%= variant %>"));
+        # set var.denominator_<%= test %> += var.nominator_<%= test %>_<%= variant %>;
 <% end -%>
 <% variants.each_with_index do |variant, idx| -%>
 <% if variant == variants.first -%>
-        set var.denominator_<%= test %>_<%= variant %> = var.denominator_<%= test %>;
+        # set var.denominator_<%= test %>_<%= variant %> = var.denominator_<%= test %>;
 <% elsif variant != variants.last -%>
 <% previous_variant = variants[idx - 1] -%>
-        set var.denominator_<%= test %>_<%= variant %> = var.denominator_<%= test %>_<%= previous_variant %>;
-        set var.denominator_<%= test %>_<%= variant %> -= var.nominator_<%= test %>_<%= previous_variant %>;
+        # set var.denominator_<%= test %>_<%= variant %> = var.denominator_<%= test %>_<%= previous_variant %>;
+        # set var.denominator_<%= test %>_<%= variant %> -= var.nominator_<%= test %>_<%= previous_variant %>;
 <% end # if -%>
 <% end # variants.each_with_index -%>
 <% variants.each do |variant| -%>
 <% if variant == variants.first -%>
-        if (randombool(var.nominator_<%= test %>_<%= variant %>, var.denominator_<%= test %>_<%= variant %>)) {
-          set req.http.GOVUK-ABTest-<%= test %> = "<%= variant %>";
+        # if (randombool(var.nominator_<%= test %>_<%= variant %>, var.denominator_<%= test %>_<%= variant %>)) {
+        #   set req.http.GOVUK-ABTest-<%= test %> = "<%= variant %>";
 <% elsif variant != variants.first && variant != variants.last -%>
-        } else if (randombool(var.nominator_<%= test %>_<%= variant %>, var.denominator_<%= test %>_<%= variant %>)) {
-          set req.http.GOVUK-ABTest-<%= test %> = "<%= variant %>";
+        # } else if (randombool(var.nominator_<%= test %>_<%= variant %>, var.denominator_<%= test %>_<%= variant %>)) {
+        #   set req.http.GOVUK-ABTest-<%= test %> = "<%= variant %>";
 <% else -%>
-        } else {
-          set req.http.GOVUK-ABTest-<%= test %> = "<%= variant %>";
-        }
+        # } else {
+        #   set req.http.GOVUK-ABTest-<%= test %> = "<%= variant %>";
+        # }
 <% end -%>
 <% end # variants.each-%>
       }
-    }
+    # }
 <% end # test_config.each -%>
 <% end # ab_tests.each -%>
   }

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -178,10 +178,12 @@ sub vcl_recv {
   <% end %>
 
   # Force SSL.
+  # TODO: Wrap this in a for_fastly? if statement
+<% if %w(fastly).include?(environment) %>
   if (!req.http.Fastly-SSL) {
      error 801 "Force SSL";
   }
-
+<% end %>
   # Serve a 404 Not Found response if request URL matches "/autodiscover/autodiscover.xml"
   if (req.url ~ "(?i)/autodiscover/autodiscover.xml$") {
     error 804 "Not Found";
@@ -194,6 +196,10 @@ sub vcl_recv {
   # chosen
   set req.backend = F_origin;
   set req.http.Fastly-Backend-Name = "origin";
+
+  # TODO: wrap in if statement for test mode %>
+  # uses the default test backend
+  set req.backend = s1;
 
   # Set header to show recommended related links for Whitehall content. This is to be used
   # as a rollback mechanism should we ever need to stop showing these links.

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -1,22 +1,10 @@
 backend F_origin {
     .connect_timeout = 5s;
-    .dynamic = true;
     .port = "<%= config.fetch('origin_port', 443) %>";
     .host = "<%= config.fetch('origin_hostname') %>";
     .first_byte_timeout = 15s;
     .max_connections = 200;
     .between_bytes_timeout = 10s;
-    .share_key = "<%= config.fetch('service_id') %>";
-
-    .ssl = true;
-    .ssl_check_cert = <%= config['disable_tls_validation'] ? 'never' : 'always' %>;
-    .min_tls_version = "<%= config.fetch('min_tls_version', '1.2') %>";
-    <%- if config['ssl_ciphers'] -%>
-    .ssl_ciphers = "<%= config['ssl_ciphers'] -%>";
-    <%- end -%>
-    .ssl_cert_hostname = "<%= config.fetch('ssl_cert_hostname', config.fetch('origin_hostname')) %>";
-    .ssl_sni_hostname = "<%= config.fetch('ssl_sni_hostname', config.fetch('origin_hostname')) %>";
-
     .probe = {
         .request =
             "HEAD / HTTP/1.1"
@@ -42,23 +30,11 @@ backend F_origin {
 # Mirror backend for S3
 backend F_mirrorS3 {
     .connect_timeout = 1s;
-    .dynamic = true;
     .port = "<%= config.fetch('s3_mirror_port', 443) %>";
     .host = "<%= config.fetch('s3_mirror_hostname') %>";
     .first_byte_timeout = 15s;
     .max_connections = 200;
     .between_bytes_timeout = 10s;
-    .share_key = "<%= config.fetch('service_id') %>";
-
-    .ssl = true;
-    .ssl_check_cert = <%= config['disable_tls_validation'] ? 'never' : 'always' %>;
-    .min_tls_version = "<%= config.fetch('min_tls_version', '1.2') %>";
-    <%- if config['ssl_ciphers'] -%>
-    .ssl_ciphers = "<%= config['ssl_ciphers'] -%>";
-    <%- end -%>
-    .ssl_cert_hostname = "<%= config.fetch('ssl_cert_hostname', config.fetch('s3_mirror_hostname')) %>";
-    .ssl_sni_hostname = "<%= config.fetch('ssl_sni_hostname', config.fetch('s3_mirror_hostname')) %>";
-
     .probe = {
         .request =
             "HEAD <%= config.fetch('s3_mirror_probe_request', '/') %> HTTP/1.1"
@@ -77,23 +53,11 @@ backend F_mirrorS3 {
 # Mirror backend for S3 replica
 backend F_mirrorS3Replica {
     .connect_timeout = 1s;
-    .dynamic = true;
     .port = "<%= config.fetch('s3_mirror_replica_port', 443) %>";
     .host = "<%= config.fetch('s3_mirror_replica_hostname') %>";
     .first_byte_timeout = 15s;
     .max_connections = 200;
     .between_bytes_timeout = 10s;
-    .share_key = "<%= config.fetch('service_id') %>";
-
-    .ssl = true;
-    .ssl_check_cert = <%= config['disable_tls_validation'] ? 'never' : 'always' %>;
-    .min_tls_version = "<%= config.fetch('min_tls_version', '1.2') %>";
-    <%- if config['ssl_ciphers'] -%>
-    .ssl_ciphers = "<%= config['ssl_ciphers'] -%>";
-    <%- end -%>
-    .ssl_cert_hostname = "<%= config.fetch('ssl_cert_hostname', config.fetch('s3_mirror_replica_hostname')) %>";
-    .ssl_sni_hostname = "<%= config.fetch('ssl_sni_hostname', config.fetch('s3_mirror_replica_hostname')) %>";
-
     .probe = {
         .request =
             "HEAD <%= config.fetch('s3_mirror_replica_probe_request', '/') %> HTTP/1.1"
@@ -112,23 +76,11 @@ backend F_mirrorS3Replica {
 # Mirror backend for GCS
 backend F_mirrorGCS {
     .connect_timeout = 1s;
-    .dynamic = true;
     .port = "<%= config.fetch('gcs_mirror_port', 443) %>";
     .host = "<%= config.fetch('gcs_mirror_hostname') %>";
     .first_byte_timeout = 15s;
     .max_connections = 200;
     .between_bytes_timeout = 10s;
-    .share_key = "<%= config.fetch('service_id') %>";
-
-    .ssl = true;
-    .ssl_check_cert = <%= config['disable_tls_validation'] ? 'never' : 'always' %>;
-    .min_tls_version = "<%= config.fetch('min_tls_version', '1.2') %>";
-    <%- if config['ssl_ciphers'] -%>
-    .ssl_ciphers = "<%= config['ssl_ciphers'] -%>";
-    <%- end -%>
-    .ssl_cert_hostname = "<%= config.fetch('ssl_cert_hostname', config.fetch('gcs_mirror_hostname')) %>";
-    .ssl_sni_hostname = "<%= config.fetch('ssl_sni_hostname', config.fetch('gcs_mirror_hostname')) %>";
-
     .probe = {
         .request =
             "HEAD <%= config.fetch('gcs_mirror_probe_request', '/') %> HTTP/1.1"
@@ -183,18 +135,24 @@ acl purge_ip_whitelist {
   "167.82.224.0"/20;  # Fastly cache node
 }
 
-<% if %w(staging integration).include?(environment) %>
+# TODO: Inject ip_address_blacklist at build time dependent on environment
+acl ip_address_blacklist {
+}
+
+<% if %w(staging).include?(environment) %>
 acl allowed_ip_addresses {
   <% config.fetch('allowed_ip_addresses', []).each do |ip_address| %>
   "<%= ip_address %>";
   <% end %>
 }
+<% else %>
+# acl allowed_ip_addresses {}
 <% end %>
 
 sub vcl_recv {
 
   # Require authentication for FASTLYPURGE requests unless from IP in ACL
-  if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_whitelist) {
+  if (req.request == "FASTLYPURGE" && !(client.ip ~ purge_ip_whitelist)) {
     set req.http.Fastly-Purge-Requires-Auth = "1";
   }
 
@@ -206,7 +164,7 @@ sub vcl_recv {
   <% end %>
 
   # Check whether the remote IP address is in the list of blocked IPs
-  if (table.lookup(ip_address_blacklist, client.ip)) {
+  if (client.ip ~ ip_address_blacklist) {
     error 403 "Forbidden";
   }
 
@@ -225,7 +183,7 @@ sub vcl_recv {
   }
 
   # Serve a 404 Not Found response if request URL matches "/autodiscover/autodiscover.xml"
-  if (req.url.path ~ "(?i)/autodiscover/autodiscover.xml$") {
+  if (req.url ~ "(?i)/autodiscover/autodiscover.xml$") {
     error 804 "Not Found";
   }
 
@@ -265,7 +223,7 @@ sub vcl_recv {
     set req.url = regsuball(req.url, "([^:])//+", "\1/");
 
     # Requests without document extension, rewrite adding .html
-    if (req.url !~ "^([^#\?\s]+)\.(atom|chm|css|csv|diff|doc|docx|dot|dxf|eps|gif|gml|html|ico|ics|jpeg|jpg|JPG|js|json|kml|odp|ods|odt|pdf|PDF|png|ppt|pptx|ps|rdf|rtf|sch|txt|wsdl|xls|xlsm|xlsx|xlt|xml|xsd|xslt|zip)([\?#]+.*)?$") {
+    if (!(req.url ~ "^([^#\?\s]+)\.(atom|chm|css|csv|diff|doc|docx|dot|dxf|eps|gif|gml|html|ico|ics|jpeg|jpg|JPG|js|json|kml|odp|ods|odt|pdf|PDF|png|ppt|pptx|ps|rdf|rtf|sch|txt|wsdl|xls|xlsm|xlsx|xlt|xml|xsd|xslt|zip)([\?#]+.*)?$")) {
       set req.url = regsub(req.url, "^([^#\?\s]+)([\?#]+.*)?$", "\1.html\2");
     }
   }
@@ -300,7 +258,7 @@ sub vcl_recv {
     set req.url = "/<%= config.fetch('gcs_mirror_prefix') %>" req.url;
 
     set req.http.Date = now;
-    set req.http.Authorization = "AWS <%= config.fetch('gcs_mirror_access_id') %>:" digest.hmac_sha1_base64("<%= config.fetch('gcs_mirror_secret_key') %>", "GET" LF LF LF now LF "/<%= config.fetch('gcs_mirror_bucket_name') %>" req.url.path);
+    set req.http.Authorization = "AWS <%= config.fetch('gcs_mirror_access_id') %>:" digest.hmac_sha1_base64("<%= config.fetch('gcs_mirror_secret_key') %>", "GET" LF LF LF now LF "/<%= config.fetch('gcs_mirror_bucket_name') %>" req.url);
   }
   <% end %>
 
@@ -310,7 +268,7 @@ sub vcl_recv {
   # Set a TLSversion request header for requests going to the Licensify application
   # This is used to block unsecure requests at the application level for payment security reasons and an absence of caching in Licensify
   if (req.url ~ "^/apply-for-a-licence/.*") {
-    set req.http.TLSversion = tls.client.protocol;
+    # set req.http.TLSversion = tls.client.protocol;
   }
 
 <% if config['basic_authentication'] -%>
@@ -420,28 +378,28 @@ sub vcl_deliver {
   # ensures that most visitors to the site aren't assigned an irrelevant test
   # cookie.
   if (req.url ~ "^/help/ab-testing"
-    && req.http.User-Agent !~ "^GOV\.UK Crawler Worker"
-    && req.http.Cookie !~ "ABTest-Example") {
+    && !(req.http.User-Agent ~ "^GOV\.UK Crawler Worker")
+    && !(req.http.Cookie ~ "ABTest-Example")) {
     # Set a fairly short cookie expiry because this is just an A/B test demo.
-    add resp.http.Set-Cookie = "ABTest-Example=" req.http.GOVUK-ABTest-Example "; secure; expires=" now + 1d;
+    # add resp.http.Set-Cookie = "ABTest-Example=" req.http.GOVUK-ABTest-Example "; secure; expires=" now + 1d;
   }
 
   # Begin dynamic section
 <% if ab_tests -%>
-  declare local var.expiry TIME;
+  # declare local var.expiry TIME;
 <% ab_tests.each do |test_config| -%>
 <% test_config.each do |test, _| -%>
 <% unless test == "Example" -%>
-  if (req.http.Cookie ~ "cookies_policy") {
-    if (req.http.Cookie:cookies_policy ~ "%22usage%22:true") {
-      if (table.lookup(active_ab_tests, "<%= test %>") == "true") {
-        if (req.http.Cookie !~ "ABTest-<%= test %>" || req.url ~ "[\?\&]ABTest-<%= test %>" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
-          set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "<%= test %>"))));
-          add resp.http.Set-Cookie = "ABTest-<%= test %>=" req.http.GOVUK-ABTest-<%= test %> "; secure; expires=" var.expiry "; path=/";
-        }
-      }
-    }
-  }
+  # if (req.http.Cookie ~ "cookies_policy") {
+    # if (req.http.Cookie ~ "cookies_policy=%22usage%22:true") {
+      # if (table.lookup(active_ab_tests, "<%= test %>") == "true") {
+      #   if (!(req.http.Cookie ~ "ABTest-<%= test %>") || req.url ~ "[\?\&]ABTest-<%= test %>" && !(req.http.User-Agent ~ "^GOV\.UK Crawler Worker")) {
+      #     set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "<%= test %>"))));
+      #     add resp.http.Set-Cookie = "ABTest-<%= test %>=" req.http.GOVUK-ABTest-<%= test %> "; secure; expires=" var.expiry "; path=/";
+      #   }
+      # }
+    # }
+  # }
 <% end # unless -%>
 <% end # test_config.each -%>
 <% end # ab_tests.each -%>
@@ -501,9 +459,11 @@ sub vcl_error {
   # of serving stale only when the backend is the origin.
   if ((req.restarts == 0) && (obj.status >= 500 && obj.status < 600)) {
     /* deliver stale object if it is available */
-    if (stale.exists) {
-      return(deliver_stale);
-    }
+    # Possibly replaceable with custom VCL logic
+    # https://varnish-cache.org/docs/trunk/users-guide/vcl-grace.html#misbehaving-servers
+    # if (stale.exists) {
+    #   return(deliver_stale);
+    # }
   }
 
   # Assume we've hit vcl_error() because the backend is unavailable


### PR DESCRIPTION
**Note:** This PR is not ready for merge.

This spike demonstrates how we might use [varnishtest](https://varnish-cache.org/docs/2.1/reference/varnishtest.html) to unit test the VCL for GOV.UK.

I propose that we would generate another instance of VCL for each environment for testing, e.g. www-integration.test.vcl, which we could then run unit tests against.

The tests can be run as part of our CI test suite, with a single command:

```
docker run -v $(pwd):/work rhargreaves/varnishtest /test-vcl.sh spec/unit/www_tests.vtc spec/test-outputs/www-integration.out.vcl
```

I would recommend reading the PR by commit.

Below I discuss the pros and cons of this approach, I'd be grateful for feedback on this work-in-progress.

Pros:

- We will gain more confidence in the VCL we write, enabling us to work in a TDD way.
- This repository will conform to the GDS way, since it will have tests as part of the CI.
- We will catch some bugs before they go to any environment including syntax errors and functional errors.
- Varnishtest is still supported and I found it to be [very well documented](https://varnish-cache.org/docs/trunk/reference/vtc.html) with [lots of example tests](https://github.com/varnishcache/varnish-cache/tree/2.1/bin/varnishtest/tests).
- We will be able to write vanilla VCL, not dependent on Fastly, making it easier to migrate to another CDN.
- This approach could also be applied to the Varnish instances we run on cache machines.
- A side effect of not using Fastly VCL features is that we can deploy CDN changes in one step, not two, as we won't need to use dictionaries. Another side effect is that we will be able to deprecrate the cdn-secrets repo and move those secrets to the main secrets repository.
- Finally, as a result of the above, we will reduce the number of incidents related to changes we make to our VCL config in Fastly, provided the test coverage is good.

Cons:

- This approach requires us to not use Fastly VCL features, or at least not test those we use. See the previous commit for detail. This is because Fastly VCL is not valid VCL so cannot be compiled outside of Fastly's environment.
- Since Fastly runs a customized version of Varnish that this tests against, these tests may build false confidence in the effect of a change.
- The tests are written in VTC, a nice language, but not something folks working on GOV.UK will likely have experience with.
- It requires a very careful initial migration away from using Fastly's VCL - one that itself could cause an incident
- It might encourage more complex logic being implemented in VCL.

Other approaches evaluated

Relying more heavily on Smokey for testing VCL config is an option. The tests we write for VCL behaviour against a live environment would likely become quite flaky.

I looked at using Fastly Fiddle in CI as proposed by Fastly in https://www.fastly.com/blog/testing-fastly-ci. I decided against this route partly because it's an experimental tool not recommended for production

I also considered reviving a previous project for testing VCL that former colleagues worked on:
https://technology.blog.gov.uk/2014/10/01/cdn-acceptance-testing/.

Another recommendation was https://github.com/instrumenta/conftest.

I decided to go for varnishtest since it seemed like the best way to comprehensively test VCL behaviour.

https://trello.com/c/gS8EksUN/1373-investigate-fastly-vcl-unit-tests

The next step for this will be to gather some feedback on the approach and decide whether we want to try out other options or press on with this.