### PR TITLE
Set GOV.UK-Request-Id to allow request tracing

### DIFF
--- a/spec/test-outputs/www-integration.out.vcl
+++ b/spec/test-outputs/www-integration.out.vcl
@@ -106,6 +106,9 @@ sub vcl_recv {
   # as a rollback mechanism should we ever need to stop showing these links.
   set req.http.Govuk-Use-Recommended-Related-Links = "true";
 
+  # Set a request id header to allow requests to be traced through the stack
+  set req.http.GOVUK-Request-Id = uuid.version4();
+
   
 
   # Unspoofable original client address (e.g. for rate limiting).

--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -199,6 +199,9 @@ sub vcl_recv {
   # as a rollback mechanism should we ever need to stop showing these links.
   set req.http.Govuk-Use-Recommended-Related-Links = "true";
 
+  # Set a request id header to allow requests to be traced through the stack
+  set req.http.GOVUK-Request-Id = uuid.version4();
+
   
 
   # Save original request url because req.url changes after restarts.

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -208,6 +208,9 @@ sub vcl_recv {
   # as a rollback mechanism should we ever need to stop showing these links.
   set req.http.Govuk-Use-Recommended-Related-Links = "true";
 
+  # Set a request id header to allow requests to be traced through the stack
+  set req.http.GOVUK-Request-Id = uuid.version4();
+
   
 
   # Save original request url because req.url changes after restarts.

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -244,6 +244,9 @@ sub vcl_recv {
   # as a rollback mechanism should we ever need to stop showing these links.
   set req.http.Govuk-Use-Recommended-Related-Links = "true";
 
+  # Set a request id header to allow requests to be traced through the stack
+  set req.http.GOVUK-Request-Id = uuid.version4();
+
   <% if %w(staging production).include?(environment) %>
 
   # Save original request url because req.url changes after restarts.


### PR DESCRIPTION
To enable request tracing for GOV.UK we need to set a request id at the CDN so we can trace requests through all layers of GOV.UK