### PR TITLE
Extend default rake task with rubocop linting

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,4 +5,9 @@ require "rspec/core/rake_task"
 RuboCop::RakeTask.new
 RSpec::Core::RakeTask.new
 
-task default: %i[rubocop spec]
+desc "Lint Ruby"
+task :lint do
+  sh "bundle exec rubocop --format clang"
+end
+
+task default: %i[rubocop spec lint]


### PR DESCRIPTION
[Trello card](https://trello.com/c/5Gob6WUL/147-for-everyone-ensure-that-rubocop-runs-as-part-of-bundle-exec-rake-as-one-of-the-default-tasks)