### PR TITLE
Fix ability to synthesise redirects from vcl_recv.

### DIFF
--- a/spec/test-outputs/www-integration.out.vcl
+++ b/spec/test-outputs/www-integration.out.vcl
@@ -328,6 +328,15 @@ sub vcl_error {
     return (deliver);
   }
 
+  # Arbitrary 302 redirects called from vcl_recv.
+  if (obj.status == 802) {
+    set obj.status = 302;
+    set obj.http.Location = "https://" req.http.host obj.response;
+    set obj.response = "Moved";
+    synthetic {""};
+    return (deliver);
+  }
+
   if (obj.status == 804) {
     set obj.status = 404;
     set obj.response = "Not Found";

--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -482,6 +482,15 @@ sub vcl_error {
     return (deliver);
   }
 
+  # Arbitrary 302 redirects called from vcl_recv.
+  if (obj.status == 802) {
+    set obj.status = 302;
+    set obj.http.Location = "https://" req.http.host obj.response;
+    set obj.response = "Moved";
+    synthetic {""};
+    return (deliver);
+  }
+
   if (obj.status == 804) {
     set obj.status = 404;
     set obj.response = "Not Found";

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -493,6 +493,15 @@ sub vcl_error {
     return (deliver);
   }
 
+  # Arbitrary 302 redirects called from vcl_recv.
+  if (obj.status == 802) {
+    set obj.status = 302;
+    set obj.http.Location = "https://" req.http.host obj.response;
+    set obj.response = "Moved";
+    synthetic {""};
+    return (deliver);
+  }
+
   if (obj.status == 804) {
     set obj.status = 404;
     set obj.response = "Not Found";

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -473,6 +473,15 @@ sub vcl_error {
     return (deliver);
   }
 
+  # Arbitrary 302 redirects called from vcl_recv.
+  if (obj.status == 802) {
+    set obj.status = 302;
+    set obj.http.Location = "https://" req.http.host obj.response;
+    set obj.response = "Moved";
+    synthetic {""};
+    return (deliver);
+  }
+
   if (obj.status == 804) {
     set obj.status = 404;
     set obj.response = "Not Found";


### PR DESCRIPTION
7e78be3 didn't work for two reasons: firstly, accidentally omitted the vcl_synth subroutine; secondly, Fastly doesn't support vcl_synth() anyway so we need to use vcl_error().

Use vcl_error() to allow synthesising 302 responses from within vcl_recv. We're using this in alphagov/govuk-cdn-config-secrets#131.

Co-authored-by: @OllieJC

Tested: tested positive and negative cases in staging

See also alphagov/govuk-cdn-config-secrets#132