### PR TITLE
Allow private VCL code snippets in all environments.

### DIFF
--- a/spec/test-outputs/www-integration.out.vcl
+++ b/spec/test-outputs/www-integration.out.vcl
@@ -86,6 +86,9 @@ sub vcl_recv {
      error 801 "Force SSL";
   }
 
+  
+  # some private vcl code
+
   # Serve a 404 Not Found response if request URL matches "/autodiscover/autodiscover.xml"
   if (req.url.path ~ "(?i)/autodiscover/autodiscover.xml$") {
     error 804 "Not Found";

--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -179,6 +179,9 @@ sub vcl_recv {
      error 801 "Force SSL";
   }
 
+  
+  # some private vcl code
+
   # Serve a 404 Not Found response if request URL matches "/autodiscover/autodiscover.xml"
   if (req.url.path ~ "(?i)/autodiscover/autodiscover.xml$") {
     error 804 "Not Found";

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -175,8 +175,6 @@ sub vcl_recv {
     error 403 "Forbidden";
   }
   
-  # some private vcl code
-  
 
   # Check whether the remote IP address is in the list of blocked IPs
   if (table.lookup(ip_address_denylist, client.ip)) {
@@ -189,6 +187,9 @@ sub vcl_recv {
   if (!req.http.Fastly-SSL) {
      error 801 "Force SSL";
   }
+
+  
+  # some private vcl code
 
   # Serve a 404 Not Found response if request URL matches "/autodiscover/autodiscover.xml"
   if (req.url.path ~ "(?i)/autodiscover/autodiscover.xml$") {

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -203,8 +203,6 @@ sub vcl_recv {
   if (! (client.ip ~ allowed_ip_addresses)) {
     error 403 "Forbidden";
   }
-  <%# See govuk-cdn-config-secrets/fastly/fastly.yaml %>
-  <%= config.fetch("private_extra_code_in_vcl_recv") %>
   <% end %>
 
   # Check whether the remote IP address is in the list of blocked IPs
@@ -225,6 +223,9 @@ sub vcl_recv {
   if (!req.http.Fastly-SSL) {
      error 801 "Force SSL";
   }
+
+  <%# See govuk-cdn-config-secrets/fastly/fastly.yaml %>
+  <%= config.fetch("private_extra_code_in_vcl_recv", "") %>
 
   # Serve a 404 Not Found response if request URL matches "/autodiscover/autodiscover.xml"
   if (req.url.path ~ "(?i)/autodiscover/autodiscover.xml$") {


### PR DESCRIPTION
The (per-environment) config item `private_extra_code_in_vcl_recv` allows inserting snippets of VCL from the private govuk-cdn-config-secrets repo into `vcl_recv()`.

Allow this to be used in any environment rather than just staging, now that it's been tested in staging.

Also be a bit more flexible by ignoring the case when `private_extra_code_in_vcl_recv` is not specified in the config, instead of failing.

Follows on from #307 and alphagov/govuk-cdn-config-secrets#132.

Test/rollout plan: rspec is passing. Will test in staging once merged, before rolling to prod.