### PR TITLE
Never cache pages which manipulate the user's session 

### DIFF
--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -559,6 +559,13 @@ sub vcl_fetch {
   if (beresp.http.Set-Cookie) {
     return (deliver);
   }
+
+  # Never cache responses which manipulate the user's session
+  if (beresp.http.GOVUK-Account-End-Session) {
+    return (pass);
+  } else if (beresp.http.GOVUK-Account-Session) {
+    return (pass);
+  }
 }
 
 sub vcl_hit {
@@ -573,8 +580,10 @@ sub vcl_deliver {
   # GOV.UK accounts
   if (resp.http.GOVUK-Account-End-Session) {
     add resp.http.Set-Cookie = "__Host-govuk_account_session=; secure; httponly; samesite=lax; path=/; max-age=0";
+    set resp.http.Cache-Control:no-store = "";
   } else if (resp.http.GOVUK-Account-Session) {
     add resp.http.Set-Cookie = "__Host-govuk_account_session=" + resp.http.GOVUK-Account-Session + "; secure; httponly; samesite=lax; path=/";
+    set resp.http.Cache-Control:no-store = "";
   }
 
   if (resp.http.Vary ~ "GOVUK-Account-Session") {

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -568,6 +568,13 @@ sub vcl_fetch {
   if (beresp.http.Set-Cookie) {
     return (deliver);
   }
+
+  # Never cache responses which manipulate the user's session
+  if (beresp.http.GOVUK-Account-End-Session) {
+    return (pass);
+  } else if (beresp.http.GOVUK-Account-Session) {
+    return (pass);
+  }
 }
 
 sub vcl_hit {
@@ -582,8 +589,10 @@ sub vcl_deliver {
   # GOV.UK accounts
   if (resp.http.GOVUK-Account-End-Session) {
     add resp.http.Set-Cookie = "__Host-govuk_account_session=; secure; httponly; samesite=lax; path=/; max-age=0";
+    set resp.http.Cache-Control:no-store = "";
   } else if (resp.http.GOVUK-Account-Session) {
     add resp.http.Set-Cookie = "__Host-govuk_account_session=" + resp.http.GOVUK-Account-Session + "; secure; httponly; samesite=lax; path=/";
+    set resp.http.Cache-Control:no-store = "";
   }
 
   if (resp.http.Vary ~ "GOVUK-Account-Session") {

--- a/spec/test-outputs/www-test.out.vcl
+++ b/spec/test-outputs/www-test.out.vcl
@@ -394,6 +394,13 @@ sub vcl_fetch {
   if (beresp.http.Set-Cookie) {
     return (deliver);
   }
+
+  # Never cache responses which manipulate the user's session
+  if (beresp.http.GOVUK-Account-End-Session) {
+    return (pass);
+  } else if (beresp.http.GOVUK-Account-Session) {
+    return (pass);
+  }
 }
 
 sub vcl_hit {
@@ -408,8 +415,10 @@ sub vcl_deliver {
   # GOV.UK accounts
   if (resp.http.GOVUK-Account-End-Session) {
     add resp.http.Set-Cookie = "__Host-govuk_account_session=; secure; httponly; samesite=lax; path=/; max-age=0";
+    set resp.http.Cache-Control:no-store = "";
   } else if (resp.http.GOVUK-Account-Session) {
     add resp.http.Set-Cookie = "__Host-govuk_account_session=" + resp.http.GOVUK-Account-Session + "; secure; httponly; samesite=lax; path=/";
+    set resp.http.Cache-Control:no-store = "";
   }
 
   if (resp.http.Vary ~ "GOVUK-Account-Session") {

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -510,6 +510,13 @@ sub vcl_fetch {
   if (beresp.http.Set-Cookie) {
     return (deliver);
   }
+
+  # Never cache responses which manipulate the user's session
+  if (beresp.http.GOVUK-Account-End-Session) {
+    return (pass);
+  } else if (beresp.http.GOVUK-Account-Session) {
+    return (pass);
+  }
 }
 
 sub vcl_hit {
@@ -524,8 +531,10 @@ sub vcl_deliver {
   # GOV.UK accounts
   if (resp.http.GOVUK-Account-End-Session) {
     add resp.http.Set-Cookie = "__Host-govuk_account_session=; secure; httponly; samesite=lax; path=/; max-age=0";
+    set resp.http.Cache-Control:no-store = "";
   } else if (resp.http.GOVUK-Account-Session) {
     add resp.http.Set-Cookie = "__Host-govuk_account_session=" + resp.http.GOVUK-Account-Session + "; secure; httponly; samesite=lax; path=/";
+    set resp.http.Cache-Control:no-store = "";
   }
 
   if (resp.http.Vary ~ "GOVUK-Account-Session") {


### PR DESCRIPTION
We specify in the govuk_personalisation docs that, if you use it, you *must*
set appropriate caching headers (like `Vary: GOVUK-Account-Session` or
`Cache-Control: no-store`) otherwise we risk showing user B a response
generated based on user A's session:

> Set the `Vary: GOVUK-Account-Session` response header.
>
> This is called as a `before_action`, to ensure that pages
> rendered using one user's session are not served to another by
> our CDN.  You should only skip this action if you are certain
> that the response does not include any personalisation, or if
> you prevent caching in some other way (for example, with
> `Cache-Control: no-store`).

https://github.com/alphagov/govuk_personalisation/blob/a5413087190099a6d74a1912f97acef75ec5de42/lib/govuk_personalisation/controller_concern.rb#L46-L54

This is called as a `before_action`, so an app would have to
intentionally disable it to not set the header.  However, we can apply
a bit of additional defence-in-depth at the CDN level, by recognising
that there is *no* case in which we want to cache a session-change
event (sign in, sign out, or token refresh), and sticking an
appropriate `Cache-Control` header on them in VCL.