### PR TITLE
Remove account signed-in-state A/B header 

### DIFF
--- a/spec/test-outputs/www-integration.out.vcl
+++ b/spec/test-outputs/www-integration.out.vcl
@@ -139,14 +139,6 @@ sub vcl_recv {
   # RFC 134
   set req.http.GOVUK-Account-Session = req.http.Cookie:__Host-govuk_account_session;
 
-  # TODO: Remove when we have switched existing apps to use the new
-  # session header
-  if (req.http.Cookie ~ "_finder-frontend_account_session") {
-    set req.http.GOVUK-ABTest-AccountExperiment = "LoggedIn";
-  } else {
-    set req.http.GOVUK-ABTest-AccountExperiment = "LoggedOut";
-  }
-
     # Begin dynamic section
 if (req.http.Cookie ~ "cookies_policy" && req.http.Cookie:cookies_policy ~ "%22usage%22:true") {
   if (table.lookup(active_ab_tests, "Example") == "true") {

--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -293,14 +293,6 @@ sub vcl_recv {
   # RFC 134
   set req.http.GOVUK-Account-Session = req.http.Cookie:__Host-govuk_account_session;
 
-  # TODO: Remove when we have switched existing apps to use the new
-  # session header
-  if (req.http.Cookie ~ "_finder-frontend_account_session") {
-    set req.http.GOVUK-ABTest-AccountExperiment = "LoggedIn";
-  } else {
-    set req.http.GOVUK-ABTest-AccountExperiment = "LoggedOut";
-  }
-
     # Begin dynamic section
 if (req.http.Cookie ~ "cookies_policy" && req.http.Cookie:cookies_policy ~ "%22usage%22:true") {
   if (table.lookup(active_ab_tests, "Example") == "true") {

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -302,14 +302,6 @@ sub vcl_recv {
   # RFC 134
   set req.http.GOVUK-Account-Session = req.http.Cookie:__Host-govuk_account_session;
 
-  # TODO: Remove when we have switched existing apps to use the new
-  # session header
-  if (req.http.Cookie ~ "_finder-frontend_account_session") {
-    set req.http.GOVUK-ABTest-AccountExperiment = "LoggedIn";
-  } else {
-    set req.http.GOVUK-ABTest-AccountExperiment = "LoggedOut";
-  }
-
     # Begin dynamic section
 if (req.http.Cookie ~ "cookies_policy" && req.http.Cookie:cookies_policy ~ "%22usage%22:true") {
   if (table.lookup(active_ab_tests, "Example") == "true") {

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -343,14 +343,6 @@ sub vcl_recv {
   # RFC 134
   set req.http.GOVUK-Account-Session = req.http.Cookie:__Host-govuk_account_session;
 
-  # TODO: Remove when we have switched existing apps to use the new
-  # session header
-  if (req.http.Cookie ~ "_finder-frontend_account_session") {
-    set req.http.GOVUK-ABTest-AccountExperiment = "LoggedIn";
-  } else {
-    set req.http.GOVUK-ABTest-AccountExperiment = "LoggedOut";
-  }
-
   <% template_path = File.join(File.dirname(__FILE__), "vcl_templates/_multivariate_tests.vcl.erb") -%>
   <%= ERB.new(File.new(template_path).read, nil, "-", "_erbout2").result(binding) %>
 


### PR DESCRIPTION
We were (ab)using an A/B test to show the signed in / out header, but
now the apps have been updated to use the GOVUK-Account-Session
header, so this is no longer needed.

---

[Trello card](https://trello.com/c/uHdKokkS/643-switch-from-the-old-cookie-to-the-new-cookie)