### PR TITLE
Set `Vary: Cookie` for account pages

### DIFF
--- a/spec/test-outputs/www-integration.out.vcl
+++ b/spec/test-outputs/www-integration.out.vcl
@@ -385,6 +385,7 @@ sub vcl_deliver {
 
   if (resp.http.Vary ~ "GOVUK-Account-Session") {
     unset resp.http.Vary:GOVUK-Account-Session;
+    set resp.http.Vary:Cookie = "";
     set resp.http.Cache-Control:private = "";
   }
 

--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -546,6 +546,7 @@ sub vcl_deliver {
 
   if (resp.http.Vary ~ "GOVUK-Account-Session") {
     unset resp.http.Vary:GOVUK-Account-Session;
+    set resp.http.Vary:Cookie = "";
     set resp.http.Cache-Control:private = "";
   }
 

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -555,6 +555,7 @@ sub vcl_deliver {
 
   if (resp.http.Vary ~ "GOVUK-Account-Session") {
     unset resp.http.Vary:GOVUK-Account-Session;
+    set resp.http.Vary:Cookie = "";
     set resp.http.Cache-Control:private = "";
   }
 

--- a/spec/test-outputs/www-test.out.vcl
+++ b/spec/test-outputs/www-test.out.vcl
@@ -381,6 +381,7 @@ sub vcl_deliver {
 
   if (resp.http.Vary ~ "GOVUK-Account-Session") {
     unset resp.http.Vary:GOVUK-Account-Session;
+    set resp.http.Vary:Cookie = "";
     set resp.http.Cache-Control:private = "";
   }
 

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -497,6 +497,7 @@ sub vcl_deliver {
 
   if (resp.http.Vary ~ "GOVUK-Account-Session") {
     unset resp.http.Vary:GOVUK-Account-Session;
+    set resp.http.Vary:Cookie = "";
     set resp.http.Cache-Control:private = "";
   }
 


### PR DESCRIPTION
We have an issue where if a user logs in or logs out, and returns to a
page they have cached, the account navigation in the header doesn't
update until the cache period expires.

Such pages return `Vary: GOVUK-Account-Session` (which makes Fastly
cache them correctly), and we prevent shared caches from holding
them (with `Cache-Control: private`), but the user's browser still
caches them.  This causes the problem described above: something has
changed, but the user's browser doesn't know what, and so it serves
the old version.

The fix is to make caching depend on cookies, so that if the user's
cookies change, the browser knows not to use the cached entry.  The
downside is that we can't tell the browser to be any more granular:
if *any* cookie changes, the browser will make a request to Fastly for
the page.  But Fastly will be able to serve a cached response if
nothing important has changed, so the performance impact isn't as bad
as going all the way to origin.

An alternative would be setting `Cache-Control: no-store` to prevent
caching entirely, but this would make *every* request go to Fastly,
not just those where the cookies have changed, so it would have a
greater performance impact.