### PR TITLE
Update Fastly ACLs

### DIFF
--- a/lib/deploy_service.rb
+++ b/lib/deploy_service.rb
@@ -14,6 +14,13 @@ class DeployService
     puts "Environment: #{environment}"
 
     vcl = RenderTemplate.render_template(configuration, environment, config, version)
+
+    dry_run = ENV.fetch("FASTLY_DRY_RUN", "").downcase
+    unless ["", "0", "false"].include?(dry_run)
+      puts vcl
+      exit
+    end
+
     delete_ui_objects(service.id, version.number)
     upload_vcl(version, vcl)
     diff_vcl(service, version)

--- a/spec/test-outputs/assets-integration.out.vcl
+++ b/spec/test-outputs/assets-integration.out.vcl
@@ -33,27 +33,6 @@ backend F_awsorigin {
 
 
 acl purge_ip_allowlist {
-  "37.26.93.252";     # Skyscape mirrors
-  "31.210.241.100";   # Carrenza mirrors
-
-  "23.235.32.0"/20;   # Fastly cache node
-  "43.249.72.0"/22;   # Fastly cache node
-  "103.244.50.0"/24;  # Fastly cache node
-  "103.245.222.0"/23; # Fastly cache node
-  "103.245.224.0"/24; # Fastly cache node
-  "104.156.80.0"/20;  # Fastly cache node
-  "151.101.0.0"/16;   # Fastly cache node
-  "157.52.64.0"/18;   # Fastly cache node
-  "172.111.64.0"/18;  # Fastly cache node
-  "185.31.16.0"/22;   # Fastly cache node
-  "199.27.72.0"/21;   # Fastly cache node
-  "199.232.0.0"/16;   # Fastly cache node
-  "202.21.128.0"/24;  # Fastly cache node
-  "203.57.145.0"/24;  # Fastly cache node
-  "167.82.0.0"/17;    # Fastly cache node
-  "167.82.128.0"/20;  # Fastly cache node
-  "167.82.160.0"/20;  # Fastly cache node
-  "167.82.224.0"/20;  # Fastly cache node
 }
 
 sub vcl_recv {

--- a/spec/test-outputs/assets-production.out.vcl
+++ b/spec/test-outputs/assets-production.out.vcl
@@ -129,32 +129,9 @@ backend F_mirrorGCS {
 
 
 acl purge_ip_allowlist {
-  "37.26.93.252";     # Skyscape mirrors
-  "31.210.241.100";   # Carrenza mirrors
-
-  "31.210.245.86";    # Carrenza Production
   "18.202.136.43";    # AWS Production
   "34.246.209.74";    # AWS Production
   "34.253.57.8";      # AWS Production
-
-  "23.235.32.0"/20;   # Fastly cache node
-  "43.249.72.0"/22;   # Fastly cache node
-  "103.244.50.0"/24;  # Fastly cache node
-  "103.245.222.0"/23; # Fastly cache node
-  "103.245.224.0"/24; # Fastly cache node
-  "104.156.80.0"/20;  # Fastly cache node
-  "151.101.0.0"/16;   # Fastly cache node
-  "157.52.64.0"/18;   # Fastly cache node
-  "172.111.64.0"/18;  # Fastly cache node
-  "185.31.16.0"/22;   # Fastly cache node
-  "199.27.72.0"/21;   # Fastly cache node
-  "199.232.0.0"/16;   # Fastly cache node
-  "202.21.128.0"/24;  # Fastly cache node
-  "203.57.145.0"/24;  # Fastly cache node
-  "167.82.0.0"/17;    # Fastly cache node
-  "167.82.128.0"/20;  # Fastly cache node
-  "167.82.160.0"/20;  # Fastly cache node
-  "167.82.224.0"/20;  # Fastly cache node
 }
 
 sub vcl_recv {

--- a/spec/test-outputs/assets-staging.out.vcl
+++ b/spec/test-outputs/assets-staging.out.vcl
@@ -129,32 +129,9 @@ backend F_mirrorGCS {
 
 
 acl purge_ip_allowlist {
-  "37.26.93.252";     # Skyscape mirrors
-  "31.210.241.100";   # Carrenza mirrors
-
-  "31.210.245.70";    # Carrenza Staging
   "18.203.108.248";   # AWS Staging
   "18.202.183.143";   # AWS Staging
   "18.203.90.80";     # AWS Staging
-
-  "23.235.32.0"/20;   # Fastly cache node
-  "43.249.72.0"/22;   # Fastly cache node
-  "103.244.50.0"/24;  # Fastly cache node
-  "103.245.222.0"/23; # Fastly cache node
-  "103.245.224.0"/24; # Fastly cache node
-  "104.156.80.0"/20;  # Fastly cache node
-  "151.101.0.0"/16;   # Fastly cache node
-  "157.52.64.0"/18;   # Fastly cache node
-  "172.111.64.0"/18;  # Fastly cache node
-  "185.31.16.0"/22;   # Fastly cache node
-  "199.27.72.0"/21;   # Fastly cache node
-  "199.232.0.0"/16;   # Fastly cache node
-  "202.21.128.0"/24;  # Fastly cache node
-  "203.57.145.0"/24;  # Fastly cache node
-  "167.82.0.0"/17;    # Fastly cache node
-  "167.82.128.0"/20;  # Fastly cache node
-  "167.82.160.0"/20;  # Fastly cache node
-  "167.82.224.0"/20;  # Fastly cache node
 }
 
 sub vcl_recv {

--- a/spec/test-outputs/assets-test.out.vcl
+++ b/spec/test-outputs/assets-test.out.vcl
@@ -33,27 +33,6 @@ backend F_awsorigin {
 
 
 acl purge_ip_allowlist {
-  "37.26.93.252";     # Skyscape mirrors
-  "31.210.241.100";   # Carrenza mirrors
-
-  "23.235.32.0"/20;   # Fastly cache node
-  "43.249.72.0"/22;   # Fastly cache node
-  "103.244.50.0"/24;  # Fastly cache node
-  "103.245.222.0"/23; # Fastly cache node
-  "103.245.224.0"/24; # Fastly cache node
-  "104.156.80.0"/20;  # Fastly cache node
-  "151.101.0.0"/16;   # Fastly cache node
-  "157.52.64.0"/18;   # Fastly cache node
-  "172.111.64.0"/18;  # Fastly cache node
-  "185.31.16.0"/22;   # Fastly cache node
-  "199.27.72.0"/21;   # Fastly cache node
-  "199.232.0.0"/16;   # Fastly cache node
-  "202.21.128.0"/24;  # Fastly cache node
-  "203.57.145.0"/24;  # Fastly cache node
-  "167.82.0.0"/17;    # Fastly cache node
-  "167.82.128.0"/20;  # Fastly cache node
-  "167.82.160.0"/20;  # Fastly cache node
-  "167.82.224.0"/20;  # Fastly cache node
 }
 
 sub vcl_recv {

--- a/spec/test-outputs/mirror-integration.out.vcl
+++ b/spec/test-outputs/mirror-integration.out.vcl
@@ -32,31 +32,12 @@ backend F_origin {
 
 
 acl purge_ip_allowlist {
-  "37.26.93.252";     # Skyscape mirrors
-  "31.210.241.100";   # Carrenza mirrors
-
-  "23.235.32.0"/20;   # Fastly cache node
-  "43.249.72.0"/22;   # Fastly cache node
-  "103.244.50.0"/24;  # Fastly cache node
-  "103.245.222.0"/23; # Fastly cache node
-  "103.245.224.0"/24; # Fastly cache node
-  "104.156.80.0"/20;  # Fastly cache node
-  "151.101.0.0"/16;   # Fastly cache node
-  "157.52.64.0"/18;   # Fastly cache node
-  "172.111.64.0"/18;  # Fastly cache node
-  "185.31.16.0"/22;   # Fastly cache node
-  "199.27.72.0"/21;   # Fastly cache node
-  "199.232.0.0"/16;   # Fastly cache node
-  "202.21.128.0"/24;  # Fastly cache node
-  "203.57.145.0"/24;  # Fastly cache node
-  "167.82.0.0"/17;    # Fastly cache node
-  "167.82.128.0"/20;  # Fastly cache node
-  "167.82.160.0"/20;  # Fastly cache node
-  "167.82.224.0"/20;  # Fastly cache node
+  "34.248.229.46";    # AWS Integration NAT gateway
+  "34.248.44.175";    # AWS Integration NAT gateway
+  "52.51.97.232";     # AWS Integration NAT gateway
 }
 
 acl allowed_ip_addresses {
-  
 }
 
 sub vcl_recv {

--- a/spec/test-outputs/mirror-production.out.vcl
+++ b/spec/test-outputs/mirror-production.out.vcl
@@ -128,36 +128,12 @@ backend F_mirrorGCS {
 
 
 acl purge_ip_allowlist {
-  "37.26.93.252";     # Skyscape mirrors
-  "31.210.241.100";   # Carrenza mirrors
-
-  "31.210.245.86";    # Carrenza Production
   "34.246.209.74";    # AWS NAT GW1
   "34.253.57.8";      # AWS NAT GW2
   "18.202.136.43";    # AWS NAT GW3
-
-  "23.235.32.0"/20;   # Fastly cache node
-  "43.249.72.0"/22;   # Fastly cache node
-  "103.244.50.0"/24;  # Fastly cache node
-  "103.245.222.0"/23; # Fastly cache node
-  "103.245.224.0"/24; # Fastly cache node
-  "104.156.80.0"/20;  # Fastly cache node
-  "151.101.0.0"/16;   # Fastly cache node
-  "157.52.64.0"/18;   # Fastly cache node
-  "172.111.64.0"/18;  # Fastly cache node
-  "185.31.16.0"/22;   # Fastly cache node
-  "199.27.72.0"/21;   # Fastly cache node
-  "199.232.0.0"/16;   # Fastly cache node
-  "202.21.128.0"/24;  # Fastly cache node
-  "203.57.145.0"/24;  # Fastly cache node
-  "167.82.0.0"/17;    # Fastly cache node
-  "167.82.128.0"/20;  # Fastly cache node
-  "167.82.160.0"/20;  # Fastly cache node
-  "167.82.224.0"/20;  # Fastly cache node
 }
 
 acl allowed_ip_addresses {
-  
 }
 
 sub vcl_recv {

--- a/spec/test-outputs/mirror-staging.out.vcl
+++ b/spec/test-outputs/mirror-staging.out.vcl
@@ -128,36 +128,12 @@ backend F_mirrorGCS {
 
 
 acl purge_ip_allowlist {
-  "37.26.93.252";     # Skyscape mirrors
-  "31.210.241.100";   # Carrenza mirrors
-
-  "31.210.245.70";    # Carrenza Staging
   "18.202.183.143";   # AWS NAT GW1
   "18.203.90.80";     # AWS NAT GW2
   "18.203.108.248";   # AWS NAT GW3
-
-  "23.235.32.0"/20;   # Fastly cache node
-  "43.249.72.0"/22;   # Fastly cache node
-  "103.244.50.0"/24;  # Fastly cache node
-  "103.245.222.0"/23; # Fastly cache node
-  "103.245.224.0"/24; # Fastly cache node
-  "104.156.80.0"/20;  # Fastly cache node
-  "151.101.0.0"/16;   # Fastly cache node
-  "157.52.64.0"/18;   # Fastly cache node
-  "172.111.64.0"/18;  # Fastly cache node
-  "185.31.16.0"/22;   # Fastly cache node
-  "199.27.72.0"/21;   # Fastly cache node
-  "199.232.0.0"/16;   # Fastly cache node
-  "202.21.128.0"/24;  # Fastly cache node
-  "203.57.145.0"/24;  # Fastly cache node
-  "167.82.0.0"/17;    # Fastly cache node
-  "167.82.128.0"/20;  # Fastly cache node
-  "167.82.160.0"/20;  # Fastly cache node
-  "167.82.224.0"/20;  # Fastly cache node
 }
 
 acl allowed_ip_addresses {
-  
 }
 
 sub vcl_recv {

--- a/spec/test-outputs/mirror-test.out.vcl
+++ b/spec/test-outputs/mirror-test.out.vcl
@@ -32,31 +32,9 @@ backend F_origin {
 
 
 acl purge_ip_allowlist {
-  "37.26.93.252";     # Skyscape mirrors
-  "31.210.241.100";   # Carrenza mirrors
-
-  "23.235.32.0"/20;   # Fastly cache node
-  "43.249.72.0"/22;   # Fastly cache node
-  "103.244.50.0"/24;  # Fastly cache node
-  "103.245.222.0"/23; # Fastly cache node
-  "103.245.224.0"/24; # Fastly cache node
-  "104.156.80.0"/20;  # Fastly cache node
-  "151.101.0.0"/16;   # Fastly cache node
-  "157.52.64.0"/18;   # Fastly cache node
-  "172.111.64.0"/18;  # Fastly cache node
-  "185.31.16.0"/22;   # Fastly cache node
-  "199.27.72.0"/21;   # Fastly cache node
-  "199.232.0.0"/16;   # Fastly cache node
-  "202.21.128.0"/24;  # Fastly cache node
-  "203.57.145.0"/24;  # Fastly cache node
-  "167.82.0.0"/17;    # Fastly cache node
-  "167.82.128.0"/20;  # Fastly cache node
-  "167.82.160.0"/20;  # Fastly cache node
-  "167.82.224.0"/20;  # Fastly cache node
 }
 
 acl allowed_ip_addresses {
-  
 }
 
 sub vcl_recv {

--- a/spec/test-outputs/performanceplatform-integration.out.vcl
+++ b/spec/test-outputs/performanceplatform-integration.out.vcl
@@ -41,26 +41,17 @@ backend sick_force_grace {
 
 
 acl purge_ip_allowlist {
-  "37.26.93.252";     # Skyscape mirrors
-  "31.210.241.100";   # Carrenza mirrors
-  "23.235.32.0"/20;   # Fastly cache node
-  "43.249.72.0"/22;   # Fastly cache node
-  "103.244.50.0"/24;  # Fastly cache node
-  "103.245.222.0"/23; # Fastly cache node
-  "103.245.224.0"/24; # Fastly cache node
-  "104.156.80.0"/20;  # Fastly cache node
-  "151.101.0.0"/16;   # Fastly cache node
-  "157.52.64.0"/18;   # Fastly cache node
-  "172.111.64.0"/18;  # Fastly cache node
-  "185.31.16.0"/22;   # Fastly cache node
-  "199.27.72.0"/21;   # Fastly cache node
-  "199.232.0.0"/16;   # Fastly cache node
-  "202.21.128.0"/24;  # Fastly cache node
-  "203.57.145.0"/24;  # Fastly cache node
-  "167.82.0.0"/17;    # Fastly cache node
-  "167.82.128.0"/20;  # Fastly cache node
-  "167.82.160.0"/20;  # Fastly cache node
-  "167.82.224.0"/20;  # Fastly cache node
+  # See https://sites.google.com/a/digital.cabinet-office.gov.uk/gds/working-at-the-white-chapel-building/gds-internal-it/gds-internal-it-network-public-ip-addresses
+  "213.86.153.211";  # GDS Office (BYOD VPN)
+  "213.86.153.212";  # GDS Office
+  "213.86.153.213";  # GDS Office
+  "213.86.153.214";  # GDS Office
+  "213.86.153.231";  # GDS Office (BYOD VPN)
+  "213.86.153.235";  # GDS Office
+  "213.86.153.236";  # GDS Office
+  "213.86.153.237";  # GDS Office
+  "51.149.8.0"/25;   # GDS Office (DR VPN)
+  "51.149.8.128"/29; # GDS Office (DR BYOD VPN)
 }
 
 sub vcl_recv {

--- a/spec/test-outputs/performanceplatform-production.out.vcl
+++ b/spec/test-outputs/performanceplatform-production.out.vcl
@@ -41,26 +41,17 @@ backend sick_force_grace {
 
 
 acl purge_ip_allowlist {
-  "37.26.93.252";     # Skyscape mirrors
-  "31.210.241.100";   # Carrenza mirrors
-  "23.235.32.0"/20;   # Fastly cache node
-  "43.249.72.0"/22;   # Fastly cache node
-  "103.244.50.0"/24;  # Fastly cache node
-  "103.245.222.0"/23; # Fastly cache node
-  "103.245.224.0"/24; # Fastly cache node
-  "104.156.80.0"/20;  # Fastly cache node
-  "151.101.0.0"/16;   # Fastly cache node
-  "157.52.64.0"/18;   # Fastly cache node
-  "172.111.64.0"/18;  # Fastly cache node
-  "185.31.16.0"/22;   # Fastly cache node
-  "199.27.72.0"/21;   # Fastly cache node
-  "199.232.0.0"/16;   # Fastly cache node
-  "202.21.128.0"/24;  # Fastly cache node
-  "203.57.145.0"/24;  # Fastly cache node
-  "167.82.0.0"/17;    # Fastly cache node
-  "167.82.128.0"/20;  # Fastly cache node
-  "167.82.160.0"/20;  # Fastly cache node
-  "167.82.224.0"/20;  # Fastly cache node
+  # See https://sites.google.com/a/digital.cabinet-office.gov.uk/gds/working-at-the-white-chapel-building/gds-internal-it/gds-internal-it-network-public-ip-addresses
+  "213.86.153.211";  # GDS Office (BYOD VPN)
+  "213.86.153.212";  # GDS Office
+  "213.86.153.213";  # GDS Office
+  "213.86.153.214";  # GDS Office
+  "213.86.153.231";  # GDS Office (BYOD VPN)
+  "213.86.153.235";  # GDS Office
+  "213.86.153.236";  # GDS Office
+  "213.86.153.237";  # GDS Office
+  "51.149.8.0"/25;   # GDS Office (DR VPN)
+  "51.149.8.128"/29; # GDS Office (DR BYOD VPN)
 }
 
 sub vcl_recv {

--- a/spec/test-outputs/performanceplatform-staging.out.vcl
+++ b/spec/test-outputs/performanceplatform-staging.out.vcl
@@ -41,26 +41,17 @@ backend sick_force_grace {
 
 
 acl purge_ip_allowlist {
-  "37.26.93.252";     # Skyscape mirrors
-  "31.210.241.100";   # Carrenza mirrors
-  "23.235.32.0"/20;   # Fastly cache node
-  "43.249.72.0"/22;   # Fastly cache node
-  "103.244.50.0"/24;  # Fastly cache node
-  "103.245.222.0"/23; # Fastly cache node
-  "103.245.224.0"/24; # Fastly cache node
-  "104.156.80.0"/20;  # Fastly cache node
-  "151.101.0.0"/16;   # Fastly cache node
-  "157.52.64.0"/18;   # Fastly cache node
-  "172.111.64.0"/18;  # Fastly cache node
-  "185.31.16.0"/22;   # Fastly cache node
-  "199.27.72.0"/21;   # Fastly cache node
-  "199.232.0.0"/16;   # Fastly cache node
-  "202.21.128.0"/24;  # Fastly cache node
-  "203.57.145.0"/24;  # Fastly cache node
-  "167.82.0.0"/17;    # Fastly cache node
-  "167.82.128.0"/20;  # Fastly cache node
-  "167.82.160.0"/20;  # Fastly cache node
-  "167.82.224.0"/20;  # Fastly cache node
+  # See https://sites.google.com/a/digital.cabinet-office.gov.uk/gds/working-at-the-white-chapel-building/gds-internal-it/gds-internal-it-network-public-ip-addresses
+  "213.86.153.211";  # GDS Office (BYOD VPN)
+  "213.86.153.212";  # GDS Office
+  "213.86.153.213";  # GDS Office
+  "213.86.153.214";  # GDS Office
+  "213.86.153.231";  # GDS Office (BYOD VPN)
+  "213.86.153.235";  # GDS Office
+  "213.86.153.236";  # GDS Office
+  "213.86.153.237";  # GDS Office
+  "51.149.8.0"/25;   # GDS Office (DR VPN)
+  "51.149.8.128"/29; # GDS Office (DR BYOD VPN)
 }
 
 sub vcl_recv {

--- a/spec/test-outputs/performanceplatform-test.out.vcl
+++ b/spec/test-outputs/performanceplatform-test.out.vcl
@@ -41,26 +41,17 @@ backend sick_force_grace {
 
 
 acl purge_ip_allowlist {
-  "37.26.93.252";     # Skyscape mirrors
-  "31.210.241.100";   # Carrenza mirrors
-  "23.235.32.0"/20;   # Fastly cache node
-  "43.249.72.0"/22;   # Fastly cache node
-  "103.244.50.0"/24;  # Fastly cache node
-  "103.245.222.0"/23; # Fastly cache node
-  "103.245.224.0"/24; # Fastly cache node
-  "104.156.80.0"/20;  # Fastly cache node
-  "151.101.0.0"/16;   # Fastly cache node
-  "157.52.64.0"/18;   # Fastly cache node
-  "172.111.64.0"/18;  # Fastly cache node
-  "185.31.16.0"/22;   # Fastly cache node
-  "199.27.72.0"/21;   # Fastly cache node
-  "199.232.0.0"/16;   # Fastly cache node
-  "202.21.128.0"/24;  # Fastly cache node
-  "203.57.145.0"/24;  # Fastly cache node
-  "167.82.0.0"/17;    # Fastly cache node
-  "167.82.128.0"/20;  # Fastly cache node
-  "167.82.160.0"/20;  # Fastly cache node
-  "167.82.224.0"/20;  # Fastly cache node
+  # See https://sites.google.com/a/digital.cabinet-office.gov.uk/gds/working-at-the-white-chapel-building/gds-internal-it/gds-internal-it-network-public-ip-addresses
+  "213.86.153.211";  # GDS Office (BYOD VPN)
+  "213.86.153.212";  # GDS Office
+  "213.86.153.213";  # GDS Office
+  "213.86.153.214";  # GDS Office
+  "213.86.153.231";  # GDS Office (BYOD VPN)
+  "213.86.153.235";  # GDS Office
+  "213.86.153.236";  # GDS Office
+  "213.86.153.237";  # GDS Office
+  "51.149.8.0"/25;   # GDS Office (DR VPN)
+  "51.149.8.128"/29; # GDS Office (DR BYOD VPN)
 }
 
 sub vcl_recv {

--- a/spec/test-outputs/www-integration.out.vcl
+++ b/spec/test-outputs/www-integration.out.vcl
@@ -32,16 +32,13 @@ backend F_origin {
 
 
 acl purge_ip_allowlist {
-
   "34.248.229.46";    # AWS Integration NAT gateway
   "34.248.44.175";    # AWS Integration NAT gateway
   "52.51.97.232";     # AWS Integration NAT gateway
-
 }
 
 
 acl allowed_ip_addresses {
-  
 }
 
 

--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -128,11 +128,9 @@ backend F_mirrorGCS {
 
 
 acl purge_ip_allowlist {
-
   "34.246.209.74";    # AWS NAT GW1
   "34.253.57.8";      # AWS NAT GW2
   "18.202.136.43";    # AWS NAT GW3
-
 }
 
 

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -128,16 +128,13 @@ backend F_mirrorGCS {
 
 
 acl purge_ip_allowlist {
-
   "18.202.183.143";   # AWS NAT GW1
   "18.203.90.80";     # AWS NAT GW2
   "18.203.108.248";   # AWS NAT GW3
-
 }
 
 
 acl allowed_ip_addresses {
-  
 }
 
 

--- a/spec/test-outputs/www-test.out.vcl
+++ b/spec/test-outputs/www-test.out.vcl
@@ -32,12 +32,10 @@ backend F_origin {
 
 
 acl purge_ip_allowlist {
-
 }
 
 
 acl allowed_ip_addresses {
-  
 }
 
 

--- a/vcl_templates/assets.vcl.erb
+++ b/vcl_templates/assets.vcl.erb
@@ -143,37 +143,15 @@ backend F_mirrorGCS {
 <% end %>
 
 acl purge_ip_allowlist {
-  "37.26.93.252";     # Skyscape mirrors
-  "31.210.241.100";   # Carrenza mirrors
-<% if environment == 'staging' %>
-  "31.210.245.70";    # Carrenza Staging
+<%- if environment.start_with? 'staging' -%>
   "18.203.108.248";   # AWS Staging
   "18.202.183.143";   # AWS Staging
   "18.203.90.80";     # AWS Staging
-<% elsif environment == 'production' %>
-  "31.210.245.86";    # Carrenza Production
+<%- elsif environment.start_with? 'production' -%>
   "18.202.136.43";    # AWS Production
   "34.246.209.74";    # AWS Production
   "34.253.57.8";      # AWS Production
-<% end %>
-  "23.235.32.0"/20;   # Fastly cache node
-  "43.249.72.0"/22;   # Fastly cache node
-  "103.244.50.0"/24;  # Fastly cache node
-  "103.245.222.0"/23; # Fastly cache node
-  "103.245.224.0"/24; # Fastly cache node
-  "104.156.80.0"/20;  # Fastly cache node
-  "151.101.0.0"/16;   # Fastly cache node
-  "157.52.64.0"/18;   # Fastly cache node
-  "172.111.64.0"/18;  # Fastly cache node
-  "185.31.16.0"/22;   # Fastly cache node
-  "199.27.72.0"/21;   # Fastly cache node
-  "199.232.0.0"/16;   # Fastly cache node
-  "202.21.128.0"/24;  # Fastly cache node
-  "203.57.145.0"/24;  # Fastly cache node
-  "167.82.0.0"/17;    # Fastly cache node
-  "167.82.128.0"/20;  # Fastly cache node
-  "167.82.160.0"/20;  # Fastly cache node
-  "167.82.224.0"/20;  # Fastly cache node
+<%- end -%>
 }
 
 sub vcl_recv {

--- a/vcl_templates/bouncer.vcl.erb
+++ b/vcl_templates/bouncer.vcl.erb
@@ -30,14 +30,17 @@ backend sick_force_grace {
 
 
 acl purge_ip_allowlist {
-  "80.194.77.90";    # Aviation House
-  "80.194.77.100";   # Aviation House
-  "213.86.153.212";  # White Chapel Building
-  "213.86.153.213";  # White Chapel Building
-  "213.86.153.214";  # White Chapel Building
-  "213.86.153.235";  # White Chapel Building
-  "213.86.153.236";  # White Chapel Building
-  "213.86.153.237";  # White Chapel Building
+  # See https://sites.google.com/a/digital.cabinet-office.gov.uk/gds/working-at-the-white-chapel-building/gds-internal-it/gds-internal-it-network-public-ip-addresses
+  "213.86.153.211";  # GDS Office (BYOD VPN)
+  "213.86.153.212";  # GDS Office
+  "213.86.153.213";  # GDS Office
+  "213.86.153.214";  # GDS Office
+  "213.86.153.231";  # GDS Office (BYOD VPN)
+  "213.86.153.235";  # GDS Office
+  "213.86.153.236";  # GDS Office
+  "213.86.153.237";  # GDS Office
+  "51.149.8.0"/25;   # GDS Office (DR VPN)
+  "51.149.8.128"/29; # GDS Office (DR BYOD VPN)
 }
 
 sub vcl_recv {

--- a/vcl_templates/mirror.vcl.erb
+++ b/vcl_templates/mirror.vcl.erb
@@ -146,43 +146,30 @@ backend F_mirrorGCS {
 <% end %>
 
 acl purge_ip_allowlist {
-  "37.26.93.252";     # Skyscape mirrors
-  "31.210.241.100";   # Carrenza mirrors
-<% if environment == 'staging' %>
-  "31.210.245.70";    # Carrenza Staging
+<%- if environment.start_with? 'integration' -%>
+  "34.248.229.46";    # AWS Integration NAT gateway
+  "34.248.44.175";    # AWS Integration NAT gateway
+  "52.51.97.232";     # AWS Integration NAT gateway
+<%- elsif environment.start_with? 'staging' -%>
   "18.202.183.143";   # AWS NAT GW1
   "18.203.90.80";     # AWS NAT GW2
   "18.203.108.248";   # AWS NAT GW3
-<% elsif environment == 'production' %>
-  "31.210.245.86";    # Carrenza Production
+<%- elsif environment.start_with? 'production' -%>
   "34.246.209.74";    # AWS NAT GW1
   "34.253.57.8";      # AWS NAT GW2
   "18.202.136.43";    # AWS NAT GW3
-<% end %>
-  "23.235.32.0"/20;   # Fastly cache node
-  "43.249.72.0"/22;   # Fastly cache node
-  "103.244.50.0"/24;  # Fastly cache node
-  "103.245.222.0"/23; # Fastly cache node
-  "103.245.224.0"/24; # Fastly cache node
-  "104.156.80.0"/20;  # Fastly cache node
-  "151.101.0.0"/16;   # Fastly cache node
-  "157.52.64.0"/18;   # Fastly cache node
-  "172.111.64.0"/18;  # Fastly cache node
-  "185.31.16.0"/22;   # Fastly cache node
-  "199.27.72.0"/21;   # Fastly cache node
-  "199.232.0.0"/16;   # Fastly cache node
-  "202.21.128.0"/24;  # Fastly cache node
-  "203.57.145.0"/24;  # Fastly cache node
-  "167.82.0.0"/17;    # Fastly cache node
-  "167.82.128.0"/20;  # Fastly cache node
-  "167.82.160.0"/20;  # Fastly cache node
-  "167.82.224.0"/20;  # Fastly cache node
+<%- end -%>
 }
 
 acl allowed_ip_addresses {
-  <% config.fetch('allowed_ip_addresses', []).each do |ip_address| %>
-  "<%= ip_address %>";
-  <% end %>
+  <%- config.fetch('allowed_ip_addresses', []).each do |cidr| -%>
+  <%- ip_address, mask = cidr.split('/') -%>
+  <%- if mask -%>
+  "<%= ip_address %>"/<%= mask -%>;
+  <%- else -%>
+  "<%= ip_address -%>";
+  <%- end -%>
+  <%- end -%>
 }
 
 sub vcl_recv {

--- a/vcl_templates/performanceplatform.vcl.erb
+++ b/vcl_templates/performanceplatform.vcl.erb
@@ -46,26 +46,17 @@ backend sick_force_grace {
 
 
 acl purge_ip_allowlist {
-  "37.26.93.252";     # Skyscape mirrors
-  "31.210.241.100";   # Carrenza mirrors
-  "23.235.32.0"/20;   # Fastly cache node
-  "43.249.72.0"/22;   # Fastly cache node
-  "103.244.50.0"/24;  # Fastly cache node
-  "103.245.222.0"/23; # Fastly cache node
-  "103.245.224.0"/24; # Fastly cache node
-  "104.156.80.0"/20;  # Fastly cache node
-  "151.101.0.0"/16;   # Fastly cache node
-  "157.52.64.0"/18;   # Fastly cache node
-  "172.111.64.0"/18;  # Fastly cache node
-  "185.31.16.0"/22;   # Fastly cache node
-  "199.27.72.0"/21;   # Fastly cache node
-  "199.232.0.0"/16;   # Fastly cache node
-  "202.21.128.0"/24;  # Fastly cache node
-  "203.57.145.0"/24;  # Fastly cache node
-  "167.82.0.0"/17;    # Fastly cache node
-  "167.82.128.0"/20;  # Fastly cache node
-  "167.82.160.0"/20;  # Fastly cache node
-  "167.82.224.0"/20;  # Fastly cache node
+  # See https://sites.google.com/a/digital.cabinet-office.gov.uk/gds/working-at-the-white-chapel-building/gds-internal-it/gds-internal-it-network-public-ip-addresses
+  "213.86.153.211";  # GDS Office (BYOD VPN)
+  "213.86.153.212";  # GDS Office
+  "213.86.153.213";  # GDS Office
+  "213.86.153.214";  # GDS Office
+  "213.86.153.231";  # GDS Office (BYOD VPN)
+  "213.86.153.235";  # GDS Office
+  "213.86.153.236";  # GDS Office
+  "213.86.153.237";  # GDS Office
+  "51.149.8.0"/25;   # GDS Office (DR VPN)
+  "51.149.8.128"/29; # GDS Office (DR BYOD VPN)
 }
 
 sub vcl_recv {

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -150,19 +150,19 @@ backend F_mirrorGCS {
 <% end %>
 
 acl purge_ip_allowlist {
-<% if environment == 'integration' %>
+<%- if environment.start_with? 'integration' -%>
   "34.248.229.46";    # AWS Integration NAT gateway
   "34.248.44.175";    # AWS Integration NAT gateway
   "52.51.97.232";     # AWS Integration NAT gateway
-<% elsif environment == 'staging' %>
+<%- elsif environment.start_with? 'staging' -%>
   "18.202.183.143";   # AWS NAT GW1
   "18.203.90.80";     # AWS NAT GW2
   "18.203.108.248";   # AWS NAT GW3
-<% elsif environment == 'production' %>
+<%- elsif environment.start_with? 'production' -%>
   "34.246.209.74";    # AWS NAT GW1
   "34.253.57.8";      # AWS NAT GW2
   "18.202.136.43";    # AWS NAT GW3
-<% end %>
+<%- end -%>
 }
 
 <% if not %w(production production-eks).include?(environment) %>

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -167,9 +167,14 @@ acl purge_ip_allowlist {
 
 <% if not %w(production production-eks).include?(environment) %>
 acl allowed_ip_addresses {
-  <% config.fetch('allowed_ip_addresses', []).each do |ip_address| %>
-  "<%= ip_address %>";
-  <% end %>
+  <%- config.fetch('allowed_ip_addresses', []).each do |cidr| -%>
+  <%- ip_address, mask = cidr.split('/') -%>
+  <%- if mask -%>
+  "<%= ip_address %>"/<%= mask -%>;
+  <%- else -%>
+  "<%= ip_address -%>";
+  <%- end -%>
+  <%- end -%>
 }
 <% end %>
 


### PR DESCRIPTION
Update Fastly ACLs and ensure that ACLs apply to the upcoming `*-eks` configurations. Getting this existing configuration into a good state will simplify adding the other EKS configs (staging, production x www, assets) whether we continue to use this codebase or port to Terraform.

- [Allow specifying CIDRs in the allowed_ip_addresses ACL.](https://github.com/alphagov/govuk-cdn-config/commit/9dca81ae7f9adbb7b597b75fb59b31bad68b24f0) Needed for alphagov/govuk-cdn-config-secrets#148.
- [Add a dry-run mode to deploy_service.rb.](https://github.com/alphagov/govuk-cdn-config/commit/716dd3cc0c7f268be20e8a9b584cab090fa39fa9)
- [Clean up the purge ACLs and include them in EKS configs.](https://github.com/alphagov/govuk-cdn-config/commit/1bfdf8c774198b41abf350090414d325b1ae54b6)
    - Include the purge ACLs in the EKS configs by matching environments on prefixes rather than exact strings.
    - Update the list of GDS office egress IPs.
    - Remove Skyscape and Carrenza addresses from ACLs. These were decommissioned yonks ago.
    - Remove Fastly IPs from purge ACLs (no longer needed; see 000c586).
    - Update the change detector tests 😒

[Trello](https://trello.com/c/9BPpFRBe/851)

#### Testing

Used the new dry run mode to check that the ACLs are formatted correctly for the CIDR (new) and plain IP address (old) cases. Existing tests pass. Applied in `integration-eks`.

#### Tips for reviewing

The files `spec/test-outputs/*.out.vcl` are auto-generated from the templates (they're literally just change detector tests, unfortunately)