### PR TITLE
Add normalization vcl for Brotli support

### DIFF
--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -274,6 +274,13 @@ sub vcl_recv {
     set req.http.Authorization = "AWS gcs-mirror-access-id:" digest.hmac_sha1_base64("gcs-mirror-secret-key", "GET" LF LF LF now LF "/gcs-bucket" req.url.path);
   }
   
+  # Add normalization vcl for Brotli support
+  if (req.http.Fastly-Orig-Accept-Encoding) {
+    if (req.http.Fastly-Orig-Accept-Encoding ~ "\bbr\b") {
+      set req.http.Accept-Encoding = "br";
+    }
+  }
+  
 
   # Unspoofable original client address (e.g. for rate limiting).
   set req.http.True-Client-IP = req.http.Fastly-Client-IP;

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -283,6 +283,13 @@ sub vcl_recv {
     set req.http.Authorization = "AWS gcs-mirror-access-id:" digest.hmac_sha1_base64("gcs-mirror-secret-key", "GET" LF LF LF now LF "/gcs-bucket" req.url.path);
   }
   
+  # Add normalization vcl for Brotli support
+  if (req.http.Fastly-Orig-Accept-Encoding) {
+    if (req.http.Fastly-Orig-Accept-Encoding ~ "\bbr\b") {
+      set req.http.Accept-Encoding = "br";
+    }
+  }
+  
 
   # Unspoofable original client address (e.g. for rate limiting).
   set req.http.True-Client-IP = req.http.Fastly-Client-IP;

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -318,6 +318,13 @@ sub vcl_recv {
     set req.http.Date = now;
     set req.http.Authorization = "AWS <%= config.fetch('gcs_mirror_access_id') %>:" digest.hmac_sha1_base64("<%= config.fetch('gcs_mirror_secret_key') %>", "GET" LF LF LF now LF "/<%= config.fetch('gcs_mirror_bucket_name') %>" req.url.path);
   }
+  
+  # Add normalization vcl for Brotli support
+  if (req.http.Fastly-Orig-Accept-Encoding) {
+    if (req.http.Fastly-Orig-Accept-Encoding ~ "\bbr\b") {
+      set req.http.Accept-Encoding = "br";
+    }
+  }
   <% end %>
 
   # Unspoofable original client address (e.g. for rate limiting).


### PR DESCRIPTION
Feedback from Fastly support:
> It looks like `www.gov.uk` doesn't have the normalization vcl in vcl_recv for Brotli support. Once you add that in this should work correctly.

```
if (req.http.Fastly-Orig-Accept-Encoding) {
    if (req.http.Fastly-Orig-Accept-Encoding ~ "\bbr\b") {
      set req.http.Accept-Encoding = "br";
    }
  }
```