### PR TITLE
Allow UI declared backends and conditions to persist on deploy

### DIFF
--- a/lib/deploy_bouncer.rb
+++ b/lib/deploy_bouncer.rb
@@ -180,7 +180,7 @@ class DeployBouncer
   def delete_ui_objects(service_id, version_number)
     # Delete objects created by the UI. We want VCL to be the source of truth.
     # Most of these don't have real objects in the Fastly API gem.
-    to_delete = %w[backend healthcheck condition request_settings cache_settings response_object header gzip]
+    to_delete = %w[healthcheck request_settings cache_settings response_object header gzip]
     to_delete.each do |type|
       type_path = "/service/#{service_id}/version/#{version_number}/#{type}"
       @fastly.client.get(type_path).map { |i| i["name"] }.each do |name|

--- a/spec/deploy_bouncer_spec.rb
+++ b/spec/deploy_bouncer_spec.rb
@@ -31,7 +31,7 @@ describe DeployBouncer do
         .to_return(body: "{}")
 
       # Stub calls to delete the "UI objects"
-      %w[backend healthcheck cache_settings condition request_settings response_object header gzip].each do |thing|
+      %w[healthcheck cache_settings request_settings response_object header gzip].each do |thing|
         @requests << stub_request(:get, "https://api.fastly.com/service/123321abc/version/3/#{thing}")
           .to_return(body: "{}")
       end


### PR DESCRIPTION
Fastly allows backends and conditions to be set in the UI,
but subsequent VCL deploys removed these.

https://github.com/alphagov/govuk-cdn-config/blob/1c272cfc79ccb3f9fa3ff89325b70a41df0b9a00/deploy_vcl#L38

We now wish to use some Fastly features that are only
available with UI declared backends and associated conditions.