### PR TITLE
Copy Accept-Encoding normalisation from EC2 Varnish

### DIFF
--- a/spec/test-outputs/www-eks-integration.out.vcl
+++ b/spec/test-outputs/www-eks-integration.out.vcl
@@ -58,6 +58,15 @@ sub vcl_recv {
 
   
 
+  
+  # Strip Accept-Encoding header if the content is already compressed
+  if (req.http.Accept-Encoding) {
+    if (req.url ~ "\.(jpeg|jpg|png|gif|gz|tgz|bz2|tbz|zip|flv|pdf|mp3|ogg)$") {
+      remove req.http.Accept-Encoding;
+    }
+  }
+  
+
   # Force SSL.
   if (!req.http.Fastly-SSL) {
      error 801 "Force SSL";

--- a/spec/test-outputs/www-eks-production.out.vcl
+++ b/spec/test-outputs/www-eks-production.out.vcl
@@ -151,6 +151,8 @@ sub vcl_recv {
 
   
 
+  
+
   # Force SSL.
   if (!req.http.Fastly-SSL) {
      error 801 "Force SSL";

--- a/spec/test-outputs/www-eks-staging.out.vcl
+++ b/spec/test-outputs/www-eks-staging.out.vcl
@@ -159,6 +159,8 @@ sub vcl_recv {
 
   
 
+  
+
   # Force SSL.
   if (!req.http.Fastly-SSL) {
      error 801 "Force SSL";

--- a/spec/test-outputs/www-eks-test.out.vcl
+++ b/spec/test-outputs/www-eks-test.out.vcl
@@ -55,6 +55,8 @@ sub vcl_recv {
 
   
 
+  
+
   # Force SSL.
   if (!req.http.Fastly-SSL) {
      error 801 "Force SSL";

--- a/spec/test-outputs/www-integration.out.vcl
+++ b/spec/test-outputs/www-integration.out.vcl
@@ -58,6 +58,15 @@ sub vcl_recv {
 
   
 
+  
+  # Strip Accept-Encoding header if the content is already compressed
+  if (req.http.Accept-Encoding) {
+    if (req.url ~ "\.(jpeg|jpg|png|gif|gz|tgz|bz2|tbz|zip|flv|pdf|mp3|ogg)$") {
+      remove req.http.Accept-Encoding;
+    }
+  }
+  
+
   # Force SSL.
   if (!req.http.Fastly-SSL) {
      error 801 "Force SSL";

--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -151,6 +151,8 @@ sub vcl_recv {
 
   
 
+  
+
   # Force SSL.
   if (!req.http.Fastly-SSL) {
      error 801 "Force SSL";

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -159,6 +159,8 @@ sub vcl_recv {
 
   
 
+  
+
   # Force SSL.
   if (!req.http.Fastly-SSL) {
      error 801 "Force SSL";

--- a/spec/test-outputs/www-test.out.vcl
+++ b/spec/test-outputs/www-test.out.vcl
@@ -55,6 +55,8 @@ sub vcl_recv {
 
   
 
+  
+
   # Force SSL.
   if (!req.http.Fastly-SSL) {
      error 801 "Force SSL";

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -204,6 +204,15 @@ sub vcl_recv {
   }
   <% end %>
 
+  <% if environment == 'integration' %>
+  # Strip Accept-Encoding header if the content is already compressed
+  if (req.http.Accept-Encoding) {
+    if (req.url ~ "\.(jpeg|jpg|png|gif|gz|tgz|bz2|tbz|zip|flv|pdf|mp3|ogg)$") {
+      remove req.http.Accept-Encoding;
+    }
+  }
+  <% end %>
+
   # Force SSL.
   if (!req.http.Fastly-SSL) {
      error 801 "Force SSL";


### PR DESCRIPTION
This is copied from the EC2-based Varnish config. This is required for replatforming work, since we will be retiring the EC2-based Varnish services.

I have tested it using Fastly Fiddle.

This is integration-only at this point to test before deploying everywhere.

Trello: https://trello.com/c/88bU7Qmm/854-normalise-accept-encoding-header-at-fastly