### PR TITLE
Recognise 307 responses as cacheable on www.gov.uk 

### DIFF
--- a/spec/test-outputs/www-integration.out.vcl
+++ b/spec/test-outputs/www-integration.out.vcl
@@ -241,6 +241,12 @@ sub vcl_fetch {
     return (pass);
   }
 
+  # Fastly doesn't recognise 307 as cacheable by default as it is based on an
+  # old version of Varnish that also lacked 307 support.
+  if (beresp.status == 307) {
+    set beresp.cacheable = true;
+  }
+
   if (beresp.http.Expires || beresp.http.Surrogate-Control ~ "max-age" || beresp.http.Cache-Control ~"(s-maxage|max-age)") {
     # keep the ttl here
   } else {

--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -395,6 +395,12 @@ sub vcl_fetch {
     return (pass);
   }
 
+  # Fastly doesn't recognise 307 as cacheable by default as it is based on an
+  # old version of Varnish that also lacked 307 support.
+  if (beresp.status == 307) {
+    set beresp.cacheable = true;
+  }
+
   if (beresp.http.Expires || beresp.http.Surrogate-Control ~ "max-age" || beresp.http.Cache-Control ~"(s-maxage|max-age)") {
     # keep the ttl here
   } else {

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -404,6 +404,12 @@ sub vcl_fetch {
     return (pass);
   }
 
+  # Fastly doesn't recognise 307 as cacheable by default as it is based on an
+  # old version of Varnish that also lacked 307 support.
+  if (beresp.status == 307) {
+    set beresp.cacheable = true;
+  }
+
   if (beresp.http.Expires || beresp.http.Surrogate-Control ~ "max-age" || beresp.http.Cache-Control ~"(s-maxage|max-age)") {
     # keep the ttl here
   } else {

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -408,6 +408,12 @@ sub vcl_fetch {
     return (pass);
   }
 
+  # Fastly doesn't recognise 307 as cacheable by default as it is based on an
+  # old version of Varnish that also lacked 307 support.
+  if (beresp.status == 307) {
+    set beresp.cacheable = true;
+  }
+
   if (beresp.http.Expires || beresp.http.Surrogate-Control ~ "max-age" || beresp.http.Cache-Control ~"(s-maxage|max-age)") {
     # keep the ttl here
   } else {


### PR DESCRIPTION
Trello: https://trello.com/c/HzeMkOac/1038-return-a-temporary-cachable-redirect-for-the-postcode-checker-while-its-unavailable

GOV.UK responds with 307 for some responses to indicate a temporary
redirect. Fastly doesn't currently support them but suggested this
change.

I decided not to include the similar 303 response in here as this seemed
a bit more contentious given it is expected to originate from a POST
request: varnishcache/varnish-cache#3340 and I
don't believe we have a need.

This same change could be applied to our other VCL files but I'm not
aware of them having a need currently so it seems superfluous to
duplicate this for each.