### PR TITLE
Remove the feature to set header in the backend

### DIFF
--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -7,10 +7,6 @@ backend F_origin {
     .max_connections = 200;
     .between_bytes_timeout = 10s;
     .share_key = "<%= config.fetch('service_id') %>";
-    <%- if config['set_backend_host_header'] %>
-    .host_header = "<%= config.fetch('origin_hostname') %>";
-    .always_use_host_header = true;
-    <%- end -%>
 
     .ssl = true;
     .ssl_check_cert = <%= config['disable_tls_validation'] ? 'never' : 'always' %>;


### PR DESCRIPTION
This feature was added because the ingress in EKS was not configured
properly to accept the original host header of fastly.

This had now been fixed in [here](https://github.com/alphagov/govuk-helm-charts/pull/270)