### PR TITLE
Remove postcode formatting

### DIFF
--- a/spec/test-outputs/www-integration.out.vcl
+++ b/spec/test-outputs/www-integration.out.vcl
@@ -112,18 +112,6 @@ sub vcl_recv {
   if (req.url.path == "/find-coronavirus-local-restrictions") {
     # get rid of all but the postcode param
     set req.url = querystring.filter_except(req.url, "postcode");
-
-    # lower case the postcode and strip any non-alnum chars
-    set req.url = querystring.set(
-      req.url,
-      "postcode",
-      regsuball(
-        std.tolower(
-          subfield(req.url.qs, "postcode", "&")
-        ),
-        "[^a-z0-9]",
-        "")
-    );
   }
 
   

--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -205,18 +205,6 @@ sub vcl_recv {
   if (req.url.path == "/find-coronavirus-local-restrictions") {
     # get rid of all but the postcode param
     set req.url = querystring.filter_except(req.url, "postcode");
-
-    # lower case the postcode and strip any non-alnum chars
-    set req.url = querystring.set(
-      req.url,
-      "postcode",
-      regsuball(
-        std.tolower(
-          subfield(req.url.qs, "postcode", "&")
-        ),
-        "[^a-z0-9]",
-        "")
-    );
   }
 
   

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -214,18 +214,6 @@ sub vcl_recv {
   if (req.url.path == "/find-coronavirus-local-restrictions") {
     # get rid of all but the postcode param
     set req.url = querystring.filter_except(req.url, "postcode");
-
-    # lower case the postcode and strip any non-alnum chars
-    set req.url = querystring.set(
-      req.url,
-      "postcode",
-      regsuball(
-        std.tolower(
-          subfield(req.url.qs, "postcode", "&")
-        ),
-        "[^a-z0-9]",
-        "")
-    );
   }
 
   

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -250,18 +250,6 @@ sub vcl_recv {
   if (req.url.path == "/find-coronavirus-local-restrictions") {
     # get rid of all but the postcode param
     set req.url = querystring.filter_except(req.url, "postcode");
-
-    # lower case the postcode and strip any non-alnum chars
-    set req.url = querystring.set(
-      req.url,
-      "postcode",
-      regsuball(
-        std.tolower(
-          subfield(req.url.qs, "postcode", "&")
-        ),
-        "[^a-z0-9]",
-        "")
-    );
   }
 
   <% if %w(staging production).include?(environment) %>


### PR DESCRIPTION
Trello: https://trello.com/c/sCaPVTCo/997-14th-december-follow-up-work

This removes the postcode formatting for requests to
/find-coronavirus-local-restrictions in favour of a JavaScript one done
within the collections app: https://github.com/alphagov/collections/pull/2156

The switch to a JavaScript approach was chosen so that the code can be
kept with the app (with tests) and to improve user experience (this CDN one will
produce confusing outcomes for invalid postcodes). The trade-off for the
JS one is that is less aggressive in it's formatting and, by nature of
being client side, not something that is forced upon a user. The
expectation is that these trade offs won't produce any significant
variance in traffic.