### PR TITLE
Prevent modification of Fastly-Client-IP by client

### DIFF
--- a/spec/test-outputs/www-integration.out.vcl
+++ b/spec/test-outputs/www-integration.out.vcl
@@ -121,6 +121,12 @@ sub vcl_recv {
 
   
 
+  # Protect header from modification at the edge of the Fastly network
+  # https://developer.fastly.com/reference/http-headers/Fastly-Client-IP
+  if (fastly.ff.visits_this_service == 0 && req.restarts == 0) {
+    set req.http.Fastly-Client-IP = client.ip;
+  }
+
   # Unspoofable original client address (e.g. for rate limiting).
   set req.http.True-Client-IP = req.http.Fastly-Client-IP;
 
@@ -269,7 +275,7 @@ else if (req.http.Cookie !~ "cookies_preferences_set") {
 sub vcl_fetch {
 #FASTLY fetch
 
-  # Enable brotli 
+  # Enable brotli
   if ((beresp.status == 200 || beresp.status == 404) && (beresp.http.content-type ~ "^(text/html|application/x-javascript|text/css|application/javascript|text/javascript|application/json|application/vnd\.ms-fontobject|application/x-font-opentype|application/x-font-truetype|application/x-font-ttf|application/xml|font/eot|font/opentype|font/otf|image/svg\+xml|image/vnd\.microsoft\.icon|text/plain|text/xml)\s*($|;)" || req.url ~ "\.(css|js|html|eot|ico|otf|ttf|json|svg)($|\?)" ) ) {
     # always set vary to make sure uncompressed versions dont always win
     if (!beresp.http.Vary ~ "Accept-Encoding") {

--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -273,7 +273,7 @@ sub vcl_recv {
     set req.http.Date = now;
     set req.http.Authorization = "AWS gcs-mirror-access-id:" digest.hmac_sha1_base64("gcs-mirror-secret-key", "GET" LF LF LF now LF "/gcs-bucket" req.url.path);
   }
-  
+
   # Add normalization vcl for Brotli support
   if (req.http.Fastly-Orig-Accept-Encoding) {
     if (req.http.Fastly-Orig-Accept-Encoding ~ "\bbr\b") {
@@ -281,6 +281,12 @@ sub vcl_recv {
     }
   }
   
+
+  # Protect header from modification at the edge of the Fastly network
+  # https://developer.fastly.com/reference/http-headers/Fastly-Client-IP
+  if (fastly.ff.visits_this_service == 0 && req.restarts == 0) {
+    set req.http.Fastly-Client-IP = client.ip;
+  }
 
   # Unspoofable original client address (e.g. for rate limiting).
   set req.http.True-Client-IP = req.http.Fastly-Client-IP;
@@ -430,7 +436,7 @@ else if (req.http.Cookie !~ "cookies_preferences_set") {
 sub vcl_fetch {
 #FASTLY fetch
 
-  # Enable brotli 
+  # Enable brotli
   if ((beresp.status == 200 || beresp.status == 404) && (beresp.http.content-type ~ "^(text/html|application/x-javascript|text/css|application/javascript|text/javascript|application/json|application/vnd\.ms-fontobject|application/x-font-opentype|application/x-font-truetype|application/x-font-ttf|application/xml|font/eot|font/opentype|font/otf|image/svg\+xml|image/vnd\.microsoft\.icon|text/plain|text/xml)\s*($|;)" || req.url ~ "\.(css|js|html|eot|ico|otf|ttf|json|svg)($|\?)" ) ) {
     # always set vary to make sure uncompressed versions dont always win
     if (!beresp.http.Vary ~ "Accept-Encoding") {

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -318,7 +318,7 @@ sub vcl_recv {
     set req.http.Date = now;
     set req.http.Authorization = "AWS <%= config.fetch('gcs_mirror_access_id') %>:" digest.hmac_sha1_base64("<%= config.fetch('gcs_mirror_secret_key') %>", "GET" LF LF LF now LF "/<%= config.fetch('gcs_mirror_bucket_name') %>" req.url.path);
   }
-  
+
   # Add normalization vcl for Brotli support
   if (req.http.Fastly-Orig-Accept-Encoding) {
     if (req.http.Fastly-Orig-Accept-Encoding ~ "\bbr\b") {
@@ -326,6 +326,12 @@ sub vcl_recv {
     }
   }
   <% end %>
+
+  # Protect header from modification at the edge of the Fastly network
+  # https://developer.fastly.com/reference/http-headers/Fastly-Client-IP
+  if (fastly.ff.visits_this_service == 0 && req.restarts == 0) {
+    set req.http.Fastly-Client-IP = client.ip;
+  }
 
   # Unspoofable original client address (e.g. for rate limiting).
   set req.http.True-Client-IP = req.http.Fastly-Client-IP;
@@ -364,7 +370,7 @@ sub vcl_recv {
 sub vcl_fetch {
 #FASTLY fetch
 
-  # Enable brotli 
+  # Enable brotli
   if ((beresp.status == 200 || beresp.status == 404) && (beresp.http.content-type ~ "^(text/html|application/x-javascript|text/css|application/javascript|text/javascript|application/json|application/vnd\.ms-fontobject|application/x-font-opentype|application/x-font-truetype|application/x-font-ttf|application/xml|font/eot|font/opentype|font/otf|image/svg\+xml|image/vnd\.microsoft\.icon|text/plain|text/xml)\s*($|;)" || req.url ~ "\.(css|js|html|eot|ico|otf|ttf|json|svg)($|\?)" ) ) {
     # always set vary to make sure uncompressed versions dont always win
     if (!beresp.http.Vary ~ "Accept-Encoding") {


### PR DESCRIPTION
As recommended in Fastly's documentation: https://developer.fastly.com/reference/http-headers/Fastly-Client-IP

If a client sets this header themselves, Fastly will use it. This has implications for us as we set the value of this header as the value of another header 'True-Client-IP', which is later set as the `real_ip_header` in [Nginx config at origin](https://github.com/alphagov/govuk-puppet/blob/32c1bbbb10067078c1406170666a135b4a10aaea/modules/router/templates/router_include.conf.erb#L12).