### PR TITLE
Update terminology and allow banning IP addresses in more services

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Script: [deploy-dictionaries.sh](/deploy-dictionaries.sh)
 Invoked via the [CDN: update dictionaries](https://deploy.publishing.service.gov.uk/job/Update_CDN_Dictionaries) Jenkins job.
 
 Fastly provide a technology called [Edge Dictionaries](https://docs.fastly.com/guides/edge-dictionaries/)
-which can be used to provide dynamic configuration to VCL. This script takes updates dictionaries defined in YAML files in [configs/dictionaries](/configs/dictionaries). We use it for [A/B testing](#ab-testing) and blocking IP addresses (the dictionary for this lives in [alphagov/govuk-cdn-config-secrets](https://github.com/alphagov/govuk-cdn-config-secrets/blob/master/fastly/dictionaries/config/ip_address_blacklist.yaml) - read [more about IP banning](https://docs.publishing.service.gov.uk/manual/cdn.html#banning-ip-addresses-at-the-cdn-edge) in the docs).
+which can be used to provide dynamic configuration to VCL. This script takes updates dictionaries defined in YAML files in [configs/dictionaries](/configs/dictionaries). We use it for [A/B testing](#ab-testing) and blocking IP addresses (the dictionary for this lives in [alphagov/govuk-cdn-config-secrets](https://github.com/alphagov/govuk-cdn-config-secrets/blob/master/fastly/dictionaries/config/ip_address_denylist.yaml) - read [more about IP banning](https://docs.publishing.service.gov.uk/manual/cdn.html#banning-ip-addresses-at-the-cdn-edge) in the docs).
 
 ### Deploy Bouncer
 

--- a/spec/test-outputs/assets-integration.out.vcl
+++ b/spec/test-outputs/assets-integration.out.vcl
@@ -32,7 +32,7 @@ backend F_awsorigin {
 
 
 
-acl purge_ip_whitelist {
+acl purge_ip_allowlist {
   "37.26.93.252";     # Skyscape mirrors
   "31.210.241.100";   # Carrenza mirrors
 
@@ -59,7 +59,7 @@ acl purge_ip_whitelist {
 sub vcl_recv {
 
   # Require authentication for FASTLYPURGE requests unless from IP in ACL
-  if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_whitelist) {
+  if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_allowlist) {
     set req.http.Fastly-Purge-Requires-Auth = "1";
   }
 

--- a/spec/test-outputs/assets-integration.out.vcl
+++ b/spec/test-outputs/assets-integration.out.vcl
@@ -63,6 +63,11 @@ sub vcl_recv {
     set req.http.Fastly-Purge-Requires-Auth = "1";
   }
 
+  # Check whether the remote IP address is in the list of blocked IPs
+  if (table.lookup(ip_address_denylist, client.ip)) {
+    error 403 "Forbidden";
+  }
+
   # Force SSL.
   if (!req.http.Fastly-SSL) {
      error 801 "Force SSL";

--- a/spec/test-outputs/assets-production.out.vcl
+++ b/spec/test-outputs/assets-production.out.vcl
@@ -164,6 +164,11 @@ sub vcl_recv {
     set req.http.Fastly-Purge-Requires-Auth = "1";
   }
 
+  # Check whether the remote IP address is in the list of blocked IPs
+  if (table.lookup(ip_address_denylist, client.ip)) {
+    error 403 "Forbidden";
+  }
+
   # Force SSL.
   if (!req.http.Fastly-SSL) {
      error 801 "Force SSL";

--- a/spec/test-outputs/assets-production.out.vcl
+++ b/spec/test-outputs/assets-production.out.vcl
@@ -128,7 +128,7 @@ backend F_mirrorGCS {
 }
 
 
-acl purge_ip_whitelist {
+acl purge_ip_allowlist {
   "37.26.93.252";     # Skyscape mirrors
   "31.210.241.100";   # Carrenza mirrors
 
@@ -160,7 +160,7 @@ acl purge_ip_whitelist {
 sub vcl_recv {
 
   # Require authentication for FASTLYPURGE requests unless from IP in ACL
-  if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_whitelist) {
+  if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_allowlist) {
     set req.http.Fastly-Purge-Requires-Auth = "1";
   }
 

--- a/spec/test-outputs/assets-staging.out.vcl
+++ b/spec/test-outputs/assets-staging.out.vcl
@@ -164,6 +164,11 @@ sub vcl_recv {
     set req.http.Fastly-Purge-Requires-Auth = "1";
   }
 
+  # Check whether the remote IP address is in the list of blocked IPs
+  if (table.lookup(ip_address_denylist, client.ip)) {
+    error 403 "Forbidden";
+  }
+
   # Force SSL.
   if (!req.http.Fastly-SSL) {
      error 801 "Force SSL";

--- a/spec/test-outputs/assets-staging.out.vcl
+++ b/spec/test-outputs/assets-staging.out.vcl
@@ -128,7 +128,7 @@ backend F_mirrorGCS {
 }
 
 
-acl purge_ip_whitelist {
+acl purge_ip_allowlist {
   "37.26.93.252";     # Skyscape mirrors
   "31.210.241.100";   # Carrenza mirrors
 
@@ -160,7 +160,7 @@ acl purge_ip_whitelist {
 sub vcl_recv {
 
   # Require authentication for FASTLYPURGE requests unless from IP in ACL
-  if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_whitelist) {
+  if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_allowlist) {
     set req.http.Fastly-Purge-Requires-Auth = "1";
   }
 

--- a/spec/test-outputs/mirror-integration.out.vcl
+++ b/spec/test-outputs/mirror-integration.out.vcl
@@ -31,7 +31,7 @@ backend F_origin {
 
 
 
-acl purge_ip_whitelist {
+acl purge_ip_allowlist {
   "37.26.93.252";     # Skyscape mirrors
   "31.210.241.100";   # Carrenza mirrors
 
@@ -62,7 +62,7 @@ acl allowed_ip_addresses {
 sub vcl_recv {
 
   # Require authentication for FASTLYPURGE requests unless from IP in ACL
-  if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_whitelist) {
+  if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_allowlist) {
     set req.http.Fastly-Purge-Requires-Auth = "1";
   }
 

--- a/spec/test-outputs/mirror-integration.out.vcl
+++ b/spec/test-outputs/mirror-integration.out.vcl
@@ -72,7 +72,7 @@ sub vcl_recv {
   }
 
   # Check whether the remote IP address is in the list of blocked IPs
-  if (table.lookup(ip_address_blacklist, client.ip)) {
+  if (table.lookup(ip_address_denylist, client.ip)) {
     error 403 "Forbidden";
   }
 

--- a/spec/test-outputs/mirror-production.out.vcl
+++ b/spec/test-outputs/mirror-production.out.vcl
@@ -173,7 +173,7 @@ sub vcl_recv {
   }
 
   # Check whether the remote IP address is in the list of blocked IPs
-  if (table.lookup(ip_address_blacklist, client.ip)) {
+  if (table.lookup(ip_address_denylist, client.ip)) {
     error 403 "Forbidden";
   }
 

--- a/spec/test-outputs/mirror-production.out.vcl
+++ b/spec/test-outputs/mirror-production.out.vcl
@@ -127,7 +127,7 @@ backend F_mirrorGCS {
 }
 
 
-acl purge_ip_whitelist {
+acl purge_ip_allowlist {
   "37.26.93.252";     # Skyscape mirrors
   "31.210.241.100";   # Carrenza mirrors
 
@@ -163,7 +163,7 @@ acl allowed_ip_addresses {
 sub vcl_recv {
 
   # Require authentication for FASTLYPURGE requests unless from IP in ACL
-  if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_whitelist) {
+  if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_allowlist) {
     set req.http.Fastly-Purge-Requires-Auth = "1";
   }
 

--- a/spec/test-outputs/mirror-staging.out.vcl
+++ b/spec/test-outputs/mirror-staging.out.vcl
@@ -173,7 +173,7 @@ sub vcl_recv {
   }
 
   # Check whether the remote IP address is in the list of blocked IPs
-  if (table.lookup(ip_address_blacklist, client.ip)) {
+  if (table.lookup(ip_address_denylist, client.ip)) {
     error 403 "Forbidden";
   }
 

--- a/spec/test-outputs/mirror-staging.out.vcl
+++ b/spec/test-outputs/mirror-staging.out.vcl
@@ -127,7 +127,7 @@ backend F_mirrorGCS {
 }
 
 
-acl purge_ip_whitelist {
+acl purge_ip_allowlist {
   "37.26.93.252";     # Skyscape mirrors
   "31.210.241.100";   # Carrenza mirrors
 
@@ -163,7 +163,7 @@ acl allowed_ip_addresses {
 sub vcl_recv {
 
   # Require authentication for FASTLYPURGE requests unless from IP in ACL
-  if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_whitelist) {
+  if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_allowlist) {
     set req.http.Fastly-Purge-Requires-Auth = "1";
   }
 

--- a/spec/test-outputs/performanceplatform-integration.out.vcl
+++ b/spec/test-outputs/performanceplatform-integration.out.vcl
@@ -70,6 +70,11 @@ sub vcl_recv {
     set req.http.Fastly-Purge-Requires-Auth = "1";
   }
 
+  # Check whether the remote IP address is in the list of blocked IPs
+  if (table.lookup(ip_address_denylist, client.ip)) {
+    error 403 "Forbidden";
+  }
+
   # Force SSL.
   if (!req.http.Fastly-SSL) {
      error 801 "Force SSL";

--- a/spec/test-outputs/performanceplatform-integration.out.vcl
+++ b/spec/test-outputs/performanceplatform-integration.out.vcl
@@ -40,7 +40,7 @@ backend sick_force_grace {
 }
 
 
-acl purge_ip_whitelist {
+acl purge_ip_allowlist {
   "37.26.93.252";     # Skyscape mirrors
   "31.210.241.100";   # Carrenza mirrors
   "23.235.32.0"/20;   # Fastly cache node
@@ -66,7 +66,7 @@ acl purge_ip_whitelist {
 sub vcl_recv {
 
   # Require authentication for FASTLYPURGE requests unless from IP in ACL
-  if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_whitelist) {
+  if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_allowlist) {
     set req.http.Fastly-Purge-Requires-Auth = "1";
   }
 

--- a/spec/test-outputs/performanceplatform-production.out.vcl
+++ b/spec/test-outputs/performanceplatform-production.out.vcl
@@ -70,6 +70,11 @@ sub vcl_recv {
     set req.http.Fastly-Purge-Requires-Auth = "1";
   }
 
+  # Check whether the remote IP address is in the list of blocked IPs
+  if (table.lookup(ip_address_denylist, client.ip)) {
+    error 403 "Forbidden";
+  }
+
   # Force SSL.
   if (!req.http.Fastly-SSL) {
      error 801 "Force SSL";

--- a/spec/test-outputs/performanceplatform-production.out.vcl
+++ b/spec/test-outputs/performanceplatform-production.out.vcl
@@ -40,7 +40,7 @@ backend sick_force_grace {
 }
 
 
-acl purge_ip_whitelist {
+acl purge_ip_allowlist {
   "37.26.93.252";     # Skyscape mirrors
   "31.210.241.100";   # Carrenza mirrors
   "23.235.32.0"/20;   # Fastly cache node
@@ -66,7 +66,7 @@ acl purge_ip_whitelist {
 sub vcl_recv {
 
   # Require authentication for FASTLYPURGE requests unless from IP in ACL
-  if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_whitelist) {
+  if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_allowlist) {
     set req.http.Fastly-Purge-Requires-Auth = "1";
   }
 

--- a/spec/test-outputs/performanceplatform-staging.out.vcl
+++ b/spec/test-outputs/performanceplatform-staging.out.vcl
@@ -70,6 +70,11 @@ sub vcl_recv {
     set req.http.Fastly-Purge-Requires-Auth = "1";
   }
 
+  # Check whether the remote IP address is in the list of blocked IPs
+  if (table.lookup(ip_address_denylist, client.ip)) {
+    error 403 "Forbidden";
+  }
+
   # Force SSL.
   if (!req.http.Fastly-SSL) {
      error 801 "Force SSL";

--- a/spec/test-outputs/performanceplatform-staging.out.vcl
+++ b/spec/test-outputs/performanceplatform-staging.out.vcl
@@ -40,7 +40,7 @@ backend sick_force_grace {
 }
 
 
-acl purge_ip_whitelist {
+acl purge_ip_allowlist {
   "37.26.93.252";     # Skyscape mirrors
   "31.210.241.100";   # Carrenza mirrors
   "23.235.32.0"/20;   # Fastly cache node
@@ -66,7 +66,7 @@ acl purge_ip_whitelist {
 sub vcl_recv {
 
   # Require authentication for FASTLYPURGE requests unless from IP in ACL
-  if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_whitelist) {
+  if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_allowlist) {
     set req.http.Fastly-Purge-Requires-Auth = "1";
   }
 

--- a/spec/test-outputs/www-integration.out.vcl
+++ b/spec/test-outputs/www-integration.out.vcl
@@ -31,7 +31,7 @@ backend F_origin {
 
 
 
-acl purge_ip_whitelist {
+acl purge_ip_allowlist {
   "37.26.93.252";     # Skyscape mirrors
   "31.210.241.100";   # Carrenza mirrors
 
@@ -68,7 +68,7 @@ acl allowed_ip_addresses {
 sub vcl_recv {
 
   # Require authentication for FASTLYPURGE requests unless from IP in ACL
-  if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_whitelist) {
+  if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_allowlist) {
     set req.http.Fastly-Purge-Requires-Auth = "1";
   }
 

--- a/spec/test-outputs/www-integration.out.vcl
+++ b/spec/test-outputs/www-integration.out.vcl
@@ -75,7 +75,7 @@ sub vcl_recv {
   
 
   # Check whether the remote IP address is in the list of blocked IPs
-  if (table.lookup(ip_address_blacklist, client.ip)) {
+  if (table.lookup(ip_address_denylist, client.ip)) {
     error 403 "Forbidden";
   }
 

--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -168,7 +168,7 @@ sub vcl_recv {
   
 
   # Check whether the remote IP address is in the list of blocked IPs
-  if (table.lookup(ip_address_blacklist, client.ip)) {
+  if (table.lookup(ip_address_denylist, client.ip)) {
     error 403 "Forbidden";
   }
 

--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -127,7 +127,7 @@ backend F_mirrorGCS {
 }
 
 
-acl purge_ip_whitelist {
+acl purge_ip_allowlist {
   "37.26.93.252";     # Skyscape mirrors
   "31.210.241.100";   # Carrenza mirrors
 
@@ -161,7 +161,7 @@ acl purge_ip_whitelist {
 sub vcl_recv {
 
   # Require authentication for FASTLYPURGE requests unless from IP in ACL
-  if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_whitelist) {
+  if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_allowlist) {
     set req.http.Fastly-Purge-Requires-Auth = "1";
   }
 

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -127,7 +127,7 @@ backend F_mirrorGCS {
 }
 
 
-acl purge_ip_whitelist {
+acl purge_ip_allowlist {
   "37.26.93.252";     # Skyscape mirrors
   "31.210.241.100";   # Carrenza mirrors
 
@@ -165,7 +165,7 @@ acl allowed_ip_addresses {
 sub vcl_recv {
 
   # Require authentication for FASTLYPURGE requests unless from IP in ACL
-  if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_whitelist) {
+  if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_allowlist) {
     set req.http.Fastly-Purge-Requires-Auth = "1";
   }
 

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -177,7 +177,7 @@ sub vcl_recv {
   
 
   # Check whether the remote IP address is in the list of blocked IPs
-  if (table.lookup(ip_address_blacklist, client.ip)) {
+  if (table.lookup(ip_address_denylist, client.ip)) {
     error 403 "Forbidden";
   }
 

--- a/vcl_templates/assets.vcl.erb
+++ b/vcl_templates/assets.vcl.erb
@@ -183,6 +183,11 @@ sub vcl_recv {
     set req.http.Fastly-Purge-Requires-Auth = "1";
   }
 
+  # Check whether the remote IP address is in the list of blocked IPs
+  if (table.lookup(ip_address_denylist, client.ip)) {
+    error 403 "Forbidden";
+  }
+
   # Force SSL.
   if (!req.http.Fastly-SSL) {
      error 801 "Force SSL";

--- a/vcl_templates/assets.vcl.erb
+++ b/vcl_templates/assets.vcl.erb
@@ -142,7 +142,7 @@ backend F_mirrorGCS {
 }
 <% end %>
 
-acl purge_ip_whitelist {
+acl purge_ip_allowlist {
   "37.26.93.252";     # Skyscape mirrors
   "31.210.241.100";   # Carrenza mirrors
 <% if environment == 'staging' %>
@@ -179,7 +179,7 @@ acl purge_ip_whitelist {
 sub vcl_recv {
 
   # Require authentication for FASTLYPURGE requests unless from IP in ACL
-  if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_whitelist) {
+  if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_allowlist) {
     set req.http.Fastly-Purge-Requires-Auth = "1";
   }
 

--- a/vcl_templates/bouncer.vcl.erb
+++ b/vcl_templates/bouncer.vcl.erb
@@ -49,7 +49,7 @@ backend sick_force_grace {
 }
 
 
-acl purge_ip_whitelist {
+acl purge_ip_allowlist {
   "80.194.77.90";    # Aviation House
   "80.194.77.100";   # Aviation House
   "213.86.153.212";  # White Chapel Building
@@ -63,7 +63,7 @@ acl purge_ip_whitelist {
 sub vcl_recv {
 
   # Require authentication for FASTLYPURGE requests unless from IP in ACL
-  if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_whitelist) {
+  if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_allowlist) {
     set req.http.Fastly-Purge-Requires-Auth = "1";
   }
 

--- a/vcl_templates/bouncer.vcl.erb
+++ b/vcl_templates/bouncer.vcl.erb
@@ -67,6 +67,11 @@ sub vcl_recv {
     set req.http.Fastly-Purge-Requires-Auth = "1";
   }
 
+  # Check whether the remote IP address is in the list of blocked IPs
+  if (table.lookup(ip_address_denylist, client.ip)) {
+    error 403 "Forbidden";
+  }
+
   # Serve a 404 Not Found response if request URL matches "/autodiscover/autodiscover.xml"
   if (req.url.path ~ "(?i)/autodiscover/autodiscover.xml$") {
     error 804 "Not Found";

--- a/vcl_templates/mirror.vcl.erb
+++ b/vcl_templates/mirror.vcl.erb
@@ -145,7 +145,7 @@ backend F_mirrorGCS {
 }
 <% end %>
 
-acl purge_ip_whitelist {
+acl purge_ip_allowlist {
   "37.26.93.252";     # Skyscape mirrors
   "31.210.241.100";   # Carrenza mirrors
 <% if environment == 'staging' %>
@@ -188,7 +188,7 @@ acl allowed_ip_addresses {
 sub vcl_recv {
 
   # Require authentication for FASTLYPURGE requests unless from IP in ACL
-  if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_whitelist) {
+  if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_allowlist) {
     set req.http.Fastly-Purge-Requires-Auth = "1";
   }
 

--- a/vcl_templates/mirror.vcl.erb
+++ b/vcl_templates/mirror.vcl.erb
@@ -198,7 +198,7 @@ sub vcl_recv {
   }
 
   # Check whether the remote IP address is in the list of blocked IPs
-  if (table.lookup(ip_address_blacklist, client.ip)) {
+  if (table.lookup(ip_address_denylist, client.ip)) {
     error 403 "Forbidden";
   }
 

--- a/vcl_templates/performanceplatform.vcl.erb
+++ b/vcl_templates/performanceplatform.vcl.erb
@@ -75,6 +75,11 @@ sub vcl_recv {
     set req.http.Fastly-Purge-Requires-Auth = "1";
   }
 
+  # Check whether the remote IP address is in the list of blocked IPs
+  if (table.lookup(ip_address_denylist, client.ip)) {
+    error 403 "Forbidden";
+  }
+
   # Force SSL.
   if (!req.http.Fastly-SSL) {
      error 801 "Force SSL";

--- a/vcl_templates/performanceplatform.vcl.erb
+++ b/vcl_templates/performanceplatform.vcl.erb
@@ -45,7 +45,7 @@ backend sick_force_grace {
 }
 
 
-acl purge_ip_whitelist {
+acl purge_ip_allowlist {
   "37.26.93.252";     # Skyscape mirrors
   "31.210.241.100";   # Carrenza mirrors
   "23.235.32.0"/20;   # Fastly cache node
@@ -71,7 +71,7 @@ acl purge_ip_whitelist {
 sub vcl_recv {
 
   # Require authentication for FASTLYPURGE requests unless from IP in ACL
-  if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_whitelist) {
+  if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_allowlist) {
     set req.http.Fastly-Purge-Requires-Auth = "1";
   }
 

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -145,7 +145,7 @@ backend F_mirrorGCS {
 }
 <% end %>
 
-acl purge_ip_whitelist {
+acl purge_ip_allowlist {
   "37.26.93.252";     # Skyscape mirrors
   "31.210.241.100";   # Carrenza mirrors
 <% if environment == 'integration' %>
@@ -194,7 +194,7 @@ acl allowed_ip_addresses {
 sub vcl_recv {
 
   # Require authentication for FASTLYPURGE requests unless from IP in ACL
-  if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_whitelist) {
+  if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_allowlist) {
     set req.http.Fastly-Purge-Requires-Auth = "1";
   }
 

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -206,7 +206,7 @@ sub vcl_recv {
   <% end %>
 
   # Check whether the remote IP address is in the list of blocked IPs
-  if (table.lookup(ip_address_blacklist, client.ip)) {
+  if (table.lookup(ip_address_denylist, client.ip)) {
     error 403 "Forbidden";
   }
 


### PR DESCRIPTION
This updates the terminology used in this repo to reflect GDS guidance:  https://docs.google.com/document/d/1LpBxQ9zJZp7c4eygTMWBQzGNtb9hMh-2SEV3jOlLLxY/edit?ts=5f10079a#

It then updates the assets, bouncer, and performanceplatform services to allow them to accept the denylist for ip addresses so that IP's can be banned from all services rather than just one and cause confusion.

There is a similar PR open for govuk-cdn-config-secrets: https://github.com/alphagov/govuk-cdn-config-secrets/pull/129 and there will be a puppet PR to allow updating the dictionaries.