### PR TITLE
Put the user in an A/B bucket based on whether they're logged in

### DIFF
--- a/spec/test-outputs/www-integration.out.vcl
+++ b/spec/test-outputs/www-integration.out.vcl
@@ -121,6 +121,12 @@ sub vcl_recv {
     return(pass);
   }
 
+  if (req.http.Cookie ~ "_finder-frontend_account_session") {
+    set req.http.GOVUK-ABTest-AccountExperiment = "LoggedIn";
+  } else {
+    set req.http.GOVUK-ABTest-AccountExperiment = "LoggedOut";
+  }
+
     # Begin dynamic section
 if (req.http.Cookie ~ "cookies_policy") {
   if (req.http.Cookie:cookies_policy ~ "%22usage%22:true") {

--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -275,6 +275,12 @@ sub vcl_recv {
     return(pass);
   }
 
+  if (req.http.Cookie ~ "_finder-frontend_account_session") {
+    set req.http.GOVUK-ABTest-AccountExperiment = "LoggedIn";
+  } else {
+    set req.http.GOVUK-ABTest-AccountExperiment = "LoggedOut";
+  }
+
     # Begin dynamic section
 if (req.http.Cookie ~ "cookies_policy") {
   if (req.http.Cookie:cookies_policy ~ "%22usage%22:true") {

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -284,6 +284,12 @@ sub vcl_recv {
     return(pass);
   }
 
+  if (req.http.Cookie ~ "_finder-frontend_account_session") {
+    set req.http.GOVUK-ABTest-AccountExperiment = "LoggedIn";
+  } else {
+    set req.http.GOVUK-ABTest-AccountExperiment = "LoggedOut";
+  }
+
     # Begin dynamic section
 if (req.http.Cookie ~ "cookies_policy") {
   if (req.http.Cookie:cookies_policy ~ "%22usage%22:true") {

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -325,6 +325,12 @@ sub vcl_recv {
     return(pass);
   }
 
+  if (req.http.Cookie ~ "_finder-frontend_account_session") {
+    set req.http.GOVUK-ABTest-AccountExperiment = "LoggedIn";
+  } else {
+    set req.http.GOVUK-ABTest-AccountExperiment = "LoggedOut";
+  }
+
   <% template_path = File.join(File.dirname(__FILE__), "vcl_templates/_multivariate_tests.vcl.erb") -%>
   <%= ERB.new(File.new(template_path).read, nil, "-", "_erbout2").result(binding) %>
 


### PR DESCRIPTION
We want to show an accounts-related header on /transition and in the
transition checker, with either sign in or sign out links.

A/B testing feels like a slightly weird way to do this, because it's
not an A/B test, but it is an established technique we have for
displaying variants of GOV.UK pages which plays nicely with caching.

We should revisit this when we address the larger topic of how to be
logged in across GOV.UK (rather than logged in to one app).

---

The cookie was introduced in https://github.com/alphagov/finder-frontend/pull/2263

---

[Trello card](https://trello.com/c/uV2ZSNzH/376-put-the-user-in-an-a-b-bucket-based-on-the-presence-of-the-accounts-session-cookie)