### PR TITLE
Add coronavirus link to error pages

### DIFF
--- a/spec/test-outputs/www-integration.out.vcl
+++ b/spec/test-outputs/www-integration.out.vcl
@@ -452,6 +452,7 @@ sub vcl_error {
       <body>
         <header><h1>GOV.UK</h1></header>
         <p>We're experiencing technical difficulties. Please try again later.</p>
+        <p>You can <a href="/coronavirus">find coronavirus information</a> on GOV.UK.</p>
       </body>
     </html>"};
 

--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -611,6 +611,7 @@ sub vcl_error {
       <body>
         <header><h1>GOV.UK</h1></header>
         <p>We're experiencing technical difficulties. Please try again later.</p>
+        <p>You can <a href="/coronavirus">find coronavirus information</a> on GOV.UK.</p>
       </body>
     </html>"};
 

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -620,6 +620,7 @@ sub vcl_error {
       <body>
         <header><h1>GOV.UK</h1></header>
         <p>We're experiencing technical difficulties. Please try again later.</p>
+        <p>You can <a href="/coronavirus">find coronavirus information</a> on GOV.UK.</p>
       </body>
     </html>"};
 

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -534,6 +534,7 @@ sub vcl_error {
       <body>
         <header><h1>GOV.UK</h1></header>
         <p>We're experiencing technical difficulties. Please try again later.</p>
+        <p>You can <a href="/coronavirus">find coronavirus information</a> on GOV.UK.</p>
       </body>
     </html>"};
 


### PR DESCRIPTION
We're anticipating a lot of traffic and want to make sure users can find what they need.