### PR TITLE
Have the deploy scripts run a shallow git clone.

### DIFF
--- a/deploy-dictionaries.sh
+++ b/deploy-dictionaries.sh
@@ -3,7 +3,7 @@ set -eu
 
 # Copy secret dictionaries over into /configs
 rm -rf govuk-cdn-config-secrets
-git clone git@github.com:alphagov/govuk-cdn-config-secrets.git
+git clone --depth 1 git@github.com:alphagov/govuk-cdn-config-secrets.git
 
 cp govuk-cdn-config-secrets/fastly/dictionaries/config/* configs/dictionaries
 cp govuk-cdn-config-secrets/fastly/fastly.yaml .

--- a/deploy-service.sh
+++ b/deploy-service.sh
@@ -2,7 +2,7 @@
 set -eu
 
 rm -rf govuk-cdn-config-secrets
-git clone git@github.com:alphagov/govuk-cdn-config-secrets.git
+git clone --depth 1 git@github.com:alphagov/govuk-cdn-config-secrets.git
 
 cp govuk-cdn-config-secrets/fastly/fastly.yaml .
 


### PR DESCRIPTION
We only need to fetch the head of the main branch of `govuk-cdn-config-secrets`. This speeds up deployment and saves a little bit on resource usage.

Tested: scripts still work locally.