### PR TITLE
Allow UI compression settings to persist on deploy

### DIFF
--- a/lib/deploy_service.rb
+++ b/lib/deploy_service.rb
@@ -60,7 +60,7 @@ private
   def delete_ui_objects(service_id, version_number)
     # Delete objects created by the UI. We want VCL to be the source of truth.
     # Most of these don't have real objects in the Fastly API gem.
-    to_delete = %w[healthcheck cache_settings request_settings response_object header gzip]
+    to_delete = %w[healthcheck cache_settings request_settings response_object header]
     to_delete.each do |type|
       type_path = "/service/#{service_id}/version/#{version_number}/#{type}"
       @fastly.client.get(type_path).map { |i| i["name"] }.each do |name|

--- a/spec/deploy_service_spec.rb
+++ b/spec/deploy_service_spec.rb
@@ -12,7 +12,7 @@ describe DeployService do
         .to_return(body: File.read("spec/fixtures/fastly-put-clone.json"))
 
       # Stub calls to delete the "UI objects"
-      %w[healthcheck cache_settings request_settings response_object header gzip].each do |thing|
+      %w[healthcheck cache_settings request_settings response_object header].each do |thing|
         @requests << stub_request(:get, "https://api.fastly.com/service/123321abc/version/3/#{thing}")
           .to_return(body: "{}")
       end


### PR DESCRIPTION
Fastly allows compressions settings to be toggled in the UI. We'd like
to investigate enabling this on staging, and if it looks good roll it
out to production.

The Default compression policy says:

> Compress text to speed the transfer of data. By default we compress:
css, js, html, eot, ico, otf, ttf, json, and svg formats.

> We support Brotli (the default) and gzip compression formats. The
setting depends upon browser support.

Toggling this and looking at the config diff shows that it puts
everything in the `gzip` section of the config (a bit badly named, since
it supports Brotli as well as GZip, but I imagine that's historical).

Currently our deployment script deletes any `gzip` objects it finds in
the UI, so we can't use the feature. Removing this will allow us to
snowflake the config in.

In the long run we should use terraform for this instead.