### PR TITLE
Restore the Bouncer backend probe

### DIFF
--- a/vcl_templates/bouncer.vcl.erb
+++ b/vcl_templates/bouncer.vcl.erb
@@ -8,6 +8,14 @@ backend F_origin0 {
     .max_connections = 200;
     .between_bytes_timeout = 10s;
     .share_key = "<%= service_id %>";
+
+    .probe = {
+        .request = "HEAD /healthcheck HTTP/1.1"  "Host: bouncer.<%= app_domain %>" "Connection: close";
+        .window = 2;
+        .threshold = 1;
+        .timeout = 2s;
+        .interval = 5m;
+      }
 }
 
 backend sick_force_grace {


### PR DESCRIPTION
As Fastly/Varnish don't like it being removed. A dynamic backend must
have a probe, and the backend must be dynamic to use a hostname.

This is adding back the probe, but further increasing the interval
since I don't think there's much value in sending probe requests very
frequently.