### PR TITLE
Fix coronavirus path regex

### DIFF
--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -205,7 +205,7 @@ sub vcl_recv {
 
   # Remove querystrings from coronavirus related pages
   if (req.url.path ~ "(?i)^(/coronavirus|/government/publications/covid-19)") {
-    set req.url = std.tolower(re.group.0);
+    set req.url = std.tolower(req.url.path);
   }
 
   # Common config when failover to mirror buckets

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -214,7 +214,7 @@ sub vcl_recv {
 
   # Remove querystrings from coronavirus related pages
   if (req.url.path ~ "(?i)^(/coronavirus|/government/publications/covid-19)") {
-    set req.url = std.tolower(re.group.0);
+    set req.url = std.tolower(req.url.path);
   }
 
   # Common config when failover to mirror buckets

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -250,7 +250,7 @@ sub vcl_recv {
 
   # Remove querystrings from coronavirus related pages
   if (req.url.path ~ "(?i)^(/coronavirus|/government/publications/covid-19)") {
-    set req.url = std.tolower(re.group.0);
+    set req.url = std.tolower(req.url.path);
   }
 
   # Common config when failover to mirror buckets


### PR DESCRIPTION
Avoiding the need for `re.group.0` as `req.url.path` contains the path without any query parameters.