### PR TITLE
Revert "Remove query params from requests to Eat Out to Help Out Scheme page"

### DIFF
--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -203,11 +203,6 @@ sub vcl_recv {
     set req.http.original-url = req.url;
   }
 
-  # Remove querystrings from Eat Out To Help Out page
-  if (req.url.path ~ "(?i)^(/guidance/get-a-discount-with-the-eat-out-to-help-out-scheme)") {
-    set req.url = std.tolower(req.url.path);
-  }
-
   # Common config when failover to mirror buckets
   if (req.restarts > 0) {
     set req.url = req.http.original-url;

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -212,11 +212,6 @@ sub vcl_recv {
     set req.http.original-url = req.url;
   }
 
-  # Remove querystrings from Eat Out To Help Out page
-  if (req.url.path ~ "(?i)^(/guidance/get-a-discount-with-the-eat-out-to-help-out-scheme)") {
-    set req.url = std.tolower(req.url.path);
-  }
-
   # Common config when failover to mirror buckets
   if (req.restarts > 0) {
     set req.url = req.http.original-url;

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -248,11 +248,6 @@ sub vcl_recv {
     set req.http.original-url = req.url;
   }
 
-  # Remove querystrings from Eat Out To Help Out page
-  if (req.url.path ~ "(?i)^(/guidance/get-a-discount-with-the-eat-out-to-help-out-scheme)") {
-    set req.url = std.tolower(req.url.path);
-  }
-
   # Common config when failover to mirror buckets
   if (req.restarts > 0) {
     set req.url = req.http.original-url;


### PR DESCRIPTION
Reverts alphagov/govuk-cdn-config#276

The scheme is over now so we don't need to be striping query strings anymore.