### PR TITLE
Recognise 406 responses as cacheable on www.gov.uk

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,14 @@ Invoked via the [CDN: deploy Bouncer configs](https://deploy.blue.production.gov
 
 This configures the `bouncer` Fastly service with transitioned domains from Transition ([read about Transition here](https://docs.publishing.service.gov.uk/manual/transition-architecture.html)). The Jenkins job is not usually run manually - it's triggered by the [one of the transition Jenkins jobs](https://deploy.blue.production.govuk.digital/job/Transition_load_site_config). Read [more about the Fastly service](https://docs.publishing.service.gov.uk/manual/cdn.html#bouncer39s-fastly-service) in the developer docs.
 
+## Making changes to VCL
+
+You will need to re-generate the spec files when making changes to `www.vcl.erb`.
+
+```sh
+REGENERATE_EXPECTATIONS=1 bundle exec rspec
+```
+
 ## A/B testing
 
 We use edge dictionaries to define the configuration for A/B and multivariate tests. The same configuration applies to A/B and multivariate tests, differing only on the number of variants.

--- a/spec/test-outputs/www-integration.out.vcl
+++ b/spec/test-outputs/www-integration.out.vcl
@@ -291,6 +291,10 @@ sub vcl_fetch {
     set beresp.cacheable = true;
   }
 
+  if (beresp.status == 406) {
+    set beresp.cacheable = true;
+  }
+
   if (beresp.http.Expires || beresp.http.Surrogate-Control ~ "max-age" || beresp.http.Cache-Control ~"(s-maxage|max-age)") {
     # keep the ttl here
   } else {

--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -445,6 +445,10 @@ sub vcl_fetch {
     set beresp.cacheable = true;
   }
 
+  if (beresp.status == 406) {
+    set beresp.cacheable = true;
+  }
+
   if (beresp.http.Expires || beresp.http.Surrogate-Control ~ "max-age" || beresp.http.Cache-Control ~"(s-maxage|max-age)") {
     # keep the ttl here
   } else {

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -454,6 +454,10 @@ sub vcl_fetch {
     set beresp.cacheable = true;
   }
 
+  if (beresp.status == 406) {
+    set beresp.cacheable = true;
+  }
+
   if (beresp.http.Expires || beresp.http.Surrogate-Control ~ "max-age" || beresp.http.Cache-Control ~"(s-maxage|max-age)") {
     # keep the ttl here
   } else {

--- a/spec/test-outputs/www-test.out.vcl
+++ b/spec/test-outputs/www-test.out.vcl
@@ -287,6 +287,10 @@ sub vcl_fetch {
     set beresp.cacheable = true;
   }
 
+  if (beresp.status == 406) {
+    set beresp.cacheable = true;
+  }
+
   if (beresp.http.Expires || beresp.http.Surrogate-Control ~ "max-age" || beresp.http.Cache-Control ~"(s-maxage|max-age)") {
     # keep the ttl here
   } else {

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -411,6 +411,10 @@ sub vcl_fetch {
     set beresp.cacheable = true;
   }
 
+  if (beresp.status == 406) {
+    set beresp.cacheable = true;
+  }
+
   if (beresp.http.Expires || beresp.http.Surrogate-Control ~ "max-age" || beresp.http.Cache-Control ~"(s-maxage|max-age)") {
     # keep the ttl here
   } else {


### PR DESCRIPTION
Fastly doesn't cache 406 responses by default:
https://docs.fastly.com/en/guides/http-status-codes-cached-by-default

Nor does Varnish:
https://varnish-cache.org/docs/2.1/reference/vcl.html#variables

This change is to support a change in Manuals Frontend, which will
now start returning 406 responses when requests are made with an
'Accepts' header that doesn't include `text/html`. However, in
practice we are already returning 406 responses in Government
Frontend, which are currently hitting origin.
https://github.com/alphagov/manuals-frontend/pull/1078

I've taken inspiration from https://github.com/alphagov/govuk-cdn-config/pull/316.

Trello:
https://trello.com/c/XNQhMGRt/2391-3-make-manuals-frontend-respond-to-bad-requests-with-406-status