### PR TITLE
Remove query string stripping of coronavirus pages

### DIFF
--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -203,11 +203,6 @@ sub vcl_recv {
     set req.http.original-url = req.url;
   }
 
-  # Remove querystrings from coronavirus related pages
-  if (req.url.path ~ "(?i)^(/coronavirus|/government/publications/covid-19|/government/publications/full-guidance-on-staying-at-home-and-away-from-others|/government/publications/further-businesses-and-premises-to-close|/government/publications/guidance-to-employers-and-businesses-about-covid-19)") {
-    set req.url = std.tolower(req.url.path);
-  }
-
   # Common config when failover to mirror buckets
   if (req.restarts > 0) {
     set req.url = req.http.original-url;

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -212,11 +212,6 @@ sub vcl_recv {
     set req.http.original-url = req.url;
   }
 
-  # Remove querystrings from coronavirus related pages
-  if (req.url.path ~ "(?i)^(/coronavirus|/government/publications/covid-19|/government/publications/full-guidance-on-staying-at-home-and-away-from-others|/government/publications/further-businesses-and-premises-to-close|/government/publications/guidance-to-employers-and-businesses-about-covid-19)") {
-    set req.url = std.tolower(req.url.path);
-  }
-
   # Common config when failover to mirror buckets
   if (req.restarts > 0) {
     set req.url = req.http.original-url;

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -248,11 +248,6 @@ sub vcl_recv {
     set req.http.original-url = req.url;
   }
 
-  # Remove querystrings from coronavirus related pages
-  if (req.url.path ~ "(?i)^(/coronavirus|/government/publications/covid-19|/government/publications/full-guidance-on-staying-at-home-and-away-from-others|/government/publications/further-businesses-and-premises-to-close|/government/publications/guidance-to-employers-and-businesses-about-covid-19)") {
-    set req.url = std.tolower(req.url.path);
-  }
-
   # Common config when failover to mirror buckets
   if (req.restarts > 0) {
     set req.url = req.http.original-url;


### PR DESCRIPTION
We added this when we were anticipating high levels of traffic on these pages, but it causes confusion when trying to view the latest version of these pages.