### PR TITLE
Remove the disaster recovery backend for bouncer

### DIFF
--- a/vcl_templates/bouncer.vcl.erb
+++ b/vcl_templates/bouncer.vcl.erb
@@ -8,36 +8,6 @@ backend F_origin0 {
     .max_connections = 200;
     .between_bytes_timeout = 10s;
     .share_key = "<%= service_id %>";
-
-
-    .probe = {
-        .request = "HEAD /healthcheck HTTP/1.1"  "Host: bouncer.<%= app_domain %>" "Connection: close";
-        .window = 5;
-        .threshold = 1;
-        .timeout = 2s;
-        .initial = 5;
-        .interval = 30s;
-      }
-}
-
-backend F_origin1 {
-    .connect_timeout = 1s;
-    .dynamic = true;
-    .port = "80";
-    .host = "bouncer-dr.<%= app_domain %>";
-    .first_byte_timeout = 15s;
-    .max_connections = 200;
-    .between_bytes_timeout = 10s;
-    .share_key = "<%= service_id %>";
-
-    .probe = {
-        .request = "HEAD /healthcheck HTTP/1.1"  "Host: bouncer-dr.<%= app_domain %>" "Connection: close";
-        .window = 5;
-        .threshold = 1;
-        .timeout = 2s;
-        .initial = 5;
-        .interval = 30s;
-      }
 }
 
 backend sick_force_grace {
@@ -91,15 +61,6 @@ sub vcl_recv {
   if (req.restarts > 0) {
     set req.backend = sick_force_grace;
     set req.http.Fastly-Backend-Name = "stale";
-  }
-
-  # Failover to origin1.
-  if (req.restarts > 1) {
-    # Don't serve from stale from DR
-    set req.grace = 0s;
-    set req.http.Fastly-Failover = "1";
-
-    set req.backend = F_origin1;
   }
 
 


### PR DESCRIPTION
As it doesn't exist, at least now Bouncer is running in AWS. I believe
this also removes the need for a healthcheck, since there's only one
backend to use, you don't need the healthcheck to know when to
failover.