### PR TITLE
Add 302 redirect for security.txt in staging

### DIFF
--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -195,6 +195,10 @@ sub vcl_recv {
   if (req.url.path ~ "(?i)/autodiscover/autodiscover.xml$") {
     error 804 "Not Found";
   }
+  # Redirect to security.txt for "/.well-known/security.txt" or "/security.txt"
+  if (req.url.path ~ "(?i)^(?:/\.well[-_]known)?/security\.txt$") {
+    error 805 "security.txt";
+  }
 
   # Serve from stale for 24 hours if origin is sick
   set req.grace = 24h;
@@ -599,6 +603,14 @@ sub vcl_error {
         </body>
       </html>"};
 
+    return (deliver);
+  }
+  # 302 redirect to vdp.cabinetoffice.gov.uk called from vcl_recv.
+  if (obj.status == 805) {
+    set obj.status = 302;
+    set obj.http.Location = "https://vdp.cabinetoffice.gov.uk/.well-known/security.txt";
+    set obj.response = "Moved";
+    synthetic {""};
     return (deliver);
   }
 

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -231,6 +231,12 @@ sub vcl_recv {
   if (req.url.path ~ "(?i)/autodiscover/autodiscover.xml$") {
     error 804 "Not Found";
   }
+<% if environment == 'staging' -%>
+  # Redirect to security.txt for "/.well-known/security.txt" or "/security.txt"
+  if (req.url.path ~ "(?i)^(?:/\.well[-_]known)?/security\.txt$") {
+    error 805 "security.txt";
+  }
+<% end -%>
 
   # Serve from stale for 24 hours if origin is sick
   set req.grace = 24h;
@@ -534,6 +540,16 @@ sub vcl_error {
 
     return (deliver);
   }
+<% if environment == 'staging' -%>
+  # 302 redirect to vdp.cabinetoffice.gov.uk called from vcl_recv.
+  if (obj.status == 805) {
+    set obj.status = 302;
+    set obj.http.Location = "https://vdp.cabinetoffice.gov.uk/.well-known/security.txt";
+    set obj.response = "Moved";
+    synthetic {""};
+    return (deliver);
+  }
+<% end -%>
 
   <% if config['basic_authentication'] %>
   if (obj.status == 401) {


### PR DESCRIPTION
This is for the security.txt file redirect to a PaaS app which has the `vdp.cabinetoffice.gov.uk` domain:
https://github.com/alphagov/security.txt