### PR TITLE
Improve cache hit rate by manipulating query params

### DIFF
--- a/spec/test-outputs/www-integration.out.vcl
+++ b/spec/test-outputs/www-integration.out.vcl
@@ -99,6 +99,12 @@ sub vcl_recv {
     error 805 "security.txt";
   }
 
+  # Sort query params (improve cache hit rate)
+  set req.url = querystring.sort(req.url);
+
+  # Remove any Google Analytics campaign params
+  set req.url = querystring.globfilter(req.url, "utm_*");
+
   # Serve from stale for 24 hours if origin is sick
   set req.grace = 24h;
 

--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -192,6 +192,12 @@ sub vcl_recv {
     error 805 "security.txt";
   }
 
+  # Sort query params (improve cache hit rate)
+  set req.url = querystring.sort(req.url);
+
+  # Remove any Google Analytics campaign params
+  set req.url = querystring.globfilter(req.url, "utm_*");
+
   # Serve from stale for 24 hours if origin is sick
   set req.grace = 24h;
 

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -201,6 +201,12 @@ sub vcl_recv {
     error 805 "security.txt";
   }
 
+  # Sort query params (improve cache hit rate)
+  set req.url = querystring.sort(req.url);
+
+  # Remove any Google Analytics campaign params
+  set req.url = querystring.globfilter(req.url, "utm_*");
+
   # Serve from stale for 24 hours if origin is sick
   set req.grace = 24h;
 

--- a/spec/test-outputs/www-test.out.vcl
+++ b/spec/test-outputs/www-test.out.vcl
@@ -95,6 +95,12 @@ sub vcl_recv {
     error 805 "security.txt";
   }
 
+  # Sort query params (improve cache hit rate)
+  set req.url = querystring.sort(req.url);
+
+  # Remove any Google Analytics campaign params
+  set req.url = querystring.globfilter(req.url, "utm_*");
+
   # Serve from stale for 24 hours if origin is sick
   set req.grace = 24h;
 

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -237,6 +237,12 @@ sub vcl_recv {
     error 805 "security.txt";
   }
 
+  # Sort query params (improve cache hit rate)
+  set req.url = querystring.sort(req.url);
+
+  # Remove any Google Analytics campaign params
+  set req.url = querystring.globfilter(req.url, "utm_*");
+
   # Serve from stale for 24 hours if origin is sick
   set req.grace = 24h;
 


### PR DESCRIPTION
Follows suggestion here: https://developer.fastly.com/solutions/examples/manipulate-query-string