### PR TITLE
Parse and normalise URL query for local restrictions page

### DIFF
--- a/spec/test-outputs/www-integration.out.vcl
+++ b/spec/test-outputs/www-integration.out.vcl
@@ -109,6 +109,23 @@ sub vcl_recv {
   # Set a request id header to allow requests to be traced through the stack
   set req.http.GOVUK-Request-Id = uuid.version4();
 
+  if (req.url.path == "/find-coronavirus-local-restrictions") {
+    # get rid of all but the postcode param
+    set req.url = querystring.filter_except(req.url, "postcode");
+
+    # lower case the postcode and strip any non-alnum chars
+    set req.url = querystring.set(
+      req.url,
+      "postcode",
+      regsuball(
+        std.tolower(
+          subfield(req.url.qs, "postcode", "&")
+        ),
+        "[^a-z0-9]",
+        "")
+    );
+  }
+
   
 
   # Unspoofable original client address (e.g. for rate limiting).

--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -202,6 +202,23 @@ sub vcl_recv {
   # Set a request id header to allow requests to be traced through the stack
   set req.http.GOVUK-Request-Id = uuid.version4();
 
+  if (req.url.path == "/find-coronavirus-local-restrictions") {
+    # get rid of all but the postcode param
+    set req.url = querystring.filter_except(req.url, "postcode");
+
+    # lower case the postcode and strip any non-alnum chars
+    set req.url = querystring.set(
+      req.url,
+      "postcode",
+      regsuball(
+        std.tolower(
+          subfield(req.url.qs, "postcode", "&")
+        ),
+        "[^a-z0-9]",
+        "")
+    );
+  }
+
   
 
   # Save original request url because req.url changes after restarts.

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -211,6 +211,23 @@ sub vcl_recv {
   # Set a request id header to allow requests to be traced through the stack
   set req.http.GOVUK-Request-Id = uuid.version4();
 
+  if (req.url.path == "/find-coronavirus-local-restrictions") {
+    # get rid of all but the postcode param
+    set req.url = querystring.filter_except(req.url, "postcode");
+
+    # lower case the postcode and strip any non-alnum chars
+    set req.url = querystring.set(
+      req.url,
+      "postcode",
+      regsuball(
+        std.tolower(
+          subfield(req.url.qs, "postcode", "&")
+        ),
+        "[^a-z0-9]",
+        "")
+    );
+  }
+
   
 
   # Save original request url because req.url changes after restarts.

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -247,6 +247,23 @@ sub vcl_recv {
   # Set a request id header to allow requests to be traced through the stack
   set req.http.GOVUK-Request-Id = uuid.version4();
 
+  if (req.url.path == "/find-coronavirus-local-restrictions") {
+    # get rid of all but the postcode param
+    set req.url = querystring.filter_except(req.url, "postcode");
+
+    # lower case the postcode and strip any non-alnum chars
+    set req.url = querystring.set(
+      req.url,
+      "postcode",
+      regsuball(
+        std.tolower(
+          subfield(req.url.qs, "postcode", "&")
+        ),
+        "[^a-z0-9]",
+        "")
+    );
+  }
+
   <% if %w(staging production).include?(environment) %>
 
   # Save original request url because req.url changes after restarts.


### PR DESCRIPTION
When a user visits /find-coronavirus-local-restrictions we will remove all query parameters except for the postcode query parameter, which we will normalise (lowercase, restrict to alphanumerics). See [Fastly Fiddle for demonstration](https://fiddle.fastlydemo.net/fiddle/35784abb).