### PR TITLE
Update bouncer healthcheck

### DIFF
--- a/vcl_templates/bouncer.vcl.erb
+++ b/vcl_templates/bouncer.vcl.erb
@@ -10,7 +10,7 @@ backend F_origin0 {
     .share_key = "<%= service_id %>";
 
     .probe = {
-        .request = "HEAD /healthcheck HTTP/1.1"  "Host: bouncer.<%= app_domain %>" "Connection: close";
+        .request = "HEAD /healthcheck/ready HTTP/1.1"  "Host: bouncer.<%= app_domain %>" "Connection: close";
         .window = 2;
         .threshold = 1;
         .timeout = 2s;


### PR DESCRIPTION
In 412c44946c63eaa1a922c60e86703c681dbeaacb, the /healthcheck endpoint
was removed.  It has been replaced with /healthcheck/live and
/healthcheck/ready.