### PR TITLE
revert unreachable 404 statement in vcl_error

### DIFF
--- a/spec/test-outputs/mirror-integration.out.vcl
+++ b/spec/test-outputs/mirror-integration.out.vcl
@@ -214,7 +214,7 @@ sub vcl_error {
     return (deliver);
   }
 
-  if ((obj.status == 804) || (obj.status == 404 && req.restarts > 0)) {
+  if (obj.status == 804) {
     set obj.status = 404;
     set obj.response = "Not Found";
     set obj.http.Fastly-Backend-Name = "force_not_found";

--- a/spec/test-outputs/mirror-production.out.vcl
+++ b/spec/test-outputs/mirror-production.out.vcl
@@ -376,7 +376,7 @@ sub vcl_error {
     return (deliver);
   }
 
-  if ((obj.status == 804) || (obj.status == 404 && req.restarts > 0)) {
+  if (obj.status == 804) {
     set obj.status = 404;
     set obj.response = "Not Found";
     set obj.http.Fastly-Backend-Name = "force_not_found";

--- a/spec/test-outputs/mirror-staging.out.vcl
+++ b/spec/test-outputs/mirror-staging.out.vcl
@@ -376,7 +376,7 @@ sub vcl_error {
     return (deliver);
   }
 
-  if ((obj.status == 804) || (obj.status == 404 && req.restarts > 0)) {
+  if (obj.status == 804) {
     set obj.status = 404;
     set obj.response = "Not Found";
     set obj.http.Fastly-Backend-Name = "force_not_found";

--- a/spec/test-outputs/www-integration.out.vcl
+++ b/spec/test-outputs/www-integration.out.vcl
@@ -390,7 +390,7 @@ sub vcl_error {
     return (deliver);
   }
 
-  if ((obj.status == 804) || (obj.status == 404 && req.restarts > 0)) {
+  if (obj.status == 804) {
     set obj.status = 404;
     set obj.response = "Not Found";
     set obj.http.Fastly-Backend-Name = "force_not_found";

--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -544,7 +544,7 @@ sub vcl_error {
     return (deliver);
   }
 
-  if ((obj.status == 804) || (obj.status == 404 && req.restarts > 0)) {
+  if (obj.status == 804) {
     set obj.status = 404;
     set obj.response = "Not Found";
     set obj.http.Fastly-Backend-Name = "force_not_found";

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -553,7 +553,7 @@ sub vcl_error {
     return (deliver);
   }
 
-  if ((obj.status == 804) || (obj.status == 404 && req.restarts > 0)) {
+  if (obj.status == 804) {
     set obj.status = 404;
     set obj.response = "Not Found";
     set obj.http.Fastly-Backend-Name = "force_not_found";

--- a/vcl_templates/mirror.vcl.erb
+++ b/vcl_templates/mirror.vcl.erb
@@ -413,7 +413,7 @@ sub vcl_error {
     return (deliver);
   }
 
-  if ((obj.status == 804) || (obj.status == 404 && req.restarts > 0)) {
+  if (obj.status == 804) {
     set obj.status = 404;
     set obj.response = "Not Found";
     set obj.http.Fastly-Backend-Name = "force_not_found";

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -461,7 +461,7 @@ sub vcl_error {
     return (deliver);
   }
 
-  if ((obj.status == 804) || (obj.status == 404 && req.restarts > 0)) {
+  if (obj.status == 804) {
     set obj.status = 404;
     set obj.response = "Not Found";
     set obj.http.Fastly-Backend-Name = "force_not_found";


### PR DESCRIPTION
we need to revert unreachable 404 statement in vcl_error. This was introduced in: https://github.com/alphagov/govuk-cdn-config/pull/164 but the actual effective PR was: https://github.com/alphagov/govuk-cdn-config/pull/167