### PR TITLE
Update Fastly purge request IP allow list

### DIFF
--- a/spec/test-outputs/www-integration.out.vcl
+++ b/spec/test-outputs/www-integration.out.vcl
@@ -37,24 +37,6 @@ acl purge_ip_allowlist {
   "34.248.44.175";    # AWS Integration NAT gateway
   "52.51.97.232";     # AWS Integration NAT gateway
 
-  "23.235.32.0"/20;   # Fastly cache node
-  "43.249.72.0"/22;   # Fastly cache node
-  "103.244.50.0"/24;  # Fastly cache node
-  "103.245.222.0"/23; # Fastly cache node
-  "103.245.224.0"/24; # Fastly cache node
-  "104.156.80.0"/20;  # Fastly cache node
-  "151.101.0.0"/16;   # Fastly cache node
-  "157.52.64.0"/18;   # Fastly cache node
-  "172.111.64.0"/18;  # Fastly cache node
-  "185.31.16.0"/22;   # Fastly cache node
-  "199.27.72.0"/21;   # Fastly cache node
-  "199.232.0.0"/16;   # Fastly cache node
-  "202.21.128.0"/24;  # Fastly cache node
-  "203.57.145.0"/24;  # Fastly cache node
-  "167.82.0.0"/17;    # Fastly cache node
-  "167.82.128.0"/20;  # Fastly cache node
-  "167.82.160.0"/20;  # Fastly cache node
-  "167.82.224.0"/20;  # Fastly cache node
 }
 
 

--- a/spec/test-outputs/www-integration.out.vcl
+++ b/spec/test-outputs/www-integration.out.vcl
@@ -32,8 +32,6 @@ backend F_origin {
 
 
 acl purge_ip_allowlist {
-  "37.26.93.252";     # Skyscape mirrors
-  "31.210.241.100";   # Carrenza mirrors
 
   "34.248.229.46";    # AWS Integration NAT gateway
   "34.248.44.175";    # AWS Integration NAT gateway

--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -133,24 +133,6 @@ acl purge_ip_allowlist {
   "34.253.57.8";      # AWS NAT GW2
   "18.202.136.43";    # AWS NAT GW3
 
-  "23.235.32.0"/20;   # Fastly cache node
-  "43.249.72.0"/22;   # Fastly cache node
-  "103.244.50.0"/24;  # Fastly cache node
-  "103.245.222.0"/23; # Fastly cache node
-  "103.245.224.0"/24; # Fastly cache node
-  "104.156.80.0"/20;  # Fastly cache node
-  "151.101.0.0"/16;   # Fastly cache node
-  "157.52.64.0"/18;   # Fastly cache node
-  "172.111.64.0"/18;  # Fastly cache node
-  "185.31.16.0"/22;   # Fastly cache node
-  "199.27.72.0"/21;   # Fastly cache node
-  "199.232.0.0"/16;   # Fastly cache node
-  "202.21.128.0"/24;  # Fastly cache node
-  "203.57.145.0"/24;  # Fastly cache node
-  "167.82.0.0"/17;    # Fastly cache node
-  "167.82.128.0"/20;  # Fastly cache node
-  "167.82.160.0"/20;  # Fastly cache node
-  "167.82.224.0"/20;  # Fastly cache node
 }
 
 

--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -128,10 +128,7 @@ backend F_mirrorGCS {
 
 
 acl purge_ip_allowlist {
-  "37.26.93.252";     # Skyscape mirrors
-  "31.210.241.100";   # Carrenza mirrors
 
-  "31.210.245.86";    # Carrenza Production
   "34.246.209.74";    # AWS NAT GW1
   "34.253.57.8";      # AWS NAT GW2
   "18.202.136.43";    # AWS NAT GW3

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -133,24 +133,6 @@ acl purge_ip_allowlist {
   "18.203.90.80";     # AWS NAT GW2
   "18.203.108.248";   # AWS NAT GW3
 
-  "23.235.32.0"/20;   # Fastly cache node
-  "43.249.72.0"/22;   # Fastly cache node
-  "103.244.50.0"/24;  # Fastly cache node
-  "103.245.222.0"/23; # Fastly cache node
-  "103.245.224.0"/24; # Fastly cache node
-  "104.156.80.0"/20;  # Fastly cache node
-  "151.101.0.0"/16;   # Fastly cache node
-  "157.52.64.0"/18;   # Fastly cache node
-  "172.111.64.0"/18;  # Fastly cache node
-  "185.31.16.0"/22;   # Fastly cache node
-  "199.27.72.0"/21;   # Fastly cache node
-  "199.232.0.0"/16;   # Fastly cache node
-  "202.21.128.0"/24;  # Fastly cache node
-  "203.57.145.0"/24;  # Fastly cache node
-  "167.82.0.0"/17;    # Fastly cache node
-  "167.82.128.0"/20;  # Fastly cache node
-  "167.82.160.0"/20;  # Fastly cache node
-  "167.82.224.0"/20;  # Fastly cache node
 }
 
 

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -128,10 +128,7 @@ backend F_mirrorGCS {
 
 
 acl purge_ip_allowlist {
-  "37.26.93.252";     # Skyscape mirrors
-  "31.210.241.100";   # Carrenza mirrors
 
-  "31.210.245.70";    # Carrenza Staging
   "18.202.183.143";   # AWS NAT GW1
   "18.203.90.80";     # AWS NAT GW2
   "18.203.108.248";   # AWS NAT GW3

--- a/spec/test-outputs/www-test.out.vcl
+++ b/spec/test-outputs/www-test.out.vcl
@@ -32,8 +32,6 @@ backend F_origin {
 
 
 acl purge_ip_allowlist {
-  "37.26.93.252";     # Skyscape mirrors
-  "31.210.241.100";   # Carrenza mirrors
 
   "23.235.32.0"/20;   # Fastly cache node
   "43.249.72.0"/22;   # Fastly cache node

--- a/spec/test-outputs/www-test.out.vcl
+++ b/spec/test-outputs/www-test.out.vcl
@@ -33,24 +33,6 @@ backend F_origin {
 
 acl purge_ip_allowlist {
 
-  "23.235.32.0"/20;   # Fastly cache node
-  "43.249.72.0"/22;   # Fastly cache node
-  "103.244.50.0"/24;  # Fastly cache node
-  "103.245.222.0"/23; # Fastly cache node
-  "103.245.224.0"/24; # Fastly cache node
-  "104.156.80.0"/20;  # Fastly cache node
-  "151.101.0.0"/16;   # Fastly cache node
-  "157.52.64.0"/18;   # Fastly cache node
-  "172.111.64.0"/18;  # Fastly cache node
-  "185.31.16.0"/22;   # Fastly cache node
-  "199.27.72.0"/21;   # Fastly cache node
-  "199.232.0.0"/16;   # Fastly cache node
-  "202.21.128.0"/24;  # Fastly cache node
-  "203.57.145.0"/24;  # Fastly cache node
-  "167.82.0.0"/17;    # Fastly cache node
-  "167.82.128.0"/20;  # Fastly cache node
-  "167.82.160.0"/20;  # Fastly cache node
-  "167.82.224.0"/20;  # Fastly cache node
 }
 
 

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -146,19 +146,15 @@ backend F_mirrorGCS {
 <% end %>
 
 acl purge_ip_allowlist {
-  "37.26.93.252";     # Skyscape mirrors
-  "31.210.241.100";   # Carrenza mirrors
 <% if environment == 'integration' %>
   "34.248.229.46";    # AWS Integration NAT gateway
   "34.248.44.175";    # AWS Integration NAT gateway
   "52.51.97.232";     # AWS Integration NAT gateway
 <% elsif environment == 'staging' %>
-  "31.210.245.70";    # Carrenza Staging
   "18.202.183.143";   # AWS NAT GW1
   "18.203.90.80";     # AWS NAT GW2
   "18.203.108.248";   # AWS NAT GW3
 <% elsif environment == 'production' %>
-  "31.210.245.86";    # Carrenza Production
   "34.246.209.74";    # AWS NAT GW1
   "34.253.57.8";      # AWS NAT GW2
   "18.202.136.43";    # AWS NAT GW3

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -159,24 +159,6 @@ acl purge_ip_allowlist {
   "34.253.57.8";      # AWS NAT GW2
   "18.202.136.43";    # AWS NAT GW3
 <% end %>
-  "23.235.32.0"/20;   # Fastly cache node
-  "43.249.72.0"/22;   # Fastly cache node
-  "103.244.50.0"/24;  # Fastly cache node
-  "103.245.222.0"/23; # Fastly cache node
-  "103.245.224.0"/24; # Fastly cache node
-  "104.156.80.0"/20;  # Fastly cache node
-  "151.101.0.0"/16;   # Fastly cache node
-  "157.52.64.0"/18;   # Fastly cache node
-  "172.111.64.0"/18;  # Fastly cache node
-  "185.31.16.0"/22;   # Fastly cache node
-  "199.27.72.0"/21;   # Fastly cache node
-  "199.232.0.0"/16;   # Fastly cache node
-  "202.21.128.0"/24;  # Fastly cache node
-  "203.57.145.0"/24;  # Fastly cache node
-  "167.82.0.0"/17;    # Fastly cache node
-  "167.82.128.0"/20;  # Fastly cache node
-  "167.82.160.0"/20;  # Fastly cache node
-  "167.82.224.0"/20;  # Fastly cache node
 }
 
 <% if %w(staging integration test).include?(environment) %>


### PR DESCRIPTION
## Remove Fastly cache nodes from IP purge list

These IP addresses were [added in 2016](https://github.com/alphagov/govuk-cdn-config/commit/570d4e941f6c542b2dfcd96255b5c7b7916dee45) so that Fastly staff could purge our content if required, but only if they made the request from a Fastly cache node.

I'm not aware of this ever having been necessary since, and should it be so, we would be able to add the required IPs back again either here, or in the Fastly management console.

In addition, Fastly now advise [using API tokens to authenticate purge requests](https://docs.fastly.com/en/guides/authenticating-api-purge-requests).

I've added a [Trello card to the Platform Reliability team backlog][1] to switch this to using API tokens.

[1]: https://trello.com/c/O5Wy2X9w/2613-authenticate-fastly-purge-requests-with-an-api-token

## Remove Skyscape and Carrenza IPs

We no longer have infrastructure here that we would use to communicate with Fastly.

For context:
- Skyscape is UKCloud's former incarnation
- Carrenza is now owned by Six Degrees

Both were hosting providers for parts of GOV.UK in times of yore.