### PR TITLE
Remove query params from requests to Eat Out to Help Out Scheme page

### DIFF
--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -203,6 +203,11 @@ sub vcl_recv {
     set req.http.original-url = req.url;
   }
 
+  # Remove querystrings from Eat Out To Help Out page
+  if (req.url.path ~ "(?i)^(/guidance/get-a-discount-with-the-eat-out-to-help-out-scheme)") {
+    set req.url = std.tolower(req.url.path);
+  }
+
   # Common config when failover to mirror buckets
   if (req.restarts > 0) {
     set req.url = req.http.original-url;

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -212,6 +212,11 @@ sub vcl_recv {
     set req.http.original-url = req.url;
   }
 
+  # Remove querystrings from Eat Out To Help Out page
+  if (req.url.path ~ "(?i)^(/guidance/get-a-discount-with-the-eat-out-to-help-out-scheme)") {
+    set req.url = std.tolower(req.url.path);
+  }
+
   # Common config when failover to mirror buckets
   if (req.restarts > 0) {
     set req.url = req.http.original-url;

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -248,6 +248,11 @@ sub vcl_recv {
     set req.http.original-url = req.url;
   }
 
+  # Remove querystrings from Eat Out To Help Out page
+  if (req.url.path ~ "(?i)^(/guidance/get-a-discount-with-the-eat-out-to-help-out-scheme)") {
+    set req.url = std.tolower(req.url.path);
+  }
+
   # Common config when failover to mirror buckets
   if (req.restarts > 0) {
     set req.url = req.http.original-url;


### PR DESCRIPTION
We are anticipating increased traffic to this page and need to ensure
that is served from cache as much as possible.

[Trello](https://trello.com/c/3YPZiLhl/2091-strip-querystrings-from-eat-out-to-help-out-page)