### PR TITLE
Allow specifying the path for the www backend healthcheck.

### DIFF
--- a/spec/vcl_generation_spec.rb
+++ b/spec/vcl_generation_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe "VCL generation" do
     "origin_domain_suffix" => "boo",
     "domain_suffix" => "boo",
     "private_extra_code_in_vcl_recv" => "# some private vcl code",
+    "probe" => "/",
   }
 
   Dir.glob("vcl_templates/*.erb").each do |template|

--- a/spec/www_vcl_erb_spec.rb
+++ b/spec/www_vcl_erb_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe "VCL template" do
       "s3_mirror_hostname" => "bar",
       "s3_mirror_prefix" => "foo_",
       "default_ttl" => "5000",
+      "probe" => "/",
     }
   end
   let!(:environment) { "test" }

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -17,9 +17,10 @@ backend F_origin {
     .ssl_cert_hostname = "<%= config.fetch('ssl_cert_hostname', config.fetch('origin_hostname')) %>";
     .ssl_sni_hostname = "<%= config.fetch('ssl_sni_hostname', config.fetch('origin_hostname')) %>";
 
+<% if config['probe'] -%>
     .probe = {
         .request =
-            "HEAD / HTTP/1.1"
+            "HEAD <%= config['probe'] %> HTTP/1.1"
             "Host: <%= config.fetch('origin_hostname') %>"
             "User-Agent: Fastly healthcheck (git version: <%= config['git_version'] %>)"
 <% if config['rate_limit_token'] -%>
@@ -36,6 +37,7 @@ backend F_origin {
         .expected_response = 200;
         .interval = 10s;
     }
+<% end -%>
 }
 
 <% if %w(staging production).include?(environment) %>


### PR DESCRIPTION
In the new EKS rig, an origin request for `/` is relatively expensive so we need to be able to set this to a dedicated path that we can serve more cheaply. Fastly sends a *lot* of healthchecks.

Tested: successfully deployed the new staging-eks www service. No diffs for existing services.

https://trello.com/c/gipscM7t