### PR TITLE
Revert ip banning at bouncer

### DIFF
--- a/vcl_templates/bouncer.vcl.erb
+++ b/vcl_templates/bouncer.vcl.erb
@@ -67,11 +67,6 @@ sub vcl_recv {
     set req.http.Fastly-Purge-Requires-Auth = "1";
   }
 
-  # Check whether the remote IP address is in the list of blocked IPs
-  if (table.lookup(ip_address_denylist, client.ip)) {
-    error 403 "Forbidden";
-  }
-
   # Serve a 404 Not Found response if request URL matches "/autodiscover/autodiscover.xml"
   if (req.url.path ~ "(?i)/autodiscover/autodiscover.xml$") {
     error 804 "Not Found";


### PR DESCRIPTION
Since bouncer is handled differently to the other VCL services with a
different deployment process this wasn't easy to apply consistently. I'm
removing this for now and we can consider adding it back in were we to
establish a point of need for it.