### PR TITLE
Remove query strings from homepage

### DIFF
--- a/spec/test-outputs/www-integration.out.vcl
+++ b/spec/test-outputs/www-integration.out.vcl
@@ -125,6 +125,11 @@ sub vcl_recv {
     set req.url = querystring.filter_except(req.url, "postcode");
   }
 
+  if (req.url.path == "/") {
+    # get rid of all query parameters
+    set req.url = querystring.remove(req.url);
+  }
+
   
 
   # Protect header from modification at the edge of the Fastly network

--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -218,6 +218,11 @@ sub vcl_recv {
     set req.url = querystring.filter_except(req.url, "postcode");
   }
 
+  if (req.url.path == "/") {
+    # get rid of all query parameters
+    set req.url = querystring.remove(req.url);
+  }
+
   
 
   # Save original request url because req.url changes after restarts.

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -227,6 +227,11 @@ sub vcl_recv {
     set req.url = querystring.filter_except(req.url, "postcode");
   }
 
+  if (req.url.path == "/") {
+    # get rid of all query parameters
+    set req.url = querystring.remove(req.url);
+  }
+
   
 
   # Save original request url because req.url changes after restarts.

--- a/spec/test-outputs/www-test.out.vcl
+++ b/spec/test-outputs/www-test.out.vcl
@@ -121,6 +121,11 @@ sub vcl_recv {
     set req.url = querystring.filter_except(req.url, "postcode");
   }
 
+  if (req.url.path == "/") {
+    # get rid of all query parameters
+    set req.url = querystring.remove(req.url);
+  }
+
   
 
   # Protect header from modification at the edge of the Fastly network

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -263,6 +263,11 @@ sub vcl_recv {
     set req.url = querystring.filter_except(req.url, "postcode");
   }
 
+  if (req.url.path == "/") {
+    # get rid of all query parameters
+    set req.url = querystring.remove(req.url);
+  }
+
   <% if %w(staging production).include?(environment) %>
 
   # Save original request url because req.url changes after restarts.


### PR DESCRIPTION
This will strip query strings from the homepage using a Fastly function [querystring-remove](https://developer.fastly.com/reference/vcl/functions/query-string/querystring-remove)

The homepage's behaviour doesn't change based on query strings so we don't need to include the query params in the cache key.