### PR TITLE
Set the GOVUK-Account-Session header for all request methods

### DIFF
--- a/spec/test-outputs/www-integration.out.vcl
+++ b/spec/test-outputs/www-integration.out.vcl
@@ -132,12 +132,12 @@ sub vcl_recv {
 
 #FASTLY recv
 
+  # RFC 134
+  set req.http.GOVUK-Account-Session = req.http.Cookie:__Host-govuk_account_session;
+
   if (req.request != "HEAD" && req.request != "GET" && req.request != "FASTLYPURGE") {
     return(pass);
   }
-
-  # RFC 134
-  set req.http.GOVUK-Account-Session = req.http.Cookie:__Host-govuk_account_session;
 
     # Begin dynamic section
 if (req.http.Cookie ~ "cookies_policy" && req.http.Cookie:cookies_policy ~ "%22usage%22:true") {

--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -286,12 +286,12 @@ sub vcl_recv {
 
 #FASTLY recv
 
+  # RFC 134
+  set req.http.GOVUK-Account-Session = req.http.Cookie:__Host-govuk_account_session;
+
   if (req.request != "HEAD" && req.request != "GET" && req.request != "FASTLYPURGE") {
     return(pass);
   }
-
-  # RFC 134
-  set req.http.GOVUK-Account-Session = req.http.Cookie:__Host-govuk_account_session;
 
     # Begin dynamic section
 if (req.http.Cookie ~ "cookies_policy" && req.http.Cookie:cookies_policy ~ "%22usage%22:true") {

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -295,12 +295,12 @@ sub vcl_recv {
 
 #FASTLY recv
 
+  # RFC 134
+  set req.http.GOVUK-Account-Session = req.http.Cookie:__Host-govuk_account_session;
+
   if (req.request != "HEAD" && req.request != "GET" && req.request != "FASTLYPURGE") {
     return(pass);
   }
-
-  # RFC 134
-  set req.http.GOVUK-Account-Session = req.http.Cookie:__Host-govuk_account_session;
 
     # Begin dynamic section
 if (req.http.Cookie ~ "cookies_policy" && req.http.Cookie:cookies_policy ~ "%22usage%22:true") {

--- a/spec/test-outputs/www-test.out.vcl
+++ b/spec/test-outputs/www-test.out.vcl
@@ -128,12 +128,12 @@ sub vcl_recv {
 
 #FASTLY recv
 
+  # RFC 134
+  set req.http.GOVUK-Account-Session = req.http.Cookie:__Host-govuk_account_session;
+
   if (req.request != "HEAD" && req.request != "GET" && req.request != "FASTLYPURGE") {
     return(pass);
   }
-
-  # RFC 134
-  set req.http.GOVUK-Account-Session = req.http.Cookie:__Host-govuk_account_session;
 
     # Begin dynamic section
 if (req.http.Cookie ~ "cookies_policy" && req.http.Cookie:cookies_policy ~ "%22usage%22:true") {

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -336,12 +336,12 @@ sub vcl_recv {
 
 #FASTLY recv
 
+  # RFC 134
+  set req.http.GOVUK-Account-Session = req.http.Cookie:__Host-govuk_account_session;
+
   if (req.request != "HEAD" && req.request != "GET" && req.request != "FASTLYPURGE") {
     return(pass);
   }
-
-  # RFC 134
-  set req.http.GOVUK-Account-Session = req.http.Cookie:__Host-govuk_account_session;
 
   <% template_path = File.join(File.dirname(__FILE__), "vcl_templates/_multivariate_tests.vcl.erb") -%>
   <%= ERB.new(File.new(template_path).read, nil, "-", "_erbout2").result(binding) %>


### PR DESCRIPTION
Previously this was below a guard which prevented it from being set
for POST requests and the like.