### PR TITLE
Don't strip cookies in EC2-backed services, only EKS ones.

### DIFF
--- a/spec/test-outputs/www-eks-integration.out.vcl
+++ b/spec/test-outputs/www-eks-integration.out.vcl
@@ -123,15 +123,6 @@ sub vcl_recv {
     set req.http.TLSversion = tls.client.protocol;
   }
 
-  # Strip cookies from inbound requests. Corresponding rule in vcl_fetch{}
-  # For simplicity and security most applications should not use cookies.
-  # With the exception of:
-  #   - Licensing
-  #   - email-alert-frontend (for subscription management)
-  #   - sign-in (digital identity) callback
-  if (req.url !~ "^/(apply-for-a-licence|email|sign-in/callback)") {
-    unset req.http.Cookie;
-  }
 #FASTLY recv
 
   # GOV.UK accounts
@@ -327,10 +318,6 @@ sub vcl_fetch {
       set beresp.ttl = 900s;
       set beresp.http.Cache-Control = "max-age=900";
     }
-  }
-  # Strip cookies from outbound requests. Corresponding rule in vcl_recv{}
-  if (req.url !~ "^/(apply-for-a-licence|email|sign-in/callback)") {
-    unset beresp.http.Set-Cookie;
   }
 
   # Override default.vcl behaviour of return(pass).

--- a/spec/test-outputs/www-integration.out.vcl
+++ b/spec/test-outputs/www-integration.out.vcl
@@ -123,15 +123,6 @@ sub vcl_recv {
     set req.http.TLSversion = tls.client.protocol;
   }
 
-  # Strip cookies from inbound requests. Corresponding rule in vcl_fetch{}
-  # For simplicity and security most applications should not use cookies.
-  # With the exception of:
-  #   - Licensing
-  #   - email-alert-frontend (for subscription management)
-  #   - sign-in (digital identity) callback
-  if (req.url !~ "^/(apply-for-a-licence|email|sign-in/callback)") {
-    unset req.http.Cookie;
-  }
 #FASTLY recv
 
   # GOV.UK accounts
@@ -327,10 +318,6 @@ sub vcl_fetch {
       set beresp.ttl = 900s;
       set beresp.http.Cache-Control = "max-age=900";
     }
-  }
-  # Strip cookies from outbound requests. Corresponding rule in vcl_recv{}
-  if (req.url !~ "^/(apply-for-a-licence|email|sign-in/callback)") {
-    unset beresp.http.Set-Cookie;
   }
 
   # Override default.vcl behaviour of return(pass).

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -161,7 +161,7 @@ acl purge_ip_allowlist {
 <%- end -%>
 }
 
-<% if not %w(production production-eks).include?(environment) %>
+<% if not %w(production).include?(environment) %>
 acl allowed_ip_addresses {
   <%- config.fetch('allowed_ip_addresses', []).each do |cidr| -%>
   <%- ip_address, mask = cidr.split('/') -%>
@@ -340,7 +340,7 @@ sub vcl_recv {
     set req.http.Authorization = "Basic <%= config['basic_authentication'] %>";
   }
 <% end -%>
-<% if environment == "integration" -%>
+<% if config['origin_hostname'].include? "eks" -%>
   # Strip cookies from inbound requests. Corresponding rule in vcl_fetch{}
   # For simplicity and security most applications should not use cookies.
   # With the exception of:
@@ -468,7 +468,7 @@ sub vcl_fetch {
       set beresp.http.Cache-Control = "max-age=900";
     }
   }
-<% if environment == "integration" -%>
+<% if config['origin_hostname'].include? "eks" -%>
   # Strip cookies from outbound requests. Corresponding rule in vcl_recv{}
   if (req.url !~ "^/(apply-for-a-licence|email|sign-in/callback)") {
     unset beresp.http.Set-Cookie;


### PR DESCRIPTION
This was breaking the A/B test smoke tests in EC2 integration, which causes confusion. I'm not sure we even need to do cookie stripping in the EC2-backed services.

Partially reverts #373.

https://trello.com/c/HXtsiNCO