### PR TITLE
Revert Cookie stripping

### DIFF
--- a/spec/test-outputs/www-eks-integration.out.vcl
+++ b/spec/test-outputs/www-eks-integration.out.vcl
@@ -123,7 +123,6 @@ sub vcl_recv {
     set req.http.TLSversion = tls.client.protocol;
   }
 
-
   # Strip cookies from inbound requests. Corresponding rule in vcl_fetch{}
   # For simplicity and security most applications should not use cookies.
   # With the exception of:
@@ -133,7 +132,6 @@ sub vcl_recv {
   if (req.url !~ "^/(apply-for-a-licence|email|sign-in/callback)") {
     unset req.http.Cookie;
   }
-
 #FASTLY recv
 
   # GOV.UK accounts
@@ -318,7 +316,6 @@ sub vcl_fetch {
       set beresp.http.Cache-Control = "max-age=900";
     }
   }
-
   # Strip cookies from outbound requests. Corresponding rule in vcl_recv{}
   if (req.url !~ "^/(apply-for-a-licence|email|sign-in/callback)") {
     unset beresp.http.Set-Cookie;

--- a/spec/test-outputs/www-eks-production.out.vcl
+++ b/spec/test-outputs/www-eks-production.out.vcl
@@ -284,17 +284,6 @@ sub vcl_recv {
     set req.http.TLSversion = tls.client.protocol;
   }
 
-
-  # Strip cookies from inbound requests. Corresponding rule in vcl_fetch{}
-  # For simplicity and security most applications should not use cookies.
-  # With the exception of:
-  #   - Licensing
-  #   - email-alert-frontend (for subscription management)
-  #   - sign-in (digital identity) callback
-  if (req.url !~ "^/(apply-for-a-licence|email|sign-in/callback)") {
-    unset req.http.Cookie;
-  }
-
 #FASTLY recv
 
   # GOV.UK accounts
@@ -478,11 +467,6 @@ sub vcl_fetch {
       set beresp.ttl = 900s;
       set beresp.http.Cache-Control = "max-age=900";
     }
-  }
-
-  # Strip cookies from outbound requests. Corresponding rule in vcl_recv{}
-  if (req.url !~ "^/(apply-for-a-licence|email|sign-in/callback)") {
-    unset beresp.http.Set-Cookie;
   }
 
   # Override default.vcl behaviour of return(pass).

--- a/spec/test-outputs/www-eks-staging.out.vcl
+++ b/spec/test-outputs/www-eks-staging.out.vcl
@@ -292,17 +292,6 @@ sub vcl_recv {
     set req.http.TLSversion = tls.client.protocol;
   }
 
-
-  # Strip cookies from inbound requests. Corresponding rule in vcl_fetch{}
-  # For simplicity and security most applications should not use cookies.
-  # With the exception of:
-  #   - Licensing
-  #   - email-alert-frontend (for subscription management)
-  #   - sign-in (digital identity) callback
-  if (req.url !~ "^/(apply-for-a-licence|email|sign-in/callback)") {
-    unset req.http.Cookie;
-  }
-
 #FASTLY recv
 
   # GOV.UK accounts
@@ -486,11 +475,6 @@ sub vcl_fetch {
       set beresp.ttl = 900s;
       set beresp.http.Cache-Control = "max-age=900";
     }
-  }
-
-  # Strip cookies from outbound requests. Corresponding rule in vcl_recv{}
-  if (req.url !~ "^/(apply-for-a-licence|email|sign-in/callback)") {
-    unset beresp.http.Set-Cookie;
   }
 
   # Override default.vcl behaviour of return(pass).

--- a/spec/test-outputs/www-eks-test.out.vcl
+++ b/spec/test-outputs/www-eks-test.out.vcl
@@ -120,17 +120,6 @@ sub vcl_recv {
     set req.http.TLSversion = tls.client.protocol;
   }
 
-
-  # Strip cookies from inbound requests. Corresponding rule in vcl_fetch{}
-  # For simplicity and security most applications should not use cookies.
-  # With the exception of:
-  #   - Licensing
-  #   - email-alert-frontend (for subscription management)
-  #   - sign-in (digital identity) callback
-  if (req.url !~ "^/(apply-for-a-licence|email|sign-in/callback)") {
-    unset req.http.Cookie;
-  }
-
 #FASTLY recv
 
   # GOV.UK accounts
@@ -314,11 +303,6 @@ sub vcl_fetch {
       set beresp.ttl = 900s;
       set beresp.http.Cache-Control = "max-age=900";
     }
-  }
-
-  # Strip cookies from outbound requests. Corresponding rule in vcl_recv{}
-  if (req.url !~ "^/(apply-for-a-licence|email|sign-in/callback)") {
-    unset beresp.http.Set-Cookie;
   }
 
   # Override default.vcl behaviour of return(pass).

--- a/spec/test-outputs/www-integration.out.vcl
+++ b/spec/test-outputs/www-integration.out.vcl
@@ -123,7 +123,6 @@ sub vcl_recv {
     set req.http.TLSversion = tls.client.protocol;
   }
 
-
   # Strip cookies from inbound requests. Corresponding rule in vcl_fetch{}
   # For simplicity and security most applications should not use cookies.
   # With the exception of:
@@ -133,7 +132,6 @@ sub vcl_recv {
   if (req.url !~ "^/(apply-for-a-licence|email|sign-in/callback)") {
     unset req.http.Cookie;
   }
-
 #FASTLY recv
 
   # GOV.UK accounts
@@ -318,7 +316,6 @@ sub vcl_fetch {
       set beresp.http.Cache-Control = "max-age=900";
     }
   }
-
   # Strip cookies from outbound requests. Corresponding rule in vcl_recv{}
   if (req.url !~ "^/(apply-for-a-licence|email|sign-in/callback)") {
     unset beresp.http.Set-Cookie;

--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -284,17 +284,6 @@ sub vcl_recv {
     set req.http.TLSversion = tls.client.protocol;
   }
 
-
-  # Strip cookies from inbound requests. Corresponding rule in vcl_fetch{}
-  # For simplicity and security most applications should not use cookies.
-  # With the exception of:
-  #   - Licensing
-  #   - email-alert-frontend (for subscription management)
-  #   - sign-in (digital identity) callback
-  if (req.url !~ "^/(apply-for-a-licence|email|sign-in/callback)") {
-    unset req.http.Cookie;
-  }
-
 #FASTLY recv
 
   # GOV.UK accounts
@@ -478,11 +467,6 @@ sub vcl_fetch {
       set beresp.ttl = 900s;
       set beresp.http.Cache-Control = "max-age=900";
     }
-  }
-
-  # Strip cookies from outbound requests. Corresponding rule in vcl_recv{}
-  if (req.url !~ "^/(apply-for-a-licence|email|sign-in/callback)") {
-    unset beresp.http.Set-Cookie;
   }
 
   # Override default.vcl behaviour of return(pass).

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -292,17 +292,6 @@ sub vcl_recv {
     set req.http.TLSversion = tls.client.protocol;
   }
 
-
-  # Strip cookies from inbound requests. Corresponding rule in vcl_fetch{}
-  # For simplicity and security most applications should not use cookies.
-  # With the exception of:
-  #   - Licensing
-  #   - email-alert-frontend (for subscription management)
-  #   - sign-in (digital identity) callback
-  if (req.url !~ "^/(apply-for-a-licence|email|sign-in/callback)") {
-    unset req.http.Cookie;
-  }
-
 #FASTLY recv
 
   # GOV.UK accounts
@@ -486,11 +475,6 @@ sub vcl_fetch {
       set beresp.ttl = 900s;
       set beresp.http.Cache-Control = "max-age=900";
     }
-  }
-
-  # Strip cookies from outbound requests. Corresponding rule in vcl_recv{}
-  if (req.url !~ "^/(apply-for-a-licence|email|sign-in/callback)") {
-    unset beresp.http.Set-Cookie;
   }
 
   # Override default.vcl behaviour of return(pass).

--- a/spec/test-outputs/www-test.out.vcl
+++ b/spec/test-outputs/www-test.out.vcl
@@ -120,17 +120,6 @@ sub vcl_recv {
     set req.http.TLSversion = tls.client.protocol;
   }
 
-
-  # Strip cookies from inbound requests. Corresponding rule in vcl_fetch{}
-  # For simplicity and security most applications should not use cookies.
-  # With the exception of:
-  #   - Licensing
-  #   - email-alert-frontend (for subscription management)
-  #   - sign-in (digital identity) callback
-  if (req.url !~ "^/(apply-for-a-licence|email|sign-in/callback)") {
-    unset req.http.Cookie;
-  }
-
 #FASTLY recv
 
   # GOV.UK accounts
@@ -314,11 +303,6 @@ sub vcl_fetch {
       set beresp.ttl = 900s;
       set beresp.http.Cache-Control = "max-age=900";
     }
-  }
-
-  # Strip cookies from outbound requests. Corresponding rule in vcl_recv{}
-  if (req.url !~ "^/(apply-for-a-licence|email|sign-in/callback)") {
-    unset beresp.http.Set-Cookie;
   }
 
   # Override default.vcl behaviour of return(pass).

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -340,7 +340,7 @@ sub vcl_recv {
     set req.http.Authorization = "Basic <%= config['basic_authentication'] %>";
   }
 <% end -%>
-
+<% if environment == "integration" -%>
   # Strip cookies from inbound requests. Corresponding rule in vcl_fetch{}
   # For simplicity and security most applications should not use cookies.
   # With the exception of:
@@ -350,7 +350,7 @@ sub vcl_recv {
   if (req.url !~ "^/(apply-for-a-licence|email|sign-in/callback)") {
     unset req.http.Cookie;
   }
-
+<% end -%>
 #FASTLY recv
 
   # GOV.UK accounts
@@ -468,11 +468,12 @@ sub vcl_fetch {
       set beresp.http.Cache-Control = "max-age=900";
     }
   }
-
+<% if environment == "integration" -%>
   # Strip cookies from outbound requests. Corresponding rule in vcl_recv{}
   if (req.url !~ "^/(apply-for-a-licence|email|sign-in/callback)") {
     unset beresp.http.Set-Cookie;
   }
+<% end -%>
 
   # Override default.vcl behaviour of return(pass).
   if (beresp.http.Set-Cookie) {


### PR DESCRIPTION
Roll back https://github.com/alphagov/govuk-cdn-config/pull/374

This PR was causing AB test cookies to be stripped. 