### PR TITLE
Remove '/find-coronavirus-local-restrictions' logic

### DIFF
--- a/spec/test-outputs/www-integration.out.vcl
+++ b/spec/test-outputs/www-integration.out.vcl
@@ -120,11 +120,6 @@ sub vcl_recv {
   # Set a request id header to allow requests to be traced through the stack
   set req.http.GOVUK-Request-Id = uuid.version4();
 
-  if (req.url.path == "/find-coronavirus-local-restrictions") {
-    # get rid of all but the postcode param
-    set req.url = querystring.filter_except(req.url, "postcode");
-  }
-
   if (req.url.path == "/") {
     # get rid of all query parameters
     set req.url = querystring.remove(req.url);

--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -213,11 +213,6 @@ sub vcl_recv {
   # Set a request id header to allow requests to be traced through the stack
   set req.http.GOVUK-Request-Id = uuid.version4();
 
-  if (req.url.path == "/find-coronavirus-local-restrictions") {
-    # get rid of all but the postcode param
-    set req.url = querystring.filter_except(req.url, "postcode");
-  }
-
   if (req.url.path == "/") {
     # get rid of all query parameters
     set req.url = querystring.remove(req.url);

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -222,11 +222,6 @@ sub vcl_recv {
   # Set a request id header to allow requests to be traced through the stack
   set req.http.GOVUK-Request-Id = uuid.version4();
 
-  if (req.url.path == "/find-coronavirus-local-restrictions") {
-    # get rid of all but the postcode param
-    set req.url = querystring.filter_except(req.url, "postcode");
-  }
-
   if (req.url.path == "/") {
     # get rid of all query parameters
     set req.url = querystring.remove(req.url);

--- a/spec/test-outputs/www-test.out.vcl
+++ b/spec/test-outputs/www-test.out.vcl
@@ -116,11 +116,6 @@ sub vcl_recv {
   # Set a request id header to allow requests to be traced through the stack
   set req.http.GOVUK-Request-Id = uuid.version4();
 
-  if (req.url.path == "/find-coronavirus-local-restrictions") {
-    # get rid of all but the postcode param
-    set req.url = querystring.filter_except(req.url, "postcode");
-  }
-
   if (req.url.path == "/") {
     # get rid of all query parameters
     set req.url = querystring.remove(req.url);

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -258,11 +258,6 @@ sub vcl_recv {
   # Set a request id header to allow requests to be traced through the stack
   set req.http.GOVUK-Request-Id = uuid.version4();
 
-  if (req.url.path == "/find-coronavirus-local-restrictions") {
-    # get rid of all but the postcode param
-    set req.url = querystring.filter_except(req.url, "postcode");
-  }
-
   if (req.url.path == "/") {
     # get rid of all query parameters
     set req.url = querystring.remove(req.url);


### PR DESCRIPTION
https://www.gov.uk/find-coronavirus-local-restrictions now
redirects to https://www.gov.uk/guidance/covid-19-coronavirus-restrictions-what-you-can-and-cannot-do,
which strips any and all query string parameters from the URL.
Therefore the logic that was added in 33ccb4d935bdce972ee4765a3f596c6c8e18e13a
no longer appears to be used.