### PR TITLE
Enable Cookie stripping in Fastly rather than Varnish

### DIFF
--- a/spec/test-outputs/www-eks-integration.out.vcl
+++ b/spec/test-outputs/www-eks-integration.out.vcl
@@ -131,7 +131,7 @@ sub vcl_recv {
   #   - email-alert-frontend (for subscription management)
   #   - frontend (for sessions across funding registration form)
   #   - smart answers coronavirus find support flow
-  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email" && req.url !~ "^/brexit-eu-funding" && req.url !~ "^/find-coronavirus-support")
+  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email")
   {
     unset req.http.Cookie;
   }
@@ -290,7 +290,7 @@ sub vcl_fetch {
   }
 
   # Strip cookies from outbound requests. Corresponding rule in vcl_recv{}
-  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email" && req.url !~ "^/brexit-eu-funding" && req.url !~ "^/find-coronavirus-support") {
+  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email") {
     unset beresp.http.Set-Cookie;
   }
 

--- a/spec/test-outputs/www-eks-production.out.vcl
+++ b/spec/test-outputs/www-eks-production.out.vcl
@@ -292,7 +292,7 @@ sub vcl_recv {
   #   - email-alert-frontend (for subscription management)
   #   - frontend (for sessions across funding registration form)
   #   - smart answers coronavirus find support flow
-  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email" && req.url !~ "^/brexit-eu-funding" && req.url !~ "^/find-coronavirus-support")
+  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email")
   {
     unset req.http.Cookie;
   }
@@ -451,7 +451,7 @@ sub vcl_fetch {
   }
 
   # Strip cookies from outbound requests. Corresponding rule in vcl_recv{}
-  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email" && req.url !~ "^/brexit-eu-funding" && req.url !~ "^/find-coronavirus-support") {
+  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email") {
     unset beresp.http.Set-Cookie;
   }
 

--- a/spec/test-outputs/www-eks-staging.out.vcl
+++ b/spec/test-outputs/www-eks-staging.out.vcl
@@ -300,7 +300,7 @@ sub vcl_recv {
   #   - email-alert-frontend (for subscription management)
   #   - frontend (for sessions across funding registration form)
   #   - smart answers coronavirus find support flow
-  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email" && req.url !~ "^/brexit-eu-funding" && req.url !~ "^/find-coronavirus-support")
+  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email")
   {
     unset req.http.Cookie;
   }
@@ -459,7 +459,7 @@ sub vcl_fetch {
   }
 
   # Strip cookies from outbound requests. Corresponding rule in vcl_recv{}
-  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email" && req.url !~ "^/brexit-eu-funding" && req.url !~ "^/find-coronavirus-support") {
+  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email") {
     unset beresp.http.Set-Cookie;
   }
 

--- a/spec/test-outputs/www-eks-test.out.vcl
+++ b/spec/test-outputs/www-eks-test.out.vcl
@@ -128,7 +128,7 @@ sub vcl_recv {
   #   - email-alert-frontend (for subscription management)
   #   - frontend (for sessions across funding registration form)
   #   - smart answers coronavirus find support flow
-  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email" && req.url !~ "^/brexit-eu-funding" && req.url !~ "^/find-coronavirus-support")
+  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email")
   {
     unset req.http.Cookie;
   }
@@ -287,7 +287,7 @@ sub vcl_fetch {
   }
 
   # Strip cookies from outbound requests. Corresponding rule in vcl_recv{}
-  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email" && req.url !~ "^/brexit-eu-funding" && req.url !~ "^/find-coronavirus-support") {
+  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email") {
     unset beresp.http.Set-Cookie;
   }
 

--- a/spec/test-outputs/www-integration.out.vcl
+++ b/spec/test-outputs/www-integration.out.vcl
@@ -131,7 +131,7 @@ sub vcl_recv {
   #   - email-alert-frontend (for subscription management)
   #   - frontend (for sessions across funding registration form)
   #   - smart answers coronavirus find support flow
-  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email" && req.url !~ "^/brexit-eu-funding" && req.url !~ "^/find-coronavirus-support")
+  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email")
   {
     unset req.http.Cookie;
   }
@@ -290,7 +290,7 @@ sub vcl_fetch {
   }
 
   # Strip cookies from outbound requests. Corresponding rule in vcl_recv{}
-  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email" && req.url !~ "^/brexit-eu-funding" && req.url !~ "^/find-coronavirus-support") {
+  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email") {
     unset beresp.http.Set-Cookie;
   }
 

--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -292,7 +292,7 @@ sub vcl_recv {
   #   - email-alert-frontend (for subscription management)
   #   - frontend (for sessions across funding registration form)
   #   - smart answers coronavirus find support flow
-  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email" && req.url !~ "^/brexit-eu-funding" && req.url !~ "^/find-coronavirus-support")
+  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email")
   {
     unset req.http.Cookie;
   }
@@ -451,7 +451,7 @@ sub vcl_fetch {
   }
 
   # Strip cookies from outbound requests. Corresponding rule in vcl_recv{}
-  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email" && req.url !~ "^/brexit-eu-funding" && req.url !~ "^/find-coronavirus-support") {
+  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email") {
     unset beresp.http.Set-Cookie;
   }
 

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -300,7 +300,7 @@ sub vcl_recv {
   #   - email-alert-frontend (for subscription management)
   #   - frontend (for sessions across funding registration form)
   #   - smart answers coronavirus find support flow
-  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email" && req.url !~ "^/brexit-eu-funding" && req.url !~ "^/find-coronavirus-support")
+  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email")
   {
     unset req.http.Cookie;
   }
@@ -459,7 +459,7 @@ sub vcl_fetch {
   }
 
   # Strip cookies from outbound requests. Corresponding rule in vcl_recv{}
-  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email" && req.url !~ "^/brexit-eu-funding" && req.url !~ "^/find-coronavirus-support") {
+  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email") {
     unset beresp.http.Set-Cookie;
   }
 

--- a/spec/test-outputs/www-test.out.vcl
+++ b/spec/test-outputs/www-test.out.vcl
@@ -128,7 +128,7 @@ sub vcl_recv {
   #   - email-alert-frontend (for subscription management)
   #   - frontend (for sessions across funding registration form)
   #   - smart answers coronavirus find support flow
-  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email" && req.url !~ "^/brexit-eu-funding" && req.url !~ "^/find-coronavirus-support")
+  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email")
   {
     unset req.http.Cookie;
   }
@@ -287,7 +287,7 @@ sub vcl_fetch {
   }
 
   # Strip cookies from outbound requests. Corresponding rule in vcl_recv{}
-  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email" && req.url !~ "^/brexit-eu-funding" && req.url !~ "^/find-coronavirus-support") {
+  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email") {
     unset beresp.http.Set-Cookie;
   }
 

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -352,7 +352,7 @@ sub vcl_recv {
   #   - email-alert-frontend (for subscription management)
   #   - frontend (for sessions across funding registration form)
   #   - smart answers coronavirus find support flow
-  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email" && req.url !~ "^/brexit-eu-funding" && req.url !~ "^/find-coronavirus-support")
+  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email")
   {
     unset req.http.Cookie;
   }
@@ -476,7 +476,7 @@ sub vcl_fetch {
   }
 
   # Strip cookies from outbound requests. Corresponding rule in vcl_recv{}
-  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email" && req.url !~ "^/brexit-eu-funding" && req.url !~ "^/find-coronavirus-support") {
+  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email") {
     unset beresp.http.Set-Cookie;
   }
 


### PR DESCRIPTION
This is needed to enable the stripping from most applications except a
select few.  This is a feature that previously existed in varnish but is
now being moved to Fastly to support the EKS replatforming of the apps.

Another pr was used to test this in the integration environment, and we
were able to see using tcpdump and wireshark that the stripping was
occuring at the appropriate level in the stack.

Original PR: https://github.com/alphagov/govuk-cdn-config/pull/373

https://trello.com/c/HXtsiNCO

Co-authored-by: smford <stephen.ford@digital.cabinet-office.gov.uk>
Co-authored-by: samsimpson1 <sam.simpson@digital.cabinet-office.gov.uk>
Co-authored-by: jibolaolu <seun.adiomowo@digital.cabinet-office.gov.uk>