### PR TITLE
Use a custom request header for account flash caching purposes

### DIFF
--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -319,6 +319,14 @@ sub vcl_recv {
   if (req.http.Cookie ~ "__Host-govuk_account_session") {
     set req.http.GOVUK-Account-Session = req.http.Cookie:__Host-govuk_account_session;
     set req.http.GOVUK-Account-Session-Exists = "1";
+
+    if (req.http.GOVUK-Account-Session ~ "\$\$(.+)$") {
+      # Not directly used by apps (govuk_personalisation extracts the
+      # flash from the `GOVUK-Account-Session` header), but this is so
+      # we can have `Vary: GOVUK-Account-Session-Flash` as a response
+      # header for pages with success banners (etc).
+      set req.http.GOVUK-Account-Session-Flash = re.group.1;
+    }
   }
 
   if (req.http.Cookie ~ "cookies_policy") {
@@ -460,12 +468,6 @@ if (req.http.Cookie ~ "cookies_policy" && req.http.Cookie:cookies_policy ~ "%22u
 # End dynamic section
 
 
-  # Bypass cache if there is a flash message to show (see
-  # govuk_personalisation gem for session encoding logic)
-  if (req.http.GOVUK-Account-Session ~ "\$\$") {
-    return (pass);
-  }
-
   return(lookup);
 }
 
@@ -601,6 +603,7 @@ sub vcl_deliver {
   unset resp.http.GOVUK-Account-End-Session;
   unset resp.http.Vary:GOVUK-Account-Session;
   unset resp.http.Vary:GOVUK-Account-Session-Exists;
+  unset resp.http.Vary:GOVUK-Account-Session-Flash;
 
   # Set the A/B cookies
   # Only set the A/B example cookie if the request is to the A/B test page. This

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -328,6 +328,14 @@ sub vcl_recv {
   if (req.http.Cookie ~ "__Host-govuk_account_session") {
     set req.http.GOVUK-Account-Session = req.http.Cookie:__Host-govuk_account_session;
     set req.http.GOVUK-Account-Session-Exists = "1";
+
+    if (req.http.GOVUK-Account-Session ~ "\$\$(.+)$") {
+      # Not directly used by apps (govuk_personalisation extracts the
+      # flash from the `GOVUK-Account-Session` header), but this is so
+      # we can have `Vary: GOVUK-Account-Session-Flash` as a response
+      # header for pages with success banners (etc).
+      set req.http.GOVUK-Account-Session-Flash = re.group.1;
+    }
   }
 
   if (req.http.Cookie ~ "cookies_policy") {
@@ -469,12 +477,6 @@ if (req.http.Cookie ~ "cookies_policy" && req.http.Cookie:cookies_policy ~ "%22u
 # End dynamic section
 
 
-  # Bypass cache if there is a flash message to show (see
-  # govuk_personalisation gem for session encoding logic)
-  if (req.http.GOVUK-Account-Session ~ "\$\$") {
-    return (pass);
-  }
-
   return(lookup);
 }
 
@@ -610,6 +612,7 @@ sub vcl_deliver {
   unset resp.http.GOVUK-Account-End-Session;
   unset resp.http.Vary:GOVUK-Account-Session;
   unset resp.http.Vary:GOVUK-Account-Session-Exists;
+  unset resp.http.Vary:GOVUK-Account-Session-Flash;
 
   # Set the A/B cookies
   # Only set the A/B example cookie if the request is to the A/B test page. This

--- a/spec/test-outputs/www-test.out.vcl
+++ b/spec/test-outputs/www-test.out.vcl
@@ -154,6 +154,14 @@ sub vcl_recv {
   if (req.http.Cookie ~ "__Host-govuk_account_session") {
     set req.http.GOVUK-Account-Session = req.http.Cookie:__Host-govuk_account_session;
     set req.http.GOVUK-Account-Session-Exists = "1";
+
+    if (req.http.GOVUK-Account-Session ~ "\$\$(.+)$") {
+      # Not directly used by apps (govuk_personalisation extracts the
+      # flash from the `GOVUK-Account-Session` header), but this is so
+      # we can have `Vary: GOVUK-Account-Session-Flash` as a response
+      # header for pages with success banners (etc).
+      set req.http.GOVUK-Account-Session-Flash = re.group.1;
+    }
   }
 
   if (req.http.Cookie ~ "cookies_policy") {
@@ -295,12 +303,6 @@ if (req.http.Cookie ~ "cookies_policy" && req.http.Cookie:cookies_policy ~ "%22u
 # End dynamic section
 
 
-  # Bypass cache if there is a flash message to show (see
-  # govuk_personalisation gem for session encoding logic)
-  if (req.http.GOVUK-Account-Session ~ "\$\$") {
-    return (pass);
-  }
-
   return(lookup);
 }
 
@@ -436,6 +438,7 @@ sub vcl_deliver {
   unset resp.http.GOVUK-Account-End-Session;
   unset resp.http.Vary:GOVUK-Account-Session;
   unset resp.http.Vary:GOVUK-Account-Session-Exists;
+  unset resp.http.Vary:GOVUK-Account-Session-Flash;
 
   # Set the A/B cookies
   # Only set the A/B example cookie if the request is to the A/B test page. This

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -369,6 +369,14 @@ sub vcl_recv {
   if (req.http.Cookie ~ "__Host-govuk_account_session") {
     set req.http.GOVUK-Account-Session = req.http.Cookie:__Host-govuk_account_session;
     set req.http.GOVUK-Account-Session-Exists = "1";
+
+    if (req.http.GOVUK-Account-Session ~ "\$\$(.+)$") {
+      # Not directly used by apps (govuk_personalisation extracts the
+      # flash from the `GOVUK-Account-Session` header), but this is so
+      # we can have `Vary: GOVUK-Account-Session-Flash` as a response
+      # header for pages with success banners (etc).
+      set req.http.GOVUK-Account-Session-Flash = re.group.1;
+    }
   }
 
   if (req.http.Cookie ~ "cookies_policy") {
@@ -410,12 +418,6 @@ sub vcl_recv {
 
   <% template_path = File.join(File.dirname(__FILE__), "vcl_templates/_multivariate_tests.vcl.erb") -%>
   <%= ERB.new(File.new(template_path).read, nil, "-", "_erbout2").result(binding) %>
-
-  # Bypass cache if there is a flash message to show (see
-  # govuk_personalisation gem for session encoding logic)
-  if (req.http.GOVUK-Account-Session ~ "\$\$") {
-    return (pass);
-  }
 
   return(lookup);
 }
@@ -552,6 +554,7 @@ sub vcl_deliver {
   unset resp.http.GOVUK-Account-End-Session;
   unset resp.http.Vary:GOVUK-Account-Session;
   unset resp.http.Vary:GOVUK-Account-Session-Exists;
+  unset resp.http.Vary:GOVUK-Account-Session-Flash;
 
   # Set the A/B cookies
   # Only set the A/B example cookie if the request is to the A/B test page. This


### PR DESCRIPTION
Previously, we bypassed Fastly when there is a flash message in the
session.  But this isn't enough: there's also our Varnish.

A request header with a corresponding `Vary` response header is the
standard way to handle a request that is conditionally cacheable so,
rather than implementing a further special case for our Varnish, just
go for the standard.

Then, the way a page which shows a flash and account navigation but
doesn't use a user's attributes will work is:

1. It reads and decodes the account session header
2. It sets `Vary: GOVUK-Account-Session-Exists`
3. It sets `Vary: GOVUK-Account-Session-Flash`
4. It fetches the appropriate template from static
5. It reads the flash to determine what will be shown

This is better than just setting `Vary: GOVUK-Account-Session` (which
would also work), because there's no need to cache one
page-with-empty-flash for each individual logged in user.

This replaces #356.

---

[Trello card](https://trello.com/c/V8IhzaMH/983-success-banner-on-content-pages-progressive-enchantment)