### PR TITLE
Add config for replatforming traffic split experiment

### DIFF
--- a/spec/test-outputs/www-eks-integration.out.vcl
+++ b/spec/test-outputs/www-eks-integration.out.vcl
@@ -32,6 +32,8 @@ backend F_origin {
 
 
 
+
+
 acl allowed_ip_addresses {
 }
 

--- a/spec/test-outputs/www-eks-production.out.vcl
+++ b/spec/test-outputs/www-eks-production.out.vcl
@@ -30,6 +30,8 @@ backend F_origin {
 }
 
 
+
+
 # Mirror backend for S3
 backend F_mirrorS3 {
     .connect_timeout = 1s;

--- a/spec/test-outputs/www-eks-staging.out.vcl
+++ b/spec/test-outputs/www-eks-staging.out.vcl
@@ -30,6 +30,8 @@ backend F_origin {
 }
 
 
+
+
 # Mirror backend for S3
 backend F_mirrorS3 {
     .connect_timeout = 1s;

--- a/spec/test-outputs/www-eks-test.out.vcl
+++ b/spec/test-outputs/www-eks-test.out.vcl
@@ -32,6 +32,8 @@ backend F_origin {
 
 
 
+
+
 acl allowed_ip_addresses {
 }
 

--- a/spec/test-outputs/www-integration.out.vcl
+++ b/spec/test-outputs/www-integration.out.vcl
@@ -32,6 +32,8 @@ backend F_origin {
 
 
 
+
+
 acl allowed_ip_addresses {
 }
 

--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -30,6 +30,8 @@ backend F_origin {
 }
 
 
+
+
 # Mirror backend for S3
 backend F_mirrorS3 {
     .connect_timeout = 1s;

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -30,6 +30,8 @@ backend F_origin {
 }
 
 
+
+
 # Mirror backend for S3
 backend F_mirrorS3 {
     .connect_timeout = 1s;

--- a/spec/test-outputs/www-test.out.vcl
+++ b/spec/test-outputs/www-test.out.vcl
@@ -32,6 +32,8 @@ backend F_origin {
 
 
 
+
+
 acl allowed_ip_addresses {
 }
 

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -40,6 +40,55 @@ backend F_origin {
 <% end -%>
 }
 
+<%- if config['replatforming_traffic_split'] %>
+backend F_eks_origin {
+    .connect_timeout = 5s;
+    .dynamic = true;
+    .port = "443";
+    .host = "www-origin.eks.staging.govuk.digital";
+    .first_byte_timeout = 15s;
+    .max_connections = 200;
+    .between_bytes_timeout = 10s;
+    .share_key = "<%= config.fetch('service_id') %>";
+
+    .ssl = true;
+    .ssl_check_cert = <%= config['disable_tls_validation'] ? 'never' : 'always' %>;
+    .min_tls_version = "<%= config.fetch('min_tls_version', '1.2') %>";
+    <%- if config['ssl_ciphers'] -%>
+    .ssl_ciphers = "<%= config['ssl_ciphers'] -%>";
+    <%- end -%>
+    .ssl_cert_hostname = "www-origin.eks.staging.govuk.digital";
+    .ssl_sni_hostname = "www-origin.eks.staging.govuk.digital";
+
+<% if config['probe'] -%>
+    .probe = {
+        .request =
+            "HEAD <%= config['probe'] %> HTTP/1.1"
+            "Host: <%= config.fetch('origin_hostname') %>"
+            "User-Agent: Fastly healthcheck (git version: <%= config['git_version'] %>)"
+<% if config['rate_limit_token'] -%>
+            "Rate-Limit-Token: <%= config['rate_limit_token'] %>"
+<% end -%>
+<% if config['basic_authentication'] -%>
+            "Authorization: Basic <%= config['basic_authentication'] %>"
+<% end -%>
+            "Connection: close";
+        .threshold = 1;
+        .window = 2;
+        .timeout = 5s;
+        .initial = 1;
+        .expected_response = 200;
+        .interval = 10s;
+    }
+<% end -%>
+}
+
+director D_traffic_split random {
+  { .backend = F_origin; .weight = 1; }
+  { .backend = F_eks_origin; .weight = 99; }
+}
+<%- end %>
+
 <% if %w(staging production production-eks).include?(environment) %>
 # Mirror backend for S3
 backend F_mirrorS3 {
@@ -222,7 +271,7 @@ sub vcl_recv {
 
   # Default backend, these details will be overwritten if other backends are
   # chosen
-  set req.backend = F_origin;
+  set req.backend = <%= config['replatforming_traffic_split'] ? 'D_traffic_split' : 'F_origin' %>;
   set req.http.Fastly-Backend-Name = "origin";
 
   # Set header to show recommended related links for Whitehall content. This is to be used


### PR DESCRIPTION
This is a temporary change to enable sending a proportion of traffic to the new k8s GOV.UK stack. It is enabled with a config variable, and has been set up for use in staging before the production test next week.

https://trello.com/c/a6qhzsAy/987-create-fastly-config-for-production-traffic-split-experiment