### PR TITLE
Strip cookies for applications that don't them at fastly

### DIFF
--- a/spec/test-outputs/www-eks-integration.out.vcl
+++ b/spec/test-outputs/www-eks-integration.out.vcl
@@ -124,6 +124,18 @@ sub vcl_recv {
   }
 
 
+  # Strip cookies from inbound requests. Corresponding rule in vcl_fetch{}
+  # For simplicity and security most applications should not use cookies.
+  # With the exception of:
+  #   - Licensing
+  #   - email-alert-frontend (for subscription management)
+  #   - frontend (for sessions across funding registration form)
+  #   - smart answers coronavirus find support flow
+  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email" && req.url !~ "^/brexit-eu-funding" && req.url !~ "^/find-coronavirus-support")
+  {
+    unset req.http.Cookie;
+  }
+
 #FASTLY recv
 
   # GOV.UK accounts
@@ -275,6 +287,11 @@ sub vcl_fetch {
       set beresp.ttl = 900s;
       set beresp.http.Cache-Control = "max-age=900";
     }
+  }
+
+  # Strip cookies from outbound requests. Corresponding rule in vcl_recv{}
+  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email" && req.url !~ "^/brexit-eu-funding" && req.url !~ "^/find-coronavirus-support") {
+    unset beresp.http.Set-Cookie;
   }
 
   # Override default.vcl behaviour of return(pass).

--- a/spec/test-outputs/www-eks-production.out.vcl
+++ b/spec/test-outputs/www-eks-production.out.vcl
@@ -285,6 +285,7 @@ sub vcl_recv {
   }
 
 
+
 #FASTLY recv
 
   # GOV.UK accounts
@@ -437,6 +438,7 @@ sub vcl_fetch {
       set beresp.http.Cache-Control = "max-age=900";
     }
   }
+
 
   # Override default.vcl behaviour of return(pass).
   if (beresp.http.Set-Cookie) {

--- a/spec/test-outputs/www-eks-staging.out.vcl
+++ b/spec/test-outputs/www-eks-staging.out.vcl
@@ -293,6 +293,7 @@ sub vcl_recv {
   }
 
 
+
 #FASTLY recv
 
   # GOV.UK accounts
@@ -445,6 +446,7 @@ sub vcl_fetch {
       set beresp.http.Cache-Control = "max-age=900";
     }
   }
+
 
   # Override default.vcl behaviour of return(pass).
   if (beresp.http.Set-Cookie) {

--- a/spec/test-outputs/www-eks-test.out.vcl
+++ b/spec/test-outputs/www-eks-test.out.vcl
@@ -121,6 +121,7 @@ sub vcl_recv {
   }
 
 
+
 #FASTLY recv
 
   # GOV.UK accounts
@@ -273,6 +274,7 @@ sub vcl_fetch {
       set beresp.http.Cache-Control = "max-age=900";
     }
   }
+
 
   # Override default.vcl behaviour of return(pass).
   if (beresp.http.Set-Cookie) {

--- a/spec/test-outputs/www-integration.out.vcl
+++ b/spec/test-outputs/www-integration.out.vcl
@@ -124,6 +124,18 @@ sub vcl_recv {
   }
 
 
+  # Strip cookies from inbound requests. Corresponding rule in vcl_fetch{}
+  # For simplicity and security most applications should not use cookies.
+  # With the exception of:
+  #   - Licensing
+  #   - email-alert-frontend (for subscription management)
+  #   - frontend (for sessions across funding registration form)
+  #   - smart answers coronavirus find support flow
+  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email" && req.url !~ "^/brexit-eu-funding" && req.url !~ "^/find-coronavirus-support")
+  {
+    unset req.http.Cookie;
+  }
+
 #FASTLY recv
 
   # GOV.UK accounts
@@ -275,6 +287,11 @@ sub vcl_fetch {
       set beresp.ttl = 900s;
       set beresp.http.Cache-Control = "max-age=900";
     }
+  }
+
+  # Strip cookies from outbound requests. Corresponding rule in vcl_recv{}
+  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email" && req.url !~ "^/brexit-eu-funding" && req.url !~ "^/find-coronavirus-support") {
+    unset beresp.http.Set-Cookie;
   }
 
   # Override default.vcl behaviour of return(pass).

--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -285,6 +285,7 @@ sub vcl_recv {
   }
 
 
+
 #FASTLY recv
 
   # GOV.UK accounts
@@ -437,6 +438,7 @@ sub vcl_fetch {
       set beresp.http.Cache-Control = "max-age=900";
     }
   }
+
 
   # Override default.vcl behaviour of return(pass).
   if (beresp.http.Set-Cookie) {

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -293,6 +293,7 @@ sub vcl_recv {
   }
 
 
+
 #FASTLY recv
 
   # GOV.UK accounts
@@ -445,6 +446,7 @@ sub vcl_fetch {
       set beresp.http.Cache-Control = "max-age=900";
     }
   }
+
 
   # Override default.vcl behaviour of return(pass).
   if (beresp.http.Set-Cookie) {

--- a/spec/test-outputs/www-test.out.vcl
+++ b/spec/test-outputs/www-test.out.vcl
@@ -121,6 +121,7 @@ sub vcl_recv {
   }
 
 
+
 #FASTLY recv
 
   # GOV.UK accounts
@@ -273,6 +274,7 @@ sub vcl_fetch {
       set beresp.http.Cache-Control = "max-age=900";
     }
   }
+
 
   # Override default.vcl behaviour of return(pass).
   if (beresp.http.Set-Cookie) {

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -345,6 +345,20 @@ sub vcl_recv {
   }
 <% end -%>
 
+<% if environment == "integration" -%>
+  # Strip cookies from inbound requests. Corresponding rule in vcl_fetch{}
+  # For simplicity and security most applications should not use cookies.
+  # With the exception of:
+  #   - Licensing
+  #   - email-alert-frontend (for subscription management)
+  #   - frontend (for sessions across funding registration form)
+  #   - smart answers coronavirus find support flow
+  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email" && req.url !~ "^/brexit-eu-funding" && req.url !~ "^/find-coronavirus-support")
+  {
+    unset req.http.Cookie;
+  }
+<% end -%>
+
 #FASTLY recv
 
   # GOV.UK accounts
@@ -462,6 +476,13 @@ sub vcl_fetch {
       set beresp.http.Cache-Control = "max-age=900";
     }
   }
+
+<% if environment == "integration" -%>
+  # Strip cookies from outbound requests. Corresponding rule in vcl_recv{}
+  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email" && req.url !~ "^/brexit-eu-funding" && req.url !~ "^/find-coronavirus-support") {
+    unset beresp.http.Set-Cookie;
+  }
+<% end -%>
 
   # Override default.vcl behaviour of return(pass).
   if (beresp.http.Set-Cookie) {


### PR DESCRIPTION
This functionality is currently handled by varnish in EC2, but as part of the move to EKS we need to move this to fastly.

Trello: https://trello.com/c/HXtsiNCO/855-strip-cookies-at-fastly