### PR TITLE
Add parts-in-results A/B test

### DIFF
--- a/ab_tests/ab_tests.yaml
+++ b/ab_tests/ab_tests.yaml
@@ -13,3 +13,6 @@
   - F
   - G
   - H
+- ShowPartsInResultsABTest:
+  - unchanged
+  - showparts

--- a/configs/dictionaries/ab_test_expiries.yaml
+++ b/configs/dictionaries/ab_test_expiries.yaml
@@ -7,3 +7,4 @@
 ---
 Example: 86400
 ElectricCarABTest: 86400
+ShowPartsInResultsABTest: 86400

--- a/configs/dictionaries/active_ab_tests.yaml
+++ b/configs/dictionaries/active_ab_tests.yaml
@@ -5,3 +5,4 @@
 ---
 Example: true
 ElectricCarABTest: true
+ShowPartsInResultsABTest: true

--- a/configs/dictionaries/showpartsinresultsabtest_percentages.yaml
+++ b/configs/dictionaries/showpartsinresultsabtest_percentages.yaml
@@ -1,0 +1,3 @@
+---
+unchanged: 50
+showparts: 50

--- a/spec/test-outputs/www-integration.out.vcl
+++ b/spec/test-outputs/www-integration.out.vcl
@@ -260,6 +260,38 @@ if (req.http.Cookie ~ "cookies_policy") {
         }
       }
     }
+    if (table.lookup(active_ab_tests, "ShowPartsInResultsABTest") == "true") {
+      if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
+        set req.http.GOVUK-ABTest-ShowPartsInResultsABTest = "unchanged";
+      } else if (req.url ~ "[\?\&]ABTest-ShowPartsInResultsABTest=unchanged(&|$)") {
+        # Some users, such as remote testers, will be given a URL with a query string
+        # to place them into a specific bucket.
+        set req.http.GOVUK-ABTest-ShowPartsInResultsABTest = "unchanged";
+      } else if (req.url ~ "[\?\&]ABTest-ShowPartsInResultsABTest=showparts(&|$)") {
+        # Some users, such as remote testers, will be given a URL with a query string
+        # to place them into a specific bucket.
+        set req.http.GOVUK-ABTest-ShowPartsInResultsABTest = "showparts";
+      } else if (req.http.Cookie ~ "ABTest-ShowPartsInResultsABTest") {
+        # Set the value of the header to whatever decision was previously made
+        set req.http.GOVUK-ABTest-ShowPartsInResultsABTest = req.http.Cookie:ABTest-ShowPartsInResultsABTest;
+      } else {
+        declare local var.denominator_ShowPartsInResultsABTest INTEGER;
+        declare local var.denominator_ShowPartsInResultsABTest_unchanged INTEGER;
+        declare local var.nominator_ShowPartsInResultsABTest_unchanged INTEGER;
+        set var.nominator_ShowPartsInResultsABTest_unchanged = std.atoi(table.lookup(showpartsinresultsabtest_percentages, "unchanged"));
+        set var.denominator_ShowPartsInResultsABTest += var.nominator_ShowPartsInResultsABTest_unchanged;
+        declare local var.denominator_ShowPartsInResultsABTest_showparts INTEGER;
+        declare local var.nominator_ShowPartsInResultsABTest_showparts INTEGER;
+        set var.nominator_ShowPartsInResultsABTest_showparts = std.atoi(table.lookup(showpartsinresultsabtest_percentages, "showparts"));
+        set var.denominator_ShowPartsInResultsABTest += var.nominator_ShowPartsInResultsABTest_showparts;
+        set var.denominator_ShowPartsInResultsABTest_unchanged = var.denominator_ShowPartsInResultsABTest;
+        if (randombool(var.nominator_ShowPartsInResultsABTest_unchanged, var.denominator_ShowPartsInResultsABTest_unchanged)) {
+          set req.http.GOVUK-ABTest-ShowPartsInResultsABTest = "unchanged";
+        } else {
+          set req.http.GOVUK-ABTest-ShowPartsInResultsABTest = "showparts";
+        }
+      }
+    }
   }
 }
 # End dynamic section
@@ -371,6 +403,16 @@ sub vcl_deliver {
         if (req.http.Cookie !~ "ABTest-ElectricCarABTest" || req.url ~ "[\?\&]ABTest-ElectricCarABTest" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
           set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "ElectricCarABTest"))));
           add resp.http.Set-Cookie = "ABTest-ElectricCarABTest=" req.http.GOVUK-ABTest-ElectricCarABTest "; secure; expires=" var.expiry "; path=/";
+        }
+      }
+    }
+  }
+  if (req.http.Cookie ~ "cookies_policy") {
+    if (req.http.Cookie:cookies_policy ~ "%22usage%22:true") {
+      if (table.lookup(active_ab_tests, "ShowPartsInResultsABTest") == "true") {
+        if (req.http.Cookie !~ "ABTest-ShowPartsInResultsABTest" || req.url ~ "[\?\&]ABTest-ShowPartsInResultsABTest" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
+          set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "ShowPartsInResultsABTest"))));
+          add resp.http.Set-Cookie = "ABTest-ShowPartsInResultsABTest=" req.http.GOVUK-ABTest-ShowPartsInResultsABTest "; secure; expires=" var.expiry "; path=/";
         }
       }
     }

--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -419,6 +419,38 @@ if (req.http.Cookie ~ "cookies_policy") {
         }
       }
     }
+    if (table.lookup(active_ab_tests, "ShowPartsInResultsABTest") == "true") {
+      if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
+        set req.http.GOVUK-ABTest-ShowPartsInResultsABTest = "unchanged";
+      } else if (req.url ~ "[\?\&]ABTest-ShowPartsInResultsABTest=unchanged(&|$)") {
+        # Some users, such as remote testers, will be given a URL with a query string
+        # to place them into a specific bucket.
+        set req.http.GOVUK-ABTest-ShowPartsInResultsABTest = "unchanged";
+      } else if (req.url ~ "[\?\&]ABTest-ShowPartsInResultsABTest=showparts(&|$)") {
+        # Some users, such as remote testers, will be given a URL with a query string
+        # to place them into a specific bucket.
+        set req.http.GOVUK-ABTest-ShowPartsInResultsABTest = "showparts";
+      } else if (req.http.Cookie ~ "ABTest-ShowPartsInResultsABTest") {
+        # Set the value of the header to whatever decision was previously made
+        set req.http.GOVUK-ABTest-ShowPartsInResultsABTest = req.http.Cookie:ABTest-ShowPartsInResultsABTest;
+      } else {
+        declare local var.denominator_ShowPartsInResultsABTest INTEGER;
+        declare local var.denominator_ShowPartsInResultsABTest_unchanged INTEGER;
+        declare local var.nominator_ShowPartsInResultsABTest_unchanged INTEGER;
+        set var.nominator_ShowPartsInResultsABTest_unchanged = std.atoi(table.lookup(showpartsinresultsabtest_percentages, "unchanged"));
+        set var.denominator_ShowPartsInResultsABTest += var.nominator_ShowPartsInResultsABTest_unchanged;
+        declare local var.denominator_ShowPartsInResultsABTest_showparts INTEGER;
+        declare local var.nominator_ShowPartsInResultsABTest_showparts INTEGER;
+        set var.nominator_ShowPartsInResultsABTest_showparts = std.atoi(table.lookup(showpartsinresultsabtest_percentages, "showparts"));
+        set var.denominator_ShowPartsInResultsABTest += var.nominator_ShowPartsInResultsABTest_showparts;
+        set var.denominator_ShowPartsInResultsABTest_unchanged = var.denominator_ShowPartsInResultsABTest;
+        if (randombool(var.nominator_ShowPartsInResultsABTest_unchanged, var.denominator_ShowPartsInResultsABTest_unchanged)) {
+          set req.http.GOVUK-ABTest-ShowPartsInResultsABTest = "unchanged";
+        } else {
+          set req.http.GOVUK-ABTest-ShowPartsInResultsABTest = "showparts";
+        }
+      }
+    }
   }
 }
 # End dynamic section
@@ -530,6 +562,16 @@ sub vcl_deliver {
         if (req.http.Cookie !~ "ABTest-ElectricCarABTest" || req.url ~ "[\?\&]ABTest-ElectricCarABTest" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
           set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "ElectricCarABTest"))));
           add resp.http.Set-Cookie = "ABTest-ElectricCarABTest=" req.http.GOVUK-ABTest-ElectricCarABTest "; secure; expires=" var.expiry "; path=/";
+        }
+      }
+    }
+  }
+  if (req.http.Cookie ~ "cookies_policy") {
+    if (req.http.Cookie:cookies_policy ~ "%22usage%22:true") {
+      if (table.lookup(active_ab_tests, "ShowPartsInResultsABTest") == "true") {
+        if (req.http.Cookie !~ "ABTest-ShowPartsInResultsABTest" || req.url ~ "[\?\&]ABTest-ShowPartsInResultsABTest" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
+          set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "ShowPartsInResultsABTest"))));
+          add resp.http.Set-Cookie = "ABTest-ShowPartsInResultsABTest=" req.http.GOVUK-ABTest-ShowPartsInResultsABTest "; secure; expires=" var.expiry "; path=/";
         }
       }
     }

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -428,6 +428,38 @@ if (req.http.Cookie ~ "cookies_policy") {
         }
       }
     }
+    if (table.lookup(active_ab_tests, "ShowPartsInResultsABTest") == "true") {
+      if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
+        set req.http.GOVUK-ABTest-ShowPartsInResultsABTest = "unchanged";
+      } else if (req.url ~ "[\?\&]ABTest-ShowPartsInResultsABTest=unchanged(&|$)") {
+        # Some users, such as remote testers, will be given a URL with a query string
+        # to place them into a specific bucket.
+        set req.http.GOVUK-ABTest-ShowPartsInResultsABTest = "unchanged";
+      } else if (req.url ~ "[\?\&]ABTest-ShowPartsInResultsABTest=showparts(&|$)") {
+        # Some users, such as remote testers, will be given a URL with a query string
+        # to place them into a specific bucket.
+        set req.http.GOVUK-ABTest-ShowPartsInResultsABTest = "showparts";
+      } else if (req.http.Cookie ~ "ABTest-ShowPartsInResultsABTest") {
+        # Set the value of the header to whatever decision was previously made
+        set req.http.GOVUK-ABTest-ShowPartsInResultsABTest = req.http.Cookie:ABTest-ShowPartsInResultsABTest;
+      } else {
+        declare local var.denominator_ShowPartsInResultsABTest INTEGER;
+        declare local var.denominator_ShowPartsInResultsABTest_unchanged INTEGER;
+        declare local var.nominator_ShowPartsInResultsABTest_unchanged INTEGER;
+        set var.nominator_ShowPartsInResultsABTest_unchanged = std.atoi(table.lookup(showpartsinresultsabtest_percentages, "unchanged"));
+        set var.denominator_ShowPartsInResultsABTest += var.nominator_ShowPartsInResultsABTest_unchanged;
+        declare local var.denominator_ShowPartsInResultsABTest_showparts INTEGER;
+        declare local var.nominator_ShowPartsInResultsABTest_showparts INTEGER;
+        set var.nominator_ShowPartsInResultsABTest_showparts = std.atoi(table.lookup(showpartsinresultsabtest_percentages, "showparts"));
+        set var.denominator_ShowPartsInResultsABTest += var.nominator_ShowPartsInResultsABTest_showparts;
+        set var.denominator_ShowPartsInResultsABTest_unchanged = var.denominator_ShowPartsInResultsABTest;
+        if (randombool(var.nominator_ShowPartsInResultsABTest_unchanged, var.denominator_ShowPartsInResultsABTest_unchanged)) {
+          set req.http.GOVUK-ABTest-ShowPartsInResultsABTest = "unchanged";
+        } else {
+          set req.http.GOVUK-ABTest-ShowPartsInResultsABTest = "showparts";
+        }
+      }
+    }
   }
 }
 # End dynamic section
@@ -539,6 +571,16 @@ sub vcl_deliver {
         if (req.http.Cookie !~ "ABTest-ElectricCarABTest" || req.url ~ "[\?\&]ABTest-ElectricCarABTest" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
           set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "ElectricCarABTest"))));
           add resp.http.Set-Cookie = "ABTest-ElectricCarABTest=" req.http.GOVUK-ABTest-ElectricCarABTest "; secure; expires=" var.expiry "; path=/";
+        }
+      }
+    }
+  }
+  if (req.http.Cookie ~ "cookies_policy") {
+    if (req.http.Cookie:cookies_policy ~ "%22usage%22:true") {
+      if (table.lookup(active_ab_tests, "ShowPartsInResultsABTest") == "true") {
+        if (req.http.Cookie !~ "ABTest-ShowPartsInResultsABTest" || req.url ~ "[\?\&]ABTest-ShowPartsInResultsABTest" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
+          set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "ShowPartsInResultsABTest"))));
+          add resp.http.Set-Cookie = "ABTest-ShowPartsInResultsABTest=" req.http.GOVUK-ABTest-ShowPartsInResultsABTest "; secure; expires=" var.expiry "; path=/";
         }
       }
     }


### PR DESCRIPTION
See also https://github.com/alphagov/finder-frontend/pull/2025

We shouldn't deploy this until the "HTML attachments as parts" work is deployed.

---

[Trello card](https://trello.com/c/sDDx1mn8/1463-display-parts-in-search-results-ab-test)