### PR TITLE
Add custom GOVUK-Account-Session-Exists request header

### DIFF
--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -315,9 +315,10 @@ sub vcl_recv {
 
 #FASTLY recv
 
-  # RFC 134
+  # GOV.UK accounts
   if (req.http.Cookie ~ "__Host-govuk_account_session") {
     set req.http.GOVUK-Account-Session = req.http.Cookie:__Host-govuk_account_session;
+    set req.http.GOVUK-Account-Session-Exists = "1";
   }
 
   if (req.http.Cookie ~ "cookies_policy") {
@@ -569,21 +570,22 @@ sub vcl_miss {
 }
 
 sub vcl_deliver {
-  # RFC 134
+  # GOV.UK accounts
   if (resp.http.GOVUK-Account-End-Session) {
     add resp.http.Set-Cookie = "__Host-govuk_account_session=; secure; httponly; samesite=lax; path=/; max-age=0";
-    unset resp.http.GOVUK-Account-End-Session;
   } else if (resp.http.GOVUK-Account-Session) {
     add resp.http.Set-Cookie = "__Host-govuk_account_session=" + resp.http.GOVUK-Account-Session + "; secure; httponly; samesite=lax; path=/";
   }
 
   if (resp.http.Vary ~ "GOVUK-Account-Session") {
-    unset resp.http.Vary:GOVUK-Account-Session;
     set resp.http.Vary:Cookie = "";
     set resp.http.Cache-Control:private = "";
   }
 
   unset resp.http.GOVUK-Account-Session;
+  unset resp.http.GOVUK-Account-End-Session;
+  unset resp.http.Vary:GOVUK-Account-Session;
+  unset resp.http.Vary:GOVUK-Account-Session-Exists;
 
   # Set the A/B cookies
   # Only set the A/B example cookie if the request is to the A/B test page. This

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -324,9 +324,10 @@ sub vcl_recv {
 
 #FASTLY recv
 
-  # RFC 134
+  # GOV.UK accounts
   if (req.http.Cookie ~ "__Host-govuk_account_session") {
     set req.http.GOVUK-Account-Session = req.http.Cookie:__Host-govuk_account_session;
+    set req.http.GOVUK-Account-Session-Exists = "1";
   }
 
   if (req.http.Cookie ~ "cookies_policy") {
@@ -578,21 +579,22 @@ sub vcl_miss {
 }
 
 sub vcl_deliver {
-  # RFC 134
+  # GOV.UK accounts
   if (resp.http.GOVUK-Account-End-Session) {
     add resp.http.Set-Cookie = "__Host-govuk_account_session=; secure; httponly; samesite=lax; path=/; max-age=0";
-    unset resp.http.GOVUK-Account-End-Session;
   } else if (resp.http.GOVUK-Account-Session) {
     add resp.http.Set-Cookie = "__Host-govuk_account_session=" + resp.http.GOVUK-Account-Session + "; secure; httponly; samesite=lax; path=/";
   }
 
   if (resp.http.Vary ~ "GOVUK-Account-Session") {
-    unset resp.http.Vary:GOVUK-Account-Session;
     set resp.http.Vary:Cookie = "";
     set resp.http.Cache-Control:private = "";
   }
 
   unset resp.http.GOVUK-Account-Session;
+  unset resp.http.GOVUK-Account-End-Session;
+  unset resp.http.Vary:GOVUK-Account-Session;
+  unset resp.http.Vary:GOVUK-Account-Session-Exists;
 
   # Set the A/B cookies
   # Only set the A/B example cookie if the request is to the A/B test page. This

--- a/spec/test-outputs/www-test.out.vcl
+++ b/spec/test-outputs/www-test.out.vcl
@@ -150,9 +150,10 @@ sub vcl_recv {
 
 #FASTLY recv
 
-  # RFC 134
+  # GOV.UK accounts
   if (req.http.Cookie ~ "__Host-govuk_account_session") {
     set req.http.GOVUK-Account-Session = req.http.Cookie:__Host-govuk_account_session;
+    set req.http.GOVUK-Account-Session-Exists = "1";
   }
 
   if (req.http.Cookie ~ "cookies_policy") {
@@ -404,21 +405,22 @@ sub vcl_miss {
 }
 
 sub vcl_deliver {
-  # RFC 134
+  # GOV.UK accounts
   if (resp.http.GOVUK-Account-End-Session) {
     add resp.http.Set-Cookie = "__Host-govuk_account_session=; secure; httponly; samesite=lax; path=/; max-age=0";
-    unset resp.http.GOVUK-Account-End-Session;
   } else if (resp.http.GOVUK-Account-Session) {
     add resp.http.Set-Cookie = "__Host-govuk_account_session=" + resp.http.GOVUK-Account-Session + "; secure; httponly; samesite=lax; path=/";
   }
 
   if (resp.http.Vary ~ "GOVUK-Account-Session") {
-    unset resp.http.Vary:GOVUK-Account-Session;
     set resp.http.Vary:Cookie = "";
     set resp.http.Cache-Control:private = "";
   }
 
   unset resp.http.GOVUK-Account-Session;
+  unset resp.http.GOVUK-Account-End-Session;
+  unset resp.http.Vary:GOVUK-Account-Session;
+  unset resp.http.Vary:GOVUK-Account-Session-Exists;
 
   # Set the A/B cookies
   # Only set the A/B example cookie if the request is to the A/B test page. This

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -365,9 +365,10 @@ sub vcl_recv {
 
 #FASTLY recv
 
-  # RFC 134
+  # GOV.UK accounts
   if (req.http.Cookie ~ "__Host-govuk_account_session") {
     set req.http.GOVUK-Account-Session = req.http.Cookie:__Host-govuk_account_session;
+    set req.http.GOVUK-Account-Session-Exists = "1";
   }
 
   if (req.http.Cookie ~ "cookies_policy") {
@@ -520,21 +521,22 @@ sub vcl_miss {
 }
 
 sub vcl_deliver {
-  # RFC 134
+  # GOV.UK accounts
   if (resp.http.GOVUK-Account-End-Session) {
     add resp.http.Set-Cookie = "__Host-govuk_account_session=; secure; httponly; samesite=lax; path=/; max-age=0";
-    unset resp.http.GOVUK-Account-End-Session;
   } else if (resp.http.GOVUK-Account-Session) {
     add resp.http.Set-Cookie = "__Host-govuk_account_session=" + resp.http.GOVUK-Account-Session + "; secure; httponly; samesite=lax; path=/";
   }
 
   if (resp.http.Vary ~ "GOVUK-Account-Session") {
-    unset resp.http.Vary:GOVUK-Account-Session;
     set resp.http.Vary:Cookie = "";
     set resp.http.Cache-Control:private = "";
   }
 
   unset resp.http.GOVUK-Account-Session;
+  unset resp.http.GOVUK-Account-End-Session;
+  unset resp.http.Vary:GOVUK-Account-Session;
+  unset resp.http.Vary:GOVUK-Account-Session-Exists;
 
   # Set the A/B cookies
   # Only set the A/B example cookie if the request is to the A/B test page. This


### PR DESCRIPTION
We will use this to show the appropriate navigation (signed in vs
signed out), and `Vary` based on it so we only cache one copy for all
signed in users and one copy for all signed out users, rather than one
copy each for all signed in users.

I don't think we need to add a case for:

    if (resp.http.Vary ~ "GOVUK-Account-Session-Exists")

because `~` is a regex match, so the `~ "GOVUK-Account-Session"` check
should be sufficient.

See also the progressive enhancement ADR for account-api[1].

[1] https://github.com/alphagov/account-api/blob/main/docs/adr/002-progressive-enhancement.md

---

[Trello card](https://trello.com/c/4wd8du6X/987-implement-navigation-caching-behaviour)