### PR TITLE
Add: fastly signon callback cookie setting

### DIFF
--- a/spec/test-outputs/www-eks-integration.out.vcl
+++ b/spec/test-outputs/www-eks-integration.out.vcl
@@ -129,9 +129,8 @@ sub vcl_recv {
   # With the exception of:
   #   - Licensing
   #   - email-alert-frontend (for subscription management)
-  #   - frontend (for sessions across funding registration form)
-  #   - smart answers coronavirus find support flow
-  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email")
+  #   - signon callback
+  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email" && req.url !~ "^/sign-in/callback")
   {
     unset req.http.Cookie;
   }
@@ -290,7 +289,7 @@ sub vcl_fetch {
   }
 
   # Strip cookies from outbound requests. Corresponding rule in vcl_recv{}
-  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email") {
+  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email" && req.url !~ "^/sign-in/callback") {
     unset beresp.http.Set-Cookie;
   }
 

--- a/spec/test-outputs/www-eks-integration.out.vcl
+++ b/spec/test-outputs/www-eks-integration.out.vcl
@@ -129,9 +129,8 @@ sub vcl_recv {
   # With the exception of:
   #   - Licensing
   #   - email-alert-frontend (for subscription management)
-  #   - signon callback
-  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email" && req.url !~ "^/sign-in/callback")
-  {
+  #   - sign-in (digital identity) callback
+  if (req.url !~ "^/(apply-for-a-licence|email|sign-in/callback)") {
     unset req.http.Cookie;
   }
 
@@ -289,7 +288,7 @@ sub vcl_fetch {
   }
 
   # Strip cookies from outbound requests. Corresponding rule in vcl_recv{}
-  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email" && req.url !~ "^/sign-in/callback") {
+  if (req.url !~ "^/(apply-for-a-licence|email|sign-in/callback)") {
     unset beresp.http.Set-Cookie;
   }
 

--- a/spec/test-outputs/www-eks-production.out.vcl
+++ b/spec/test-outputs/www-eks-production.out.vcl
@@ -290,9 +290,8 @@ sub vcl_recv {
   # With the exception of:
   #   - Licensing
   #   - email-alert-frontend (for subscription management)
-  #   - signon callback
-  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email" && req.url !~ "^/sign-in/callback")
-  {
+  #   - sign-in (digital identity) callback
+  if (req.url !~ "^/(apply-for-a-licence|email|sign-in/callback)") {
     unset req.http.Cookie;
   }
 
@@ -450,7 +449,7 @@ sub vcl_fetch {
   }
 
   # Strip cookies from outbound requests. Corresponding rule in vcl_recv{}
-  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email" && req.url !~ "^/sign-in/callback") {
+  if (req.url !~ "^/(apply-for-a-licence|email|sign-in/callback)") {
     unset beresp.http.Set-Cookie;
   }
 

--- a/spec/test-outputs/www-eks-production.out.vcl
+++ b/spec/test-outputs/www-eks-production.out.vcl
@@ -290,9 +290,8 @@ sub vcl_recv {
   # With the exception of:
   #   - Licensing
   #   - email-alert-frontend (for subscription management)
-  #   - frontend (for sessions across funding registration form)
-  #   - smart answers coronavirus find support flow
-  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email")
+  #   - signon callback
+  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email" && req.url !~ "^/sign-in/callback")
   {
     unset req.http.Cookie;
   }
@@ -451,7 +450,7 @@ sub vcl_fetch {
   }
 
   # Strip cookies from outbound requests. Corresponding rule in vcl_recv{}
-  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email") {
+  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email" && req.url !~ "^/sign-in/callback") {
     unset beresp.http.Set-Cookie;
   }
 

--- a/spec/test-outputs/www-eks-staging.out.vcl
+++ b/spec/test-outputs/www-eks-staging.out.vcl
@@ -298,9 +298,8 @@ sub vcl_recv {
   # With the exception of:
   #   - Licensing
   #   - email-alert-frontend (for subscription management)
-  #   - frontend (for sessions across funding registration form)
-  #   - smart answers coronavirus find support flow
-  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email")
+  #   - signon callback
+  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email" && req.url !~ "^/sign-in/callback")
   {
     unset req.http.Cookie;
   }
@@ -459,7 +458,7 @@ sub vcl_fetch {
   }
 
   # Strip cookies from outbound requests. Corresponding rule in vcl_recv{}
-  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email") {
+  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email" && req.url !~ "^/sign-in/callback") {
     unset beresp.http.Set-Cookie;
   }
 

--- a/spec/test-outputs/www-eks-staging.out.vcl
+++ b/spec/test-outputs/www-eks-staging.out.vcl
@@ -298,9 +298,8 @@ sub vcl_recv {
   # With the exception of:
   #   - Licensing
   #   - email-alert-frontend (for subscription management)
-  #   - signon callback
-  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email" && req.url !~ "^/sign-in/callback")
-  {
+  #   - sign-in (digital identity) callback
+  if (req.url !~ "^/(apply-for-a-licence|email|sign-in/callback)") {
     unset req.http.Cookie;
   }
 
@@ -458,7 +457,7 @@ sub vcl_fetch {
   }
 
   # Strip cookies from outbound requests. Corresponding rule in vcl_recv{}
-  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email" && req.url !~ "^/sign-in/callback") {
+  if (req.url !~ "^/(apply-for-a-licence|email|sign-in/callback)") {
     unset beresp.http.Set-Cookie;
   }
 

--- a/spec/test-outputs/www-eks-test.out.vcl
+++ b/spec/test-outputs/www-eks-test.out.vcl
@@ -126,9 +126,8 @@ sub vcl_recv {
   # With the exception of:
   #   - Licensing
   #   - email-alert-frontend (for subscription management)
-  #   - signon callback
-  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email" && req.url !~ "^/sign-in/callback")
-  {
+  #   - sign-in (digital identity) callback
+  if (req.url !~ "^/(apply-for-a-licence|email|sign-in/callback)") {
     unset req.http.Cookie;
   }
 
@@ -286,7 +285,7 @@ sub vcl_fetch {
   }
 
   # Strip cookies from outbound requests. Corresponding rule in vcl_recv{}
-  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email" && req.url !~ "^/sign-in/callback") {
+  if (req.url !~ "^/(apply-for-a-licence|email|sign-in/callback)") {
     unset beresp.http.Set-Cookie;
   }
 

--- a/spec/test-outputs/www-eks-test.out.vcl
+++ b/spec/test-outputs/www-eks-test.out.vcl
@@ -126,9 +126,8 @@ sub vcl_recv {
   # With the exception of:
   #   - Licensing
   #   - email-alert-frontend (for subscription management)
-  #   - frontend (for sessions across funding registration form)
-  #   - smart answers coronavirus find support flow
-  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email")
+  #   - signon callback
+  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email" && req.url !~ "^/sign-in/callback")
   {
     unset req.http.Cookie;
   }
@@ -287,7 +286,7 @@ sub vcl_fetch {
   }
 
   # Strip cookies from outbound requests. Corresponding rule in vcl_recv{}
-  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email") {
+  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email" && req.url !~ "^/sign-in/callback") {
     unset beresp.http.Set-Cookie;
   }
 

--- a/spec/test-outputs/www-integration.out.vcl
+++ b/spec/test-outputs/www-integration.out.vcl
@@ -129,9 +129,8 @@ sub vcl_recv {
   # With the exception of:
   #   - Licensing
   #   - email-alert-frontend (for subscription management)
-  #   - frontend (for sessions across funding registration form)
-  #   - smart answers coronavirus find support flow
-  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email")
+  #   - signon callback
+  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email" && req.url !~ "^/sign-in/callback")
   {
     unset req.http.Cookie;
   }
@@ -290,7 +289,7 @@ sub vcl_fetch {
   }
 
   # Strip cookies from outbound requests. Corresponding rule in vcl_recv{}
-  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email") {
+  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email" && req.url !~ "^/sign-in/callback") {
     unset beresp.http.Set-Cookie;
   }
 

--- a/spec/test-outputs/www-integration.out.vcl
+++ b/spec/test-outputs/www-integration.out.vcl
@@ -129,9 +129,8 @@ sub vcl_recv {
   # With the exception of:
   #   - Licensing
   #   - email-alert-frontend (for subscription management)
-  #   - signon callback
-  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email" && req.url !~ "^/sign-in/callback")
-  {
+  #   - sign-in (digital identity) callback
+  if (req.url !~ "^/(apply-for-a-licence|email|sign-in/callback)") {
     unset req.http.Cookie;
   }
 
@@ -289,7 +288,7 @@ sub vcl_fetch {
   }
 
   # Strip cookies from outbound requests. Corresponding rule in vcl_recv{}
-  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email" && req.url !~ "^/sign-in/callback") {
+  if (req.url !~ "^/(apply-for-a-licence|email|sign-in/callback)") {
     unset beresp.http.Set-Cookie;
   }
 

--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -290,9 +290,8 @@ sub vcl_recv {
   # With the exception of:
   #   - Licensing
   #   - email-alert-frontend (for subscription management)
-  #   - signon callback
-  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email" && req.url !~ "^/sign-in/callback")
-  {
+  #   - sign-in (digital identity) callback
+  if (req.url !~ "^/(apply-for-a-licence|email|sign-in/callback)") {
     unset req.http.Cookie;
   }
 
@@ -450,7 +449,7 @@ sub vcl_fetch {
   }
 
   # Strip cookies from outbound requests. Corresponding rule in vcl_recv{}
-  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email" && req.url !~ "^/sign-in/callback") {
+  if (req.url !~ "^/(apply-for-a-licence|email|sign-in/callback)") {
     unset beresp.http.Set-Cookie;
   }
 

--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -290,9 +290,8 @@ sub vcl_recv {
   # With the exception of:
   #   - Licensing
   #   - email-alert-frontend (for subscription management)
-  #   - frontend (for sessions across funding registration form)
-  #   - smart answers coronavirus find support flow
-  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email")
+  #   - signon callback
+  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email" && req.url !~ "^/sign-in/callback")
   {
     unset req.http.Cookie;
   }
@@ -451,7 +450,7 @@ sub vcl_fetch {
   }
 
   # Strip cookies from outbound requests. Corresponding rule in vcl_recv{}
-  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email") {
+  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email" && req.url !~ "^/sign-in/callback") {
     unset beresp.http.Set-Cookie;
   }
 

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -298,9 +298,8 @@ sub vcl_recv {
   # With the exception of:
   #   - Licensing
   #   - email-alert-frontend (for subscription management)
-  #   - frontend (for sessions across funding registration form)
-  #   - smart answers coronavirus find support flow
-  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email")
+  #   - signon callback
+  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email" && req.url !~ "^/sign-in/callback")
   {
     unset req.http.Cookie;
   }
@@ -459,7 +458,7 @@ sub vcl_fetch {
   }
 
   # Strip cookies from outbound requests. Corresponding rule in vcl_recv{}
-  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email") {
+  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email" && req.url !~ "^/sign-in/callback") {
     unset beresp.http.Set-Cookie;
   }
 

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -298,9 +298,8 @@ sub vcl_recv {
   # With the exception of:
   #   - Licensing
   #   - email-alert-frontend (for subscription management)
-  #   - signon callback
-  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email" && req.url !~ "^/sign-in/callback")
-  {
+  #   - sign-in (digital identity) callback
+  if (req.url !~ "^/(apply-for-a-licence|email|sign-in/callback)") {
     unset req.http.Cookie;
   }
 
@@ -458,7 +457,7 @@ sub vcl_fetch {
   }
 
   # Strip cookies from outbound requests. Corresponding rule in vcl_recv{}
-  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email" && req.url !~ "^/sign-in/callback") {
+  if (req.url !~ "^/(apply-for-a-licence|email|sign-in/callback)") {
     unset beresp.http.Set-Cookie;
   }
 

--- a/spec/test-outputs/www-test.out.vcl
+++ b/spec/test-outputs/www-test.out.vcl
@@ -126,9 +126,8 @@ sub vcl_recv {
   # With the exception of:
   #   - Licensing
   #   - email-alert-frontend (for subscription management)
-  #   - signon callback
-  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email" && req.url !~ "^/sign-in/callback")
-  {
+  #   - sign-in (digital identity) callback
+  if (req.url !~ "^/(apply-for-a-licence|email|sign-in/callback)") {
     unset req.http.Cookie;
   }
 
@@ -286,7 +285,7 @@ sub vcl_fetch {
   }
 
   # Strip cookies from outbound requests. Corresponding rule in vcl_recv{}
-  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email" && req.url !~ "^/sign-in/callback") {
+  if (req.url !~ "^/(apply-for-a-licence|email|sign-in/callback)") {
     unset beresp.http.Set-Cookie;
   }
 

--- a/spec/test-outputs/www-test.out.vcl
+++ b/spec/test-outputs/www-test.out.vcl
@@ -126,9 +126,8 @@ sub vcl_recv {
   # With the exception of:
   #   - Licensing
   #   - email-alert-frontend (for subscription management)
-  #   - frontend (for sessions across funding registration form)
-  #   - smart answers coronavirus find support flow
-  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email")
+  #   - signon callback
+  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email" && req.url !~ "^/sign-in/callback")
   {
     unset req.http.Cookie;
   }
@@ -287,7 +286,7 @@ sub vcl_fetch {
   }
 
   # Strip cookies from outbound requests. Corresponding rule in vcl_recv{}
-  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email") {
+  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email" && req.url !~ "^/sign-in/callback") {
     unset beresp.http.Set-Cookie;
   }
 

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -350,9 +350,8 @@ sub vcl_recv {
   # With the exception of:
   #   - Licensing
   #   - email-alert-frontend (for subscription management)
-  #   - signon callback
-  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email" && req.url !~ "^/sign-in/callback")
-  {
+  #   - sign-in (digital identity) callback
+  if (req.url !~ "^/(apply-for-a-licence|email|sign-in/callback)") {
     unset req.http.Cookie;
   }
 
@@ -475,7 +474,7 @@ sub vcl_fetch {
   }
 
   # Strip cookies from outbound requests. Corresponding rule in vcl_recv{}
-  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email" && req.url !~ "^/sign-in/callback") {
+  if (req.url !~ "^/(apply-for-a-licence|email|sign-in/callback)") {
     unset beresp.http.Set-Cookie;
   }
 

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -350,9 +350,8 @@ sub vcl_recv {
   # With the exception of:
   #   - Licensing
   #   - email-alert-frontend (for subscription management)
-  #   - frontend (for sessions across funding registration form)
-  #   - smart answers coronavirus find support flow
-  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email")
+  #   - signon callback
+  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email" && req.url !~ "^/sign-in/callback")
   {
     unset req.http.Cookie;
   }
@@ -476,7 +475,7 @@ sub vcl_fetch {
   }
 
   # Strip cookies from outbound requests. Corresponding rule in vcl_recv{}
-  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email") {
+  if (req.url !~ "^/apply-for-a-licence" && req.url !~ "^/email" && req.url !~ "^/sign-in/callback") {
     unset beresp.http.Set-Cookie;
   }
 


### PR DESCRIPTION
This needs porting from varnish to fastly configuration.

https://github.com/alphagov/govuk-puppet/commit/d8678975bf75cba14de867cb9718c42a3696b794