### PR TITLE
Only set GOVUK-Account-Session if cookie is present

### DIFF
--- a/spec/test-outputs/www-integration.out.vcl
+++ b/spec/test-outputs/www-integration.out.vcl
@@ -138,7 +138,9 @@ sub vcl_recv {
 #FASTLY recv
 
   # RFC 134
-  set req.http.GOVUK-Account-Session = req.http.Cookie:__Host-govuk_account_session;
+  if (req.http.Cookie ~ "__Host-govuk_account_session") {
+    set req.http.GOVUK-Account-Session = req.http.Cookie:__Host-govuk_account_session;
+  }
 
   if (req.request != "HEAD" && req.request != "GET" && req.request != "FASTLYPURGE") {
     return(pass);

--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -292,7 +292,9 @@ sub vcl_recv {
 #FASTLY recv
 
   # RFC 134
-  set req.http.GOVUK-Account-Session = req.http.Cookie:__Host-govuk_account_session;
+  if (req.http.Cookie ~ "__Host-govuk_account_session") {
+    set req.http.GOVUK-Account-Session = req.http.Cookie:__Host-govuk_account_session;
+  }
 
   if (req.request != "HEAD" && req.request != "GET" && req.request != "FASTLYPURGE") {
     return(pass);

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -301,7 +301,9 @@ sub vcl_recv {
 #FASTLY recv
 
   # RFC 134
-  set req.http.GOVUK-Account-Session = req.http.Cookie:__Host-govuk_account_session;
+  if (req.http.Cookie ~ "__Host-govuk_account_session") {
+    set req.http.GOVUK-Account-Session = req.http.Cookie:__Host-govuk_account_session;
+  }
 
   if (req.request != "HEAD" && req.request != "GET" && req.request != "FASTLYPURGE") {
     return(pass);

--- a/spec/test-outputs/www-test.out.vcl
+++ b/spec/test-outputs/www-test.out.vcl
@@ -134,7 +134,9 @@ sub vcl_recv {
 #FASTLY recv
 
   # RFC 134
-  set req.http.GOVUK-Account-Session = req.http.Cookie:__Host-govuk_account_session;
+  if (req.http.Cookie ~ "__Host-govuk_account_session") {
+    set req.http.GOVUK-Account-Session = req.http.Cookie:__Host-govuk_account_session;
+  }
 
   if (req.request != "HEAD" && req.request != "GET" && req.request != "FASTLYPURGE") {
     return(pass);

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -342,7 +342,9 @@ sub vcl_recv {
 #FASTLY recv
 
   # RFC 134
-  set req.http.GOVUK-Account-Session = req.http.Cookie:__Host-govuk_account_session;
+  if (req.http.Cookie ~ "__Host-govuk_account_session") {
+    set req.http.GOVUK-Account-Session = req.http.Cookie:__Host-govuk_account_session;
+  }
 
   if (req.request != "HEAD" && req.request != "GET" && req.request != "FASTLYPURGE") {
     return(pass);


### PR DESCRIPTION
Currently we're setting this header on every request, which means it's
usually getting set to the empty string.  This has resulted in
finder-frontend making a request to account-api every time the brexit
checker results page gets loaded, because it just checks if the header
is set at all, not if it's set with a nonempty value.