### PR TITLE
Strip query strings on coronavirus pages

### DIFF
--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -203,6 +203,11 @@ sub vcl_recv {
     set req.http.original-url = req.url;
   }
 
+  # Remove querystrings from coronavirus related pages
+  if (req.url.path ~ "(?i)^(/coronavirus|/government/publications/covid-19)") {
+    set req.url = std.tolower(re.group.0);
+  }
+
   # Common config when failover to mirror buckets
   if (req.restarts > 0) {
     set req.url = req.http.original-url;

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -212,6 +212,11 @@ sub vcl_recv {
     set req.http.original-url = req.url;
   }
 
+  # Remove querystrings from coronavirus related pages
+  if (req.url.path ~ "(?i)^(/coronavirus|/government/publications/covid-19)") {
+    set req.url = std.tolower(re.group.0);
+  }
+
   # Common config when failover to mirror buckets
   if (req.restarts > 0) {
     set req.url = req.http.original-url;

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -248,6 +248,11 @@ sub vcl_recv {
     set req.http.original-url = req.url;
   }
 
+  # Remove querystrings from coronavirus related pages
+  if (req.url.path ~ "(?i)^(/coronavirus|/government/publications/covid-19)") {
+    set req.url = std.tolower(re.group.0);
+  }
+
   # Common config when failover to mirror buckets
   if (req.restarts > 0) {
     set req.url = req.http.original-url;


### PR DESCRIPTION
To make sure that these pages are as cached as they possibly can.

Similar to #213.