### PR TITLE
Update replatforming traffic split URLs to production; set traffic split ratio to 5%

### DIFF
--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -45,7 +45,7 @@ backend F_eks_origin {
     .connect_timeout = 5s;
     .dynamic = true;
     .port = "443";
-    .host = "www-origin.eks.staging.govuk.digital";
+    .host = "www-origin.eks.production.govuk.digital";
     .first_byte_timeout = 15s;
     .max_connections = 200;
     .between_bytes_timeout = 10s;
@@ -57,8 +57,8 @@ backend F_eks_origin {
     <%- if config['ssl_ciphers'] -%>
     .ssl_ciphers = "<%= config['ssl_ciphers'] -%>";
     <%- end -%>
-    .ssl_cert_hostname = "www-origin.eks.staging.govuk.digital";
-    .ssl_sni_hostname = "www-origin.eks.staging.govuk.digital";
+    .ssl_cert_hostname = "www-origin.eks.production.govuk.digital";
+    .ssl_sni_hostname = "www-origin.eks.production.govuk.digital";
 
 <% if config['probe'] -%>
     .probe = {
@@ -84,8 +84,8 @@ backend F_eks_origin {
 }
 
 director D_traffic_split random {
-  { .backend = F_origin; .weight = 1; }
-  { .backend = F_eks_origin; .weight = 99; }
+  { .backend = F_origin; .weight = 20; }
+  { .backend = F_eks_origin; .weight = 1; }
 }
 <%- end %>
 


### PR DESCRIPTION
Test in staging was successful; this sets the backend URLs to the production ones, and sets the ratio to 1:20 (5%) going to the EKS platform.

https://trello.com/c/a6qhzsAy/987-create-fastly-config-for-production-traffic-split-experiment