### PR TITLE
Turn NewBrowse test off

### DIFF
--- a/configs/dictionaries/active_ab_tests.yaml
+++ b/configs/dictionaries/active_ab_tests.yaml
@@ -4,4 +4,4 @@
 # bucket allocations. See example_percentages.yaml for format.
 ---
 Example: true
-NewBrowse: true
+NewBrowse: false


### PR DESCRIPTION
Assigning users to Z is unexpected behaviour for smokey. See
https://github.com/alphagov/smokey/blob/2ba441d489c1cfb4a96401b46c8f07a5c279cd99/features/step_definitions/ab_testing_steps.rb#L43
Turning test off whilst we update smokey