### PR TITLE
Template support for forwarding traffic to EKS.

### DIFF
--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -161,7 +161,7 @@ acl purge_ip_allowlist {
 <% end %>
 }
 
-<% if %w(staging integration test).include?(environment) %>
+<% if not %w(production production-eks).include?(environment) %>
 acl allowed_ip_addresses {
   <% config.fetch('allowed_ip_addresses', []).each do |ip_address| %>
   "<%= ip_address %>";

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -7,6 +7,10 @@ backend F_origin {
     .max_connections = 200;
     .between_bytes_timeout = 10s;
     .share_key = "<%= config.fetch('service_id') %>";
+    <%- if config['set_backend_host_header'] %>
+    .host_header = "<%= config.fetch('origin_hostname') %>";
+    .always_use_host_header = true;
+    <%- end -%>
 
     .ssl = true;
     .ssl_check_cert = <%= config['disable_tls_validation'] ? 'never' : 'always' %>;


### PR DESCRIPTION
A couple of minor changes to support adding an `integration-eks` service in front of the EKS cluster. See individual commit messages for details.

* [Define the allowed_ip_addresses ACL in all non-prod environments.](https://github.com/alphagov/govuk-cdn-config/commit/b57bcc04a3f5ffe412b3356883abced7058e6d30)
* [Allow setting the Host header for requests to the EKS backend.](https://github.com/alphagov/govuk-cdn-config/commit/c9a5e96ec5655a717baee2293bc6785514abb17f)

Prerequisite for alphagov/govuk-cdn-config-secrets#147.

[Trello](https://trello.com/c/9BPpFRBe/851)