### PR TITLE
Remove /static/a endpoint

### DIFF
--- a/spec/test-outputs/assets-integration.out.vcl
+++ b/spec/test-outputs/assets-integration.out.vcl
@@ -68,11 +68,6 @@ sub vcl_recv {
      error 801 "Force SSL";
   }
 
-  # Serve and log an empty response for analytics purposes
-  if (req.url ~ "^/static/a\?") {
-     error 802 "OK";
-  }
-
   # Serve from stale for 24 hours if origin is sick
   set req.grace = 24h;
 
@@ -174,14 +169,6 @@ sub vcl_error {
     set obj.http.Location = "https://" req.http.host req.url;
     synthetic {""};
     return (deliver);
-  }
-
-  if (obj.status == 802) {
-    set obj.http.Content-Type = "text/plain";
-    set obj.http.Access-Control-Allow-Origin = "*";
-    set obj.status = 200;
-    synthetic {""};
-    return(deliver);
   }
 
   # Serve stale from error subroutine as recommended in:

--- a/spec/test-outputs/assets-production.out.vcl
+++ b/spec/test-outputs/assets-production.out.vcl
@@ -169,11 +169,6 @@ sub vcl_recv {
      error 801 "Force SSL";
   }
 
-  # Serve and log an empty response for analytics purposes
-  if (req.url ~ "^/static/a\?") {
-     error 802 "OK";
-  }
-
   # Serve from stale for 24 hours if origin is sick
   set req.grace = 24h;
 
@@ -326,14 +321,6 @@ sub vcl_error {
     set obj.http.Location = "https://" req.http.host req.url;
     synthetic {""};
     return (deliver);
-  }
-
-  if (obj.status == 802) {
-    set obj.http.Content-Type = "text/plain";
-    set obj.http.Access-Control-Allow-Origin = "*";
-    set obj.status = 200;
-    synthetic {""};
-    return(deliver);
   }
 
   # Serve stale from error subroutine as recommended in:

--- a/spec/test-outputs/assets-staging.out.vcl
+++ b/spec/test-outputs/assets-staging.out.vcl
@@ -169,11 +169,6 @@ sub vcl_recv {
      error 801 "Force SSL";
   }
 
-  # Serve and log an empty response for analytics purposes
-  if (req.url ~ "^/static/a\?") {
-     error 802 "OK";
-  }
-
   # Serve from stale for 24 hours if origin is sick
   set req.grace = 24h;
 
@@ -326,14 +321,6 @@ sub vcl_error {
     set obj.http.Location = "https://" req.http.host req.url;
     synthetic {""};
     return (deliver);
-  }
-
-  if (obj.status == 802) {
-    set obj.http.Content-Type = "text/plain";
-    set obj.http.Access-Control-Allow-Origin = "*";
-    set obj.status = 200;
-    synthetic {""};
-    return(deliver);
   }
 
   # Serve stale from error subroutine as recommended in:

--- a/vcl_templates/assets.vcl.erb
+++ b/vcl_templates/assets.vcl.erb
@@ -188,11 +188,6 @@ sub vcl_recv {
      error 801 "Force SSL";
   }
 
-  # Serve and log an empty response for analytics purposes
-  if (req.url ~ "^/static/a\?") {
-     error 802 "OK";
-  }
-
   # Serve from stale for 24 hours if origin is sick
   set req.grace = 24h;
 
@@ -345,14 +340,6 @@ sub vcl_error {
     set obj.http.Location = "https://" req.http.host req.url;
     synthetic {""};
     return (deliver);
-  }
-
-  if (obj.status == 802) {
-    set obj.http.Content-Type = "text/plain";
-    set obj.http.Access-Control-Allow-Origin = "*";
-    set obj.status = 200;
-    synthetic {""};
-    return(deliver);
   }
 
   # Serve stale from error subroutine as recommended in:


### PR DESCRIPTION
The code for this was removed from static in
https://github.com/alphagov/static/pull/2152 and thus this endpoint is
not used anymore. The 802 status response in this host was only used by
this endpoint so can also be removed.