### PR TITLE
Reset proxy headers to avoid spoofing alerts

### DIFF
--- a/spec/test-outputs/www-integration.out.vcl
+++ b/spec/test-outputs/www-integration.out.vcl
@@ -105,8 +105,12 @@ sub vcl_recv {
 
   
 
-  # Unspoofable original client address.
+  # Unspoofable original client address (e.g. for rate limiting).
   set req.http.True-Client-IP = req.http.Fastly-Client-IP;
+
+  # Reset proxy headers at the boundary to our network.
+  unset req.http.Client-IP;
+  set req.http.X-Forwarded-For = req.http.Fastly-Client-IP;
 
   # Set a TLSversion request header for requests going to the Licensify application
   # This is used to block unsecure requests at the application level for payment security reasons and an absence of caching in Licensify

--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -259,8 +259,12 @@ sub vcl_recv {
   }
   
 
-  # Unspoofable original client address.
+  # Unspoofable original client address (e.g. for rate limiting).
   set req.http.True-Client-IP = req.http.Fastly-Client-IP;
+
+  # Reset proxy headers at the boundary to our network.
+  unset req.http.Client-IP;
+  set req.http.X-Forwarded-For = req.http.Fastly-Client-IP;
 
   # Set a TLSversion request header for requests going to the Licensify application
   # This is used to block unsecure requests at the application level for payment security reasons and an absence of caching in Licensify

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -268,8 +268,12 @@ sub vcl_recv {
   }
   
 
-  # Unspoofable original client address.
+  # Unspoofable original client address (e.g. for rate limiting).
   set req.http.True-Client-IP = req.http.Fastly-Client-IP;
+
+  # Reset proxy headers at the boundary to our network.
+  unset req.http.Client-IP;
+  set req.http.X-Forwarded-For = req.http.Fastly-Client-IP;
 
   # Set a TLSversion request header for requests going to the Licensify application
   # This is used to block unsecure requests at the application level for payment security reasons and an absence of caching in Licensify

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -307,6 +307,10 @@ sub vcl_recv {
   # Unspoofable original client address.
   set req.http.True-Client-IP = req.http.Fastly-Client-IP;
 
+  # Reset proxy headers at the boundary to our network.
+  unset req.http.Client-IP;
+  set req.http.X-Forwarded-For = req.http.Fastly-Client-IP;
+
   # Set a TLSversion request header for requests going to the Licensify application
   # This is used to block unsecure requests at the application level for payment security reasons and an absence of caching in Licensify
   if (req.url ~ "^/apply-for-a-licence/.*") {

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -304,7 +304,7 @@ sub vcl_recv {
   }
   <% end %>
 
-  # Unspoofable original client address.
+  # Unspoofable original client address (e.g. for rate limiting).
   set req.http.True-Client-IP = req.http.Fastly-Client-IP;
 
   # Reset proxy headers at the boundary to our network.


### PR DESCRIPTION
https://trello.com/c/7qWgBlA7/617-investigate-handling-actiondispatchremoteipipspoofattackerror

Previously a user could manually specify these headers, which could
result in a spoofing error for Rails apps trying to detect the client
IP address [1]. Although the use of the headers by the end user is
valid, we can't trust and shouldn't care about any proxies that the
request has been through before reaching our network. This ensures
the proxy headers are reset before the request continues.

Trying this manually (before/after) shows that:

- Fastly does not have a default value for the Client-IP header, so
it's consistent to enforce that it is unset.

- Fastly pre-populates X-Forwarded-For with the "actual" client IP,
so we should preserve that (but ignore any pre-existing header).

Note that HTTP headers are not case sensitive.

[1]: https://github.com/alphagov/govuk_app_config/pull/171