### PR TITLE
Set a 30 second interval for bouncer healthchecks

### DIFF
--- a/vcl_templates/bouncer.vcl.erb
+++ b/vcl_templates/bouncer.vcl.erb
@@ -16,6 +16,7 @@ backend F_origin0 {
         .threshold = 1;
         .timeout = 2s;
         .initial = 5;
+        .interval = 30s;
       }
 }
 
@@ -35,6 +36,7 @@ backend F_origin1 {
         .threshold = 1;
         .timeout = 2s;
         .initial = 5;
+        .interval = 30s;
       }
 }
 


### PR DESCRIPTION
There are so many requests, I'm hoping this will reduce the
number. I'm not sure about the usefulness of the Fastly healthcheck
for bouncer, as I'm not sure what it should do differently if the
healthcheck fails...