### PR TITLE
Use original client IP when checking ACLs

### DIFF
--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -159,16 +159,21 @@ acl purge_ip_allowlist {
 
 
 sub vcl_recv {
+  # Protect header from modification at the edge of the Fastly network
+  # https://developer.fastly.com/reference/http-headers/Fastly-Client-IP
+  if (fastly.ff.visits_this_service == 0 && req.restarts == 0) {
+    set req.http.Fastly-Client-IP = client.ip;
+  }
 
   # Require authentication for FASTLYPURGE requests unless from IP in ACL
-  if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_allowlist) {
+  if (req.request == "FASTLYPURGE" && req.http.Fastly-Client-IP !~ purge_ip_allowlist) {
     set req.http.Fastly-Purge-Requires-Auth = "1";
   }
 
   
 
   # Check whether the remote IP address is in the list of blocked IPs
-  if (table.lookup(ip_address_denylist, client.ip)) {
+  if (table.lookup(ip_address_denylist, req.http.Fastly-Client-IP)) {
     error 403 "Forbidden";
   }
 
@@ -292,12 +297,6 @@ sub vcl_recv {
     }
   }
   
-
-  # Protect header from modification at the edge of the Fastly network
-  # https://developer.fastly.com/reference/http-headers/Fastly-Client-IP
-  if (fastly.ff.visits_this_service == 0 && req.restarts == 0) {
-    set req.http.Fastly-Client-IP = client.ip;
-  }
 
   # Unspoofable original client address (e.g. for rate limiting).
   set req.http.True-Client-IP = req.http.Fastly-Client-IP;

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -163,21 +163,26 @@ acl allowed_ip_addresses {
 
 
 sub vcl_recv {
+  # Protect header from modification at the edge of the Fastly network
+  # https://developer.fastly.com/reference/http-headers/Fastly-Client-IP
+  if (fastly.ff.visits_this_service == 0 && req.restarts == 0) {
+    set req.http.Fastly-Client-IP = client.ip;
+  }
 
   # Require authentication for FASTLYPURGE requests unless from IP in ACL
-  if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_allowlist) {
+  if (req.request == "FASTLYPURGE" && req.http.Fastly-Client-IP !~ purge_ip_allowlist) {
     set req.http.Fastly-Purge-Requires-Auth = "1";
   }
 
   
   # Only allow connections from allowed IP addresses in staging
-  if (! (client.ip ~ allowed_ip_addresses)) {
+  if (! (req.http.Fastly-Client-IP ~ allowed_ip_addresses)) {
     error 403 "Forbidden";
   }
   
 
   # Check whether the remote IP address is in the list of blocked IPs
-  if (table.lookup(ip_address_denylist, client.ip)) {
+  if (table.lookup(ip_address_denylist, req.http.Fastly-Client-IP)) {
     error 403 "Forbidden";
   }
 
@@ -301,12 +306,6 @@ sub vcl_recv {
     }
   }
   
-
-  # Protect header from modification at the edge of the Fastly network
-  # https://developer.fastly.com/reference/http-headers/Fastly-Client-IP
-  if (fastly.ff.visits_this_service == 0 && req.restarts == 0) {
-    set req.http.Fastly-Client-IP = client.ip;
-  }
 
   # Unspoofable original client address (e.g. for rate limiting).
   set req.http.True-Client-IP = req.http.Fastly-Client-IP;

--- a/spec/test-outputs/www-test.out.vcl
+++ b/spec/test-outputs/www-test.out.vcl
@@ -62,16 +62,21 @@ acl allowed_ip_addresses {
 
 
 sub vcl_recv {
+  # Protect header from modification at the edge of the Fastly network
+  # https://developer.fastly.com/reference/http-headers/Fastly-Client-IP
+  if (fastly.ff.visits_this_service == 0 && req.restarts == 0) {
+    set req.http.Fastly-Client-IP = client.ip;
+  }
 
   # Require authentication for FASTLYPURGE requests unless from IP in ACL
-  if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_allowlist) {
+  if (req.request == "FASTLYPURGE" && req.http.Fastly-Client-IP !~ purge_ip_allowlist) {
     set req.http.Fastly-Purge-Requires-Auth = "1";
   }
 
   
 
   # Check whether the remote IP address is in the list of blocked IPs
-  if (table.lookup(ip_address_denylist, client.ip)) {
+  if (table.lookup(ip_address_denylist, req.http.Fastly-Client-IP)) {
     error 403 "Forbidden";
   }
 
@@ -127,12 +132,6 @@ sub vcl_recv {
   }
 
   
-
-  # Protect header from modification at the edge of the Fastly network
-  # https://developer.fastly.com/reference/http-headers/Fastly-Client-IP
-  if (fastly.ff.visits_this_service == 0 && req.restarts == 0) {
-    set req.http.Fastly-Client-IP = client.ip;
-  }
 
   # Unspoofable original client address (e.g. for rate limiting).
   set req.http.True-Client-IP = req.http.Fastly-Client-IP;

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -192,26 +192,31 @@ acl allowed_ip_addresses {
 <% end %>
 
 sub vcl_recv {
+  # Protect header from modification at the edge of the Fastly network
+  # https://developer.fastly.com/reference/http-headers/Fastly-Client-IP
+  if (fastly.ff.visits_this_service == 0 && req.restarts == 0) {
+    set req.http.Fastly-Client-IP = client.ip;
+  }
 
   # Require authentication for FASTLYPURGE requests unless from IP in ACL
-  if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_allowlist) {
+  if (req.request == "FASTLYPURGE" && req.http.Fastly-Client-IP !~ purge_ip_allowlist) {
     set req.http.Fastly-Purge-Requires-Auth = "1";
   }
 
   <% if environment == 'staging' %>
   # Only allow connections from allowed IP addresses in staging
-  if (! (client.ip ~ allowed_ip_addresses)) {
+  if (! (req.http.Fastly-Client-IP ~ allowed_ip_addresses)) {
     error 403 "Forbidden";
   }
   <% end %>
 
   # Check whether the remote IP address is in the list of blocked IPs
-  if (table.lookup(ip_address_denylist, client.ip)) {
+  if (table.lookup(ip_address_denylist, req.http.Fastly-Client-IP)) {
     error 403 "Forbidden";
   }
 
   <% if config['basic_authentication'] %>
-  if (! (client.ip ~ allowed_ip_addresses)) {
+  if (! (req.http.Fastly-Client-IP ~ allowed_ip_addresses)) {
     # Check whether the basic auth credentials are correct in integration
     if (req.http.Authorization != "Basic <%= config['basic_authentication'] %>") {
       error 401 "Unauthorized";
@@ -337,12 +342,6 @@ sub vcl_recv {
     }
   }
   <% end %>
-
-  # Protect header from modification at the edge of the Fastly network
-  # https://developer.fastly.com/reference/http-headers/Fastly-Client-IP
-  if (fastly.ff.visits_this_service == 0 && req.restarts == 0) {
-    set req.http.Fastly-Client-IP = client.ip;
-  }
 
   # Unspoofable original client address (e.g. for rate limiting).
   set req.http.True-Client-IP = req.http.Fastly-Client-IP;


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/179659713

Previously we used "client.ip" to control access to Staging and
Integration, but this won't work for GOV.UK Alerts, since the IP
gets modified due to its use of the shielding feature [1]. This
moves setting the existing Fastly-Client-IP header earlier so that
we can reuse it as a reliable means of checking who's allowed in.

Disclaimer: I haven't tested this, since I don't have access to do
so. I'm fairly confident the header will always be set, so I don't 
expect any of the subsequent uses of it to fail.

[1]: https://developer.fastly.com/reference/vcl/variables/client-connection/client-ip/