### PR TITLE
Revert "Recognise 406 responses as cacheable on www.gov.uk"

### DIFF
--- a/spec/test-outputs/www-integration.out.vcl
+++ b/spec/test-outputs/www-integration.out.vcl
@@ -291,10 +291,6 @@ sub vcl_fetch {
     set beresp.cacheable = true;
   }
 
-  if (beresp.status == 406) {
-    set beresp.cacheable = true;
-  }
-
   if (beresp.http.Expires || beresp.http.Surrogate-Control ~ "max-age" || beresp.http.Cache-Control ~"(s-maxage|max-age)") {
     # keep the ttl here
   } else {

--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -445,10 +445,6 @@ sub vcl_fetch {
     set beresp.cacheable = true;
   }
 
-  if (beresp.status == 406) {
-    set beresp.cacheable = true;
-  }
-
   if (beresp.http.Expires || beresp.http.Surrogate-Control ~ "max-age" || beresp.http.Cache-Control ~"(s-maxage|max-age)") {
     # keep the ttl here
   } else {

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -454,10 +454,6 @@ sub vcl_fetch {
     set beresp.cacheable = true;
   }
 
-  if (beresp.status == 406) {
-    set beresp.cacheable = true;
-  }
-
   if (beresp.http.Expires || beresp.http.Surrogate-Control ~ "max-age" || beresp.http.Cache-Control ~"(s-maxage|max-age)") {
     # keep the ttl here
   } else {

--- a/spec/test-outputs/www-test.out.vcl
+++ b/spec/test-outputs/www-test.out.vcl
@@ -287,10 +287,6 @@ sub vcl_fetch {
     set beresp.cacheable = true;
   }
 
-  if (beresp.status == 406) {
-    set beresp.cacheable = true;
-  }
-
   if (beresp.http.Expires || beresp.http.Surrogate-Control ~ "max-age" || beresp.http.Cache-Control ~"(s-maxage|max-age)") {
     # keep the ttl here
   } else {

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -411,10 +411,6 @@ sub vcl_fetch {
     set beresp.cacheable = true;
   }
 
-  if (beresp.status == 406) {
-    set beresp.cacheable = true;
-  }
-
   if (beresp.http.Expires || beresp.http.Surrogate-Control ~ "max-age" || beresp.http.Cache-Control ~"(s-maxage|max-age)") {
     # keep the ttl here
   } else {


### PR DESCRIPTION
This caused issues where we were seeing 406's even when requesting HTML versions of the page, presumably because the endpoint was cached in Fastly after first getting a 406.

Will raise another PR tomorrow which considers request headers more.