### PR TITLE
Remove purge allowlist

### DIFF
--- a/spec/test-outputs/www-eks-integration.out.vcl
+++ b/spec/test-outputs/www-eks-integration.out.vcl
@@ -31,12 +31,6 @@ backend F_origin {
 
 
 
-acl purge_ip_allowlist {
-  "34.248.229.46";    # AWS Integration NAT gateway
-  "34.248.44.175";    # AWS Integration NAT gateway
-  "52.51.97.232";     # AWS Integration NAT gateway
-}
-
 
 acl allowed_ip_addresses {
 }
@@ -44,10 +38,8 @@ acl allowed_ip_addresses {
 
 sub vcl_recv {
 
-  # Require authentication for FASTLYPURGE requests unless from IP in ACL
-  if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_allowlist) {
-    set req.http.Fastly-Purge-Requires-Auth = "1";
-  }
+  # Require authentication for PURGE requests
+  set req.http.Fastly-Purge-Requires-Auth = "1";
 
   
 

--- a/spec/test-outputs/www-eks-production.out.vcl
+++ b/spec/test-outputs/www-eks-production.out.vcl
@@ -127,20 +127,12 @@ backend F_mirrorGCS {
 }
 
 
-acl purge_ip_allowlist {
-  "34.246.209.74";    # AWS NAT GW1
-  "34.253.57.8";      # AWS NAT GW2
-  "18.202.136.43";    # AWS NAT GW3
-}
-
 
 
 sub vcl_recv {
 
-  # Require authentication for FASTLYPURGE requests unless from IP in ACL
-  if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_allowlist) {
-    set req.http.Fastly-Purge-Requires-Auth = "1";
-  }
+  # Require authentication for PURGE requests
+  set req.http.Fastly-Purge-Requires-Auth = "1";
 
   
 

--- a/spec/test-outputs/www-eks-staging.out.vcl
+++ b/spec/test-outputs/www-eks-staging.out.vcl
@@ -127,12 +127,6 @@ backend F_mirrorGCS {
 }
 
 
-acl purge_ip_allowlist {
-  "18.202.183.143";   # AWS NAT GW1
-  "18.203.90.80";     # AWS NAT GW2
-  "18.203.108.248";   # AWS NAT GW3
-}
-
 
 acl allowed_ip_addresses {
 }
@@ -140,10 +134,8 @@ acl allowed_ip_addresses {
 
 sub vcl_recv {
 
-  # Require authentication for FASTLYPURGE requests unless from IP in ACL
-  if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_allowlist) {
-    set req.http.Fastly-Purge-Requires-Auth = "1";
-  }
+  # Require authentication for PURGE requests
+  set req.http.Fastly-Purge-Requires-Auth = "1";
 
   
   # Only allow connections from allowed IP addresses in staging

--- a/spec/test-outputs/www-eks-test.out.vcl
+++ b/spec/test-outputs/www-eks-test.out.vcl
@@ -31,9 +31,6 @@ backend F_origin {
 
 
 
-acl purge_ip_allowlist {
-}
-
 
 acl allowed_ip_addresses {
 }
@@ -41,10 +38,8 @@ acl allowed_ip_addresses {
 
 sub vcl_recv {
 
-  # Require authentication for FASTLYPURGE requests unless from IP in ACL
-  if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_allowlist) {
-    set req.http.Fastly-Purge-Requires-Auth = "1";
-  }
+  # Require authentication for PURGE requests
+  set req.http.Fastly-Purge-Requires-Auth = "1";
 
   
 

--- a/spec/test-outputs/www-integration.out.vcl
+++ b/spec/test-outputs/www-integration.out.vcl
@@ -31,12 +31,6 @@ backend F_origin {
 
 
 
-acl purge_ip_allowlist {
-  "34.248.229.46";    # AWS Integration NAT gateway
-  "34.248.44.175";    # AWS Integration NAT gateway
-  "52.51.97.232";     # AWS Integration NAT gateway
-}
-
 
 acl allowed_ip_addresses {
 }
@@ -44,10 +38,8 @@ acl allowed_ip_addresses {
 
 sub vcl_recv {
 
-  # Require authentication for FASTLYPURGE requests unless from IP in ACL
-  if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_allowlist) {
-    set req.http.Fastly-Purge-Requires-Auth = "1";
-  }
+  # Require authentication for PURGE requests
+  set req.http.Fastly-Purge-Requires-Auth = "1";
 
   
 

--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -127,20 +127,12 @@ backend F_mirrorGCS {
 }
 
 
-acl purge_ip_allowlist {
-  "34.246.209.74";    # AWS NAT GW1
-  "34.253.57.8";      # AWS NAT GW2
-  "18.202.136.43";    # AWS NAT GW3
-}
-
 
 
 sub vcl_recv {
 
-  # Require authentication for FASTLYPURGE requests unless from IP in ACL
-  if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_allowlist) {
-    set req.http.Fastly-Purge-Requires-Auth = "1";
-  }
+  # Require authentication for PURGE requests
+  set req.http.Fastly-Purge-Requires-Auth = "1";
 
   
 

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -127,12 +127,6 @@ backend F_mirrorGCS {
 }
 
 
-acl purge_ip_allowlist {
-  "18.202.183.143";   # AWS NAT GW1
-  "18.203.90.80";     # AWS NAT GW2
-  "18.203.108.248";   # AWS NAT GW3
-}
-
 
 acl allowed_ip_addresses {
 }
@@ -140,10 +134,8 @@ acl allowed_ip_addresses {
 
 sub vcl_recv {
 
-  # Require authentication for FASTLYPURGE requests unless from IP in ACL
-  if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_allowlist) {
-    set req.http.Fastly-Purge-Requires-Auth = "1";
-  }
+  # Require authentication for PURGE requests
+  set req.http.Fastly-Purge-Requires-Auth = "1";
 
   
   # Only allow connections from allowed IP addresses in staging

--- a/spec/test-outputs/www-test.out.vcl
+++ b/spec/test-outputs/www-test.out.vcl
@@ -31,9 +31,6 @@ backend F_origin {
 
 
 
-acl purge_ip_allowlist {
-}
-
 
 acl allowed_ip_addresses {
 }
@@ -41,10 +38,8 @@ acl allowed_ip_addresses {
 
 sub vcl_recv {
 
-  # Require authentication for FASTLYPURGE requests unless from IP in ACL
-  if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_allowlist) {
-    set req.http.Fastly-Purge-Requires-Auth = "1";
-  }
+  # Require authentication for PURGE requests
+  set req.http.Fastly-Purge-Requires-Auth = "1";
 
   
 

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -147,22 +147,6 @@ backend F_mirrorGCS {
 }
 <% end %>
 
-acl purge_ip_allowlist {
-<%- if environment.start_with? 'integration' -%>
-  "34.248.229.46";    # AWS Integration NAT gateway
-  "34.248.44.175";    # AWS Integration NAT gateway
-  "52.51.97.232";     # AWS Integration NAT gateway
-<%- elsif environment.start_with? 'staging' -%>
-  "18.202.183.143";   # AWS NAT GW1
-  "18.203.90.80";     # AWS NAT GW2
-  "18.203.108.248";   # AWS NAT GW3
-<%- elsif environment.start_with? 'production' -%>
-  "34.246.209.74";    # AWS NAT GW1
-  "34.253.57.8";      # AWS NAT GW2
-  "18.202.136.43";    # AWS NAT GW3
-<%- end -%>
-}
-
 <% if not %w(production).include?(environment) %>
 acl allowed_ip_addresses {
   <%- config.fetch('allowed_ip_addresses', []).each do |cidr| -%>
@@ -178,10 +162,8 @@ acl allowed_ip_addresses {
 
 sub vcl_recv {
 
-  # Require authentication for FASTLYPURGE requests unless from IP in ACL
-  if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_allowlist) {
-    set req.http.Fastly-Purge-Requires-Auth = "1";
-  }
+  # Require authentication for PURGE requests
+  set req.http.Fastly-Purge-Requires-Auth = "1";
 
   <% if %w(staging production-eks).include?(environment) %>
   # Only allow connections from allowed IP addresses in staging


### PR DESCRIPTION
[Trello card](https://trello.com/c/O5Wy2X9w/2946-authenticate-fastly-purge-requests-with-an-api-token-3)

Now that the "Clear CDN Cache" Jenkins job has been updated to authenticate its PURGE requests to Fastly with an API token[^1], and the developer docs have been updated to make it clear that manual PURGE requests must similarly be authenticated[^2], it should now be safe to require authentication for every PURGE request, and remove the IP allowlist.

[^1]: https://github.com/alphagov/govuk-puppet/pull/11775
[^2]: https://github.com/alphagov/govuk-developer-docs/pull/3635