### PR TITLE
Add 302 redirect for security.txt (all envs)

### DIFF
--- a/spec/test-outputs/www-integration.out.vcl
+++ b/spec/test-outputs/www-integration.out.vcl
@@ -94,6 +94,11 @@ sub vcl_recv {
     error 804 "Not Found";
   }
 
+  # Redirect to security.txt for "/.well-known/security.txt" or "/security.txt"
+  if (req.url.path ~ "(?i)^(?:/\.well[-_]known)?/security\.txt$") {
+    error 805 "security.txt";
+  }
+
   # Serve from stale for 24 hours if origin is sick
   set req.grace = 24h;
 
@@ -436,6 +441,15 @@ sub vcl_error {
         </body>
       </html>"};
 
+    return (deliver);
+  }
+
+  # 302 redirect to vdp.cabinetoffice.gov.uk called from vcl_recv.
+  if (obj.status == 805) {
+    set obj.status = 302;
+    set obj.http.Location = "https://vdp.cabinetoffice.gov.uk/.well-known/security.txt";
+    set obj.response = "Moved";
+    synthetic {""};
     return (deliver);
   }
 

--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -187,6 +187,11 @@ sub vcl_recv {
     error 804 "Not Found";
   }
 
+  # Redirect to security.txt for "/.well-known/security.txt" or "/security.txt"
+  if (req.url.path ~ "(?i)^(?:/\.well[-_]known)?/security\.txt$") {
+    error 805 "security.txt";
+  }
+
   # Serve from stale for 24 hours if origin is sick
   set req.grace = 24h;
 
@@ -590,6 +595,15 @@ sub vcl_error {
         </body>
       </html>"};
 
+    return (deliver);
+  }
+
+  # 302 redirect to vdp.cabinetoffice.gov.uk called from vcl_recv.
+  if (obj.status == 805) {
+    set obj.status = 302;
+    set obj.http.Location = "https://vdp.cabinetoffice.gov.uk/.well-known/security.txt";
+    set obj.response = "Moved";
+    synthetic {""};
     return (deliver);
   }
 

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -195,6 +195,7 @@ sub vcl_recv {
   if (req.url.path ~ "(?i)/autodiscover/autodiscover.xml$") {
     error 804 "Not Found";
   }
+
   # Redirect to security.txt for "/.well-known/security.txt" or "/security.txt"
   if (req.url.path ~ "(?i)^(?:/\.well[-_]known)?/security\.txt$") {
     error 805 "security.txt";
@@ -605,6 +606,7 @@ sub vcl_error {
 
     return (deliver);
   }
+
   # 302 redirect to vdp.cabinetoffice.gov.uk called from vcl_recv.
   if (obj.status == 805) {
     set obj.status = 302;

--- a/spec/test-outputs/www-test.out.vcl
+++ b/spec/test-outputs/www-test.out.vcl
@@ -90,6 +90,11 @@ sub vcl_recv {
     error 804 "Not Found";
   }
 
+  # Redirect to security.txt for "/.well-known/security.txt" or "/security.txt"
+  if (req.url.path ~ "(?i)^(?:/\.well[-_]known)?/security\.txt$") {
+    error 805 "security.txt";
+  }
+
   # Serve from stale for 24 hours if origin is sick
   set req.grace = 24h;
 
@@ -432,6 +437,15 @@ sub vcl_error {
         </body>
       </html>"};
 
+    return (deliver);
+  }
+
+  # 302 redirect to vdp.cabinetoffice.gov.uk called from vcl_recv.
+  if (obj.status == 805) {
+    set obj.status = 302;
+    set obj.http.Location = "https://vdp.cabinetoffice.gov.uk/.well-known/security.txt";
+    set obj.response = "Moved";
+    synthetic {""};
     return (deliver);
   }
 

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -231,12 +231,11 @@ sub vcl_recv {
   if (req.url.path ~ "(?i)/autodiscover/autodiscover.xml$") {
     error 804 "Not Found";
   }
-<% if environment == 'staging' -%>
+
   # Redirect to security.txt for "/.well-known/security.txt" or "/security.txt"
   if (req.url.path ~ "(?i)^(?:/\.well[-_]known)?/security\.txt$") {
     error 805 "security.txt";
   }
-<% end -%>
 
   # Serve from stale for 24 hours if origin is sick
   set req.grace = 24h;
@@ -540,7 +539,7 @@ sub vcl_error {
 
     return (deliver);
   }
-<% if environment == 'staging' -%>
+
   # 302 redirect to vdp.cabinetoffice.gov.uk called from vcl_recv.
   if (obj.status == 805) {
     set obj.status = 302;
@@ -549,7 +548,6 @@ sub vcl_error {
     synthetic {""};
     return (deliver);
   }
-<% end -%>
 
   <% if config['basic_authentication'] %>
   if (obj.status == 401) {


### PR DESCRIPTION
Following on from https://github.com/alphagov/govuk-cdn-config/pull/330 which is deployed in staging:
https://www.staging.publishing.service.gov.uk/.well-known/security.txt
This change enables the redirect for the security.txt file in the other environments including prod. 