### PR TITLE
Remove link to coronavirus landing page

### DIFF
--- a/spec/test-outputs/www-eks-integration.out.vcl
+++ b/spec/test-outputs/www-eks-integration.out.vcl
@@ -484,7 +484,6 @@ sub vcl_error {
       <body>
         <header><h1>GOV.UK</h1></header>
         <p>We're experiencing technical difficulties. Please try again later.</p>
-        <p>You can <a href="/coronavirus">find coronavirus information</a> on GOV.UK.</p>
       </body>
     </html>"};
 

--- a/spec/test-outputs/www-eks-production.out.vcl
+++ b/spec/test-outputs/www-eks-production.out.vcl
@@ -645,7 +645,6 @@ sub vcl_error {
       <body>
         <header><h1>GOV.UK</h1></header>
         <p>We're experiencing technical difficulties. Please try again later.</p>
-        <p>You can <a href="/coronavirus">find coronavirus information</a> on GOV.UK.</p>
       </body>
     </html>"};
 

--- a/spec/test-outputs/www-eks-staging.out.vcl
+++ b/spec/test-outputs/www-eks-staging.out.vcl
@@ -653,7 +653,6 @@ sub vcl_error {
       <body>
         <header><h1>GOV.UK</h1></header>
         <p>We're experiencing technical difficulties. Please try again later.</p>
-        <p>You can <a href="/coronavirus">find coronavirus information</a> on GOV.UK.</p>
       </body>
     </html>"};
 

--- a/spec/test-outputs/www-eks-test.out.vcl
+++ b/spec/test-outputs/www-eks-test.out.vcl
@@ -481,7 +481,6 @@ sub vcl_error {
       <body>
         <header><h1>GOV.UK</h1></header>
         <p>We're experiencing technical difficulties. Please try again later.</p>
-        <p>You can <a href="/coronavirus">find coronavirus information</a> on GOV.UK.</p>
       </body>
     </html>"};
 

--- a/spec/test-outputs/www-integration.out.vcl
+++ b/spec/test-outputs/www-integration.out.vcl
@@ -484,7 +484,6 @@ sub vcl_error {
       <body>
         <header><h1>GOV.UK</h1></header>
         <p>We're experiencing technical difficulties. Please try again later.</p>
-        <p>You can <a href="/coronavirus">find coronavirus information</a> on GOV.UK.</p>
       </body>
     </html>"};
 

--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -645,7 +645,6 @@ sub vcl_error {
       <body>
         <header><h1>GOV.UK</h1></header>
         <p>We're experiencing technical difficulties. Please try again later.</p>
-        <p>You can <a href="/coronavirus">find coronavirus information</a> on GOV.UK.</p>
       </body>
     </html>"};
 

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -653,7 +653,6 @@ sub vcl_error {
       <body>
         <header><h1>GOV.UK</h1></header>
         <p>We're experiencing technical difficulties. Please try again later.</p>
-        <p>You can <a href="/coronavirus">find coronavirus information</a> on GOV.UK.</p>
       </body>
     </html>"};
 

--- a/spec/test-outputs/www-test.out.vcl
+++ b/spec/test-outputs/www-test.out.vcl
@@ -481,7 +481,6 @@ sub vcl_error {
       <body>
         <header><h1>GOV.UK</h1></header>
         <p>We're experiencing technical difficulties. Please try again later.</p>
-        <p>You can <a href="/coronavirus">find coronavirus information</a> on GOV.UK.</p>
       </body>
     </html>"};
 

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -648,7 +648,6 @@ sub vcl_error {
       <body>
         <header><h1>GOV.UK</h1></header>
         <p>We're experiencing technical difficulties. Please try again later.</p>
-        <p>You can <a href="/coronavirus">find coronavirus information</a> on GOV.UK.</p>
       </body>
     </html>"};
 


### PR DESCRIPTION
We haven't displayed the link to the coronavirus landing page in months, and should remove it from here too for consistency.