### PR TITLE
Add accounts VCL (RFC 134) 

### DIFF
--- a/spec/test-outputs/www-integration.out.vcl
+++ b/spec/test-outputs/www-integration.out.vcl
@@ -136,6 +136,11 @@ sub vcl_recv {
     return(pass);
   }
 
+  # RFC 134
+  set req.http.GOVUK-Account-Session = req.http.Cookie:__Host-govuk_account_session;
+
+  # TODO: Remove when we have switched existing apps to use the new
+  # session header
   if (req.http.Cookie ~ "_finder-frontend_account_session") {
     set req.http.GOVUK-ABTest-AccountExperiment = "LoggedIn";
   } else {
@@ -322,6 +327,21 @@ sub vcl_miss {
 }
 
 sub vcl_deliver {
+  # RFC 134
+  if (resp.http.GOVUK-Account-End-Session) {
+    add resp.http.Set-Cookie = "__Host-govuk_account_session=; secure; httponly; samesite=strict; path=/; max-age=0";
+    unset resp.http.GOVUK-Account-End-Session;
+  } else if (resp.http.GOVUK-Account-Session) {
+    add resp.http.Set-Cookie = "__Host-govuk_account_session=" + resp.http.GOVUK-Account-Session + "; secure; httponly; samesite=strict; path=/";
+  }
+
+  if (resp.http.Vary ~ "GOVUK-Account-Session") {
+    unset resp.http.Vary:GOVUK-Account-Session;
+    set resp.http.Cache-Control:private = "";
+  }
+
+  unset resp.http.GOVUK-Account-Session;
+
   # Set the A/B cookies
   # Only set the A/B example cookie if the request is to the A/B test page. This
   # ensures that most visitors to the site aren't assigned an irrelevant test

--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -290,6 +290,11 @@ sub vcl_recv {
     return(pass);
   }
 
+  # RFC 134
+  set req.http.GOVUK-Account-Session = req.http.Cookie:__Host-govuk_account_session;
+
+  # TODO: Remove when we have switched existing apps to use the new
+  # session header
   if (req.http.Cookie ~ "_finder-frontend_account_session") {
     set req.http.GOVUK-ABTest-AccountExperiment = "LoggedIn";
   } else {
@@ -476,6 +481,21 @@ sub vcl_miss {
 }
 
 sub vcl_deliver {
+  # RFC 134
+  if (resp.http.GOVUK-Account-End-Session) {
+    add resp.http.Set-Cookie = "__Host-govuk_account_session=; secure; httponly; samesite=strict; path=/; max-age=0";
+    unset resp.http.GOVUK-Account-End-Session;
+  } else if (resp.http.GOVUK-Account-Session) {
+    add resp.http.Set-Cookie = "__Host-govuk_account_session=" + resp.http.GOVUK-Account-Session + "; secure; httponly; samesite=strict; path=/";
+  }
+
+  if (resp.http.Vary ~ "GOVUK-Account-Session") {
+    unset resp.http.Vary:GOVUK-Account-Session;
+    set resp.http.Cache-Control:private = "";
+  }
+
+  unset resp.http.GOVUK-Account-Session;
+
   # Set the A/B cookies
   # Only set the A/B example cookie if the request is to the A/B test page. This
   # ensures that most visitors to the site aren't assigned an irrelevant test

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -299,6 +299,11 @@ sub vcl_recv {
     return(pass);
   }
 
+  # RFC 134
+  set req.http.GOVUK-Account-Session = req.http.Cookie:__Host-govuk_account_session;
+
+  # TODO: Remove when we have switched existing apps to use the new
+  # session header
   if (req.http.Cookie ~ "_finder-frontend_account_session") {
     set req.http.GOVUK-ABTest-AccountExperiment = "LoggedIn";
   } else {
@@ -485,6 +490,21 @@ sub vcl_miss {
 }
 
 sub vcl_deliver {
+  # RFC 134
+  if (resp.http.GOVUK-Account-End-Session) {
+    add resp.http.Set-Cookie = "__Host-govuk_account_session=; secure; httponly; samesite=strict; path=/; max-age=0";
+    unset resp.http.GOVUK-Account-End-Session;
+  } else if (resp.http.GOVUK-Account-Session) {
+    add resp.http.Set-Cookie = "__Host-govuk_account_session=" + resp.http.GOVUK-Account-Session + "; secure; httponly; samesite=strict; path=/";
+  }
+
+  if (resp.http.Vary ~ "GOVUK-Account-Session") {
+    unset resp.http.Vary:GOVUK-Account-Session;
+    set resp.http.Cache-Control:private = "";
+  }
+
+  unset resp.http.GOVUK-Account-Session;
+
   # Set the A/B cookies
   # Only set the A/B example cookie if the request is to the A/B test page. This
   # ensures that most visitors to the site aren't assigned an irrelevant test

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -340,6 +340,11 @@ sub vcl_recv {
     return(pass);
   }
 
+  # RFC 134
+  set req.http.GOVUK-Account-Session = req.http.Cookie:__Host-govuk_account_session;
+
+  # TODO: Remove when we have switched existing apps to use the new
+  # session header
   if (req.http.Cookie ~ "_finder-frontend_account_session") {
     set req.http.GOVUK-ABTest-AccountExperiment = "LoggedIn";
   } else {
@@ -442,6 +447,21 @@ sub vcl_miss {
 }
 
 sub vcl_deliver {
+  # RFC 134
+  if (resp.http.GOVUK-Account-End-Session) {
+    add resp.http.Set-Cookie = "__Host-govuk_account_session=; secure; httponly; samesite=strict; path=/; max-age=0";
+    unset resp.http.GOVUK-Account-End-Session;
+  } else if (resp.http.GOVUK-Account-Session) {
+    add resp.http.Set-Cookie = "__Host-govuk_account_session=" + resp.http.GOVUK-Account-Session + "; secure; httponly; samesite=strict; path=/";
+  }
+
+  if (resp.http.Vary ~ "GOVUK-Account-Session") {
+    unset resp.http.Vary:GOVUK-Account-Session;
+    set resp.http.Cache-Control:private = "";
+  }
+
+  unset resp.http.GOVUK-Account-Session;
+
   # Set the A/B cookies
   # Only set the A/B example cookie if the request is to the A/B test page. This
   # ensures that most visitors to the site aren't assigned an irrelevant test


### PR DESCRIPTION
[Fastly's best practices for cookies][1] suggest parsing cookies into
custom headers and using these headers for caching purposes, rather
than caching based on the entire Set-Cookie header (which in our case
also contains non-account-related things like A/B test bucket
assignment, Google Analytics session ID, and cookie consent
preferences).

To support accounts, we introduce two new headers:

- `GOVUK-Account-Session`: holds the session cookie value.  Set by
Fastly to pass the cookie to our apps, set by our apps to create a new
cookie.

- `GOVUK-Account-End-Session`: set by our apps to expire the cookie.

We need to make two changes to our VCL:

- `vcl_recv`: extract the cookie value and pass it in the header.

- `vcl_deliver`: if appropriate, update or expire the cookie; and, if
the response depends on accounts, disable shared caches outside of
Fastly.

[1]: https://developer.fastly.com/reference/http-headers/Cookie/#best-practices

---

[Trello card](https://trello.com/c/q6azZWG8/635-write-vcl-for-new-cookie)