### PR TITLE
Bypass cache if there is a flash message to show

### DIFF
--- a/spec/test-outputs/www-integration.out.vcl
+++ b/spec/test-outputs/www-integration.out.vcl
@@ -299,6 +299,12 @@ if (req.http.Cookie ~ "cookies_policy" && req.http.Cookie:cookies_policy ~ "%22u
 # End dynamic section
 
 
+  # Bypass cache if there is a flash message to show (see
+  # govuk_personalisation gem for session encoding logic)
+  if (req.http.GOVUK-Account-Session ~ "\$\$") {
+    return (pass);
+  }
+
   return(lookup);
 }
 

--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -460,6 +460,12 @@ if (req.http.Cookie ~ "cookies_policy" && req.http.Cookie:cookies_policy ~ "%22u
 # End dynamic section
 
 
+  # Bypass cache if there is a flash message to show (see
+  # govuk_personalisation gem for session encoding logic)
+  if (req.http.GOVUK-Account-Session ~ "\$\$") {
+    return (pass);
+  }
+
   return(lookup);
 }
 

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -469,6 +469,12 @@ if (req.http.Cookie ~ "cookies_policy" && req.http.Cookie:cookies_policy ~ "%22u
 # End dynamic section
 
 
+  # Bypass cache if there is a flash message to show (see
+  # govuk_personalisation gem for session encoding logic)
+  if (req.http.GOVUK-Account-Session ~ "\$\$") {
+    return (pass);
+  }
+
   return(lookup);
 }
 

--- a/spec/test-outputs/www-test.out.vcl
+++ b/spec/test-outputs/www-test.out.vcl
@@ -295,6 +295,12 @@ if (req.http.Cookie ~ "cookies_policy" && req.http.Cookie:cookies_policy ~ "%22u
 # End dynamic section
 
 
+  # Bypass cache if there is a flash message to show (see
+  # govuk_personalisation gem for session encoding logic)
+  if (req.http.GOVUK-Account-Session ~ "\$\$") {
+    return (pass);
+  }
+
   return(lookup);
 }
 

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -411,6 +411,12 @@ sub vcl_recv {
   <% template_path = File.join(File.dirname(__FILE__), "vcl_templates/_multivariate_tests.vcl.erb") -%>
   <%= ERB.new(File.new(template_path).read, nil, "-", "_erbout2").result(binding) %>
 
+  # Bypass cache if there is a flash message to show (see
+  # govuk_personalisation gem for session encoding logic)
+  if (req.http.GOVUK-Account-Session ~ "\$\$") {
+    return (pass);
+  }
+
   return(lookup);
 }
 


### PR DESCRIPTION
The account session cookie is set by govuk_personalisation, and is in
one of two formats:

- "#{base64(encrypt(session))}"
- "#{base64(encrypt(session))$$#{flash}"

We want to bypass the cache if there is a flash message, so that the
app can render it.  We considered doing flash messages as a form of
progressive enhancement, but decided that doing them server-side made
more sense and was simpler.

---

[Trello card](https://trello.com/c/V8IhzaMH/983-success-banner-on-content-pages-progressive-enchantment)