### PR TITLE
Strip Accept-Encoding header in all environments

### DIFF
--- a/spec/test-outputs/www-eks-integration.out.vcl
+++ b/spec/test-outputs/www-eks-integration.out.vcl
@@ -58,14 +58,12 @@ sub vcl_recv {
 
   
 
-  
   # Strip Accept-Encoding header if the content is already compressed
   if (req.http.Accept-Encoding) {
     if (req.url ~ "\.(jpeg|jpg|png|gif|gz|tgz|bz2|tbz|zip|flv|pdf|mp3|ogg)$") {
       remove req.http.Accept-Encoding;
     }
   }
-  
 
   # Force SSL.
   if (!req.http.Fastly-SSL) {

--- a/spec/test-outputs/www-eks-production.out.vcl
+++ b/spec/test-outputs/www-eks-production.out.vcl
@@ -151,7 +151,12 @@ sub vcl_recv {
 
   
 
-  
+  # Strip Accept-Encoding header if the content is already compressed
+  if (req.http.Accept-Encoding) {
+    if (req.url ~ "\.(jpeg|jpg|png|gif|gz|tgz|bz2|tbz|zip|flv|pdf|mp3|ogg)$") {
+      remove req.http.Accept-Encoding;
+    }
+  }
 
   # Force SSL.
   if (!req.http.Fastly-SSL) {

--- a/spec/test-outputs/www-eks-staging.out.vcl
+++ b/spec/test-outputs/www-eks-staging.out.vcl
@@ -159,7 +159,12 @@ sub vcl_recv {
 
   
 
-  
+  # Strip Accept-Encoding header if the content is already compressed
+  if (req.http.Accept-Encoding) {
+    if (req.url ~ "\.(jpeg|jpg|png|gif|gz|tgz|bz2|tbz|zip|flv|pdf|mp3|ogg)$") {
+      remove req.http.Accept-Encoding;
+    }
+  }
 
   # Force SSL.
   if (!req.http.Fastly-SSL) {

--- a/spec/test-outputs/www-eks-test.out.vcl
+++ b/spec/test-outputs/www-eks-test.out.vcl
@@ -55,7 +55,12 @@ sub vcl_recv {
 
   
 
-  
+  # Strip Accept-Encoding header if the content is already compressed
+  if (req.http.Accept-Encoding) {
+    if (req.url ~ "\.(jpeg|jpg|png|gif|gz|tgz|bz2|tbz|zip|flv|pdf|mp3|ogg)$") {
+      remove req.http.Accept-Encoding;
+    }
+  }
 
   # Force SSL.
   if (!req.http.Fastly-SSL) {

--- a/spec/test-outputs/www-integration.out.vcl
+++ b/spec/test-outputs/www-integration.out.vcl
@@ -58,14 +58,12 @@ sub vcl_recv {
 
   
 
-  
   # Strip Accept-Encoding header if the content is already compressed
   if (req.http.Accept-Encoding) {
     if (req.url ~ "\.(jpeg|jpg|png|gif|gz|tgz|bz2|tbz|zip|flv|pdf|mp3|ogg)$") {
       remove req.http.Accept-Encoding;
     }
   }
-  
 
   # Force SSL.
   if (!req.http.Fastly-SSL) {

--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -151,7 +151,12 @@ sub vcl_recv {
 
   
 
-  
+  # Strip Accept-Encoding header if the content is already compressed
+  if (req.http.Accept-Encoding) {
+    if (req.url ~ "\.(jpeg|jpg|png|gif|gz|tgz|bz2|tbz|zip|flv|pdf|mp3|ogg)$") {
+      remove req.http.Accept-Encoding;
+    }
+  }
 
   # Force SSL.
   if (!req.http.Fastly-SSL) {

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -159,7 +159,12 @@ sub vcl_recv {
 
   
 
-  
+  # Strip Accept-Encoding header if the content is already compressed
+  if (req.http.Accept-Encoding) {
+    if (req.url ~ "\.(jpeg|jpg|png|gif|gz|tgz|bz2|tbz|zip|flv|pdf|mp3|ogg)$") {
+      remove req.http.Accept-Encoding;
+    }
+  }
 
   # Force SSL.
   if (!req.http.Fastly-SSL) {

--- a/spec/test-outputs/www-test.out.vcl
+++ b/spec/test-outputs/www-test.out.vcl
@@ -55,7 +55,12 @@ sub vcl_recv {
 
   
 
-  
+  # Strip Accept-Encoding header if the content is already compressed
+  if (req.http.Accept-Encoding) {
+    if (req.url ~ "\.(jpeg|jpg|png|gif|gz|tgz|bz2|tbz|zip|flv|pdf|mp3|ogg)$") {
+      remove req.http.Accept-Encoding;
+    }
+  }
 
   # Force SSL.
   if (!req.http.Fastly-SSL) {

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -204,14 +204,12 @@ sub vcl_recv {
   }
   <% end %>
 
-  <% if environment == 'integration' %>
   # Strip Accept-Encoding header if the content is already compressed
   if (req.http.Accept-Encoding) {
     if (req.url ~ "\.(jpeg|jpg|png|gif|gz|tgz|bz2|tbz|zip|flv|pdf|mp3|ogg)$") {
       remove req.http.Accept-Encoding;
     }
   }
-  <% end %>
 
   # Force SSL.
   if (!req.http.Fastly-SSL) {


### PR DESCRIPTION
Tests in integration look good, should be safe to roll out everywhere.

See also: https://github.com/alphagov/govuk-cdn-config/pull/379

https://trello.com/c/HXtsiNCO/855-strip-cookies-at-fastly