### PR TITLE
Remove Level 2 Browse AB Test

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,4 +98,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.17.3
+   2.3.19

--- a/ab_tests/ab_tests.yaml
+++ b/ab_tests/ab_tests.yaml
@@ -4,7 +4,3 @@
 - Example:
   - A
   - B
-- LevelTwoBrowse:
-  - A
-  - B
-  - Z

--- a/configs/dictionaries/ab_test_expiries.yaml
+++ b/configs/dictionaries/ab_test_expiries.yaml
@@ -6,4 +6,3 @@
 # ExampleTest: 86400
 ---
 Example: 86400
-LevelTwoBrowse: 7776000 # 90 days

--- a/configs/dictionaries/active_ab_tests.yaml
+++ b/configs/dictionaries/active_ab_tests.yaml
@@ -4,4 +4,3 @@
 # bucket allocations. See example_percentages.yaml for format.
 ---
 Example: true
-LevelTwoBrowse: true

--- a/spec/test-outputs/www-eks-integration.out.vcl
+++ b/spec/test-outputs/www-eks-integration.out.vcl
@@ -178,50 +178,6 @@ if (req.http.Cookie ~ "cookies_policy" && req.http.Cookie:cookies_policy ~ "%22u
       }
     }
   }
-  if (table.lookup(active_ab_tests, "LevelTwoBrowse") == "true") {
-    if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
-      set req.http.GOVUK-ABTest-LevelTwoBrowse = "A";
-    } else if (req.url ~ "[\?\&]ABTest-LevelTwoBrowse=A(&|$)") {
-      # Some users, such as remote testers, will be given a URL with a query string
-      # to place them into a specific bucket.
-      set req.http.GOVUK-ABTest-LevelTwoBrowse = "A";
-    } else if (req.url ~ "[\?\&]ABTest-LevelTwoBrowse=B(&|$)") {
-      # Some users, such as remote testers, will be given a URL with a query string
-      # to place them into a specific bucket.
-      set req.http.GOVUK-ABTest-LevelTwoBrowse = "B";
-    } else if (req.url ~ "[\?\&]ABTest-LevelTwoBrowse=Z(&|$)") {
-      # Some users, such as remote testers, will be given a URL with a query string
-      # to place them into a specific bucket.
-      set req.http.GOVUK-ABTest-LevelTwoBrowse = "Z";
-    } else if (req.http.Cookie ~ "ABTest-LevelTwoBrowse") {
-      # Set the value of the header to whatever decision was previously made
-      set req.http.GOVUK-ABTest-LevelTwoBrowse = req.http.Cookie:ABTest-LevelTwoBrowse;
-    } else {
-      declare local var.denominator_LevelTwoBrowse INTEGER;
-      declare local var.denominator_LevelTwoBrowse_A INTEGER;
-      declare local var.nominator_LevelTwoBrowse_A INTEGER;
-      set var.nominator_LevelTwoBrowse_A = std.atoi(table.lookup(leveltwobrowse_percentages, "A"));
-      set var.denominator_LevelTwoBrowse += var.nominator_LevelTwoBrowse_A;
-      declare local var.denominator_LevelTwoBrowse_B INTEGER;
-      declare local var.nominator_LevelTwoBrowse_B INTEGER;
-      set var.nominator_LevelTwoBrowse_B = std.atoi(table.lookup(leveltwobrowse_percentages, "B"));
-      set var.denominator_LevelTwoBrowse += var.nominator_LevelTwoBrowse_B;
-      declare local var.denominator_LevelTwoBrowse_Z INTEGER;
-      declare local var.nominator_LevelTwoBrowse_Z INTEGER;
-      set var.nominator_LevelTwoBrowse_Z = std.atoi(table.lookup(leveltwobrowse_percentages, "Z"));
-      set var.denominator_LevelTwoBrowse += var.nominator_LevelTwoBrowse_Z;
-      set var.denominator_LevelTwoBrowse_A = var.denominator_LevelTwoBrowse;
-      set var.denominator_LevelTwoBrowse_B = var.denominator_LevelTwoBrowse_A;
-      set var.denominator_LevelTwoBrowse_B -= var.nominator_LevelTwoBrowse_A;
-      if (randombool(var.nominator_LevelTwoBrowse_A, var.denominator_LevelTwoBrowse_A)) {
-        set req.http.GOVUK-ABTest-LevelTwoBrowse = "A";
-      } else if (randombool(var.nominator_LevelTwoBrowse_B, var.denominator_LevelTwoBrowse_B)) {
-        set req.http.GOVUK-ABTest-LevelTwoBrowse = "B";
-      } else {
-        set req.http.GOVUK-ABTest-LevelTwoBrowse = "Z";
-      }
-    }
-  }
 }
 # End dynamic section
 
@@ -376,16 +332,6 @@ sub vcl_deliver {
 
   # Begin dynamic section
   declare local var.expiry TIME;
-  if (req.http.Cookie ~ "cookies_policy") {
-    if (req.http.Cookie:cookies_policy ~ "%22usage%22:true") {
-      if (table.lookup(active_ab_tests, "LevelTwoBrowse") == "true") {
-        if (req.http.Cookie !~ "ABTest-LevelTwoBrowse" || req.url ~ "[\?\&]ABTest-LevelTwoBrowse" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
-          set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "LevelTwoBrowse"))));
-          add resp.http.Set-Cookie = "ABTest-LevelTwoBrowse=" req.http.GOVUK-ABTest-LevelTwoBrowse "; secure; expires=" var.expiry "; path=/";
-        }
-      }
-    }
-  }
   # End dynamic section
 
 #FASTLY deliver

--- a/spec/test-outputs/www-eks-production.out.vcl
+++ b/spec/test-outputs/www-eks-production.out.vcl
@@ -339,50 +339,6 @@ if (req.http.Cookie ~ "cookies_policy" && req.http.Cookie:cookies_policy ~ "%22u
       }
     }
   }
-  if (table.lookup(active_ab_tests, "LevelTwoBrowse") == "true") {
-    if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
-      set req.http.GOVUK-ABTest-LevelTwoBrowse = "A";
-    } else if (req.url ~ "[\?\&]ABTest-LevelTwoBrowse=A(&|$)") {
-      # Some users, such as remote testers, will be given a URL with a query string
-      # to place them into a specific bucket.
-      set req.http.GOVUK-ABTest-LevelTwoBrowse = "A";
-    } else if (req.url ~ "[\?\&]ABTest-LevelTwoBrowse=B(&|$)") {
-      # Some users, such as remote testers, will be given a URL with a query string
-      # to place them into a specific bucket.
-      set req.http.GOVUK-ABTest-LevelTwoBrowse = "B";
-    } else if (req.url ~ "[\?\&]ABTest-LevelTwoBrowse=Z(&|$)") {
-      # Some users, such as remote testers, will be given a URL with a query string
-      # to place them into a specific bucket.
-      set req.http.GOVUK-ABTest-LevelTwoBrowse = "Z";
-    } else if (req.http.Cookie ~ "ABTest-LevelTwoBrowse") {
-      # Set the value of the header to whatever decision was previously made
-      set req.http.GOVUK-ABTest-LevelTwoBrowse = req.http.Cookie:ABTest-LevelTwoBrowse;
-    } else {
-      declare local var.denominator_LevelTwoBrowse INTEGER;
-      declare local var.denominator_LevelTwoBrowse_A INTEGER;
-      declare local var.nominator_LevelTwoBrowse_A INTEGER;
-      set var.nominator_LevelTwoBrowse_A = std.atoi(table.lookup(leveltwobrowse_percentages, "A"));
-      set var.denominator_LevelTwoBrowse += var.nominator_LevelTwoBrowse_A;
-      declare local var.denominator_LevelTwoBrowse_B INTEGER;
-      declare local var.nominator_LevelTwoBrowse_B INTEGER;
-      set var.nominator_LevelTwoBrowse_B = std.atoi(table.lookup(leveltwobrowse_percentages, "B"));
-      set var.denominator_LevelTwoBrowse += var.nominator_LevelTwoBrowse_B;
-      declare local var.denominator_LevelTwoBrowse_Z INTEGER;
-      declare local var.nominator_LevelTwoBrowse_Z INTEGER;
-      set var.nominator_LevelTwoBrowse_Z = std.atoi(table.lookup(leveltwobrowse_percentages, "Z"));
-      set var.denominator_LevelTwoBrowse += var.nominator_LevelTwoBrowse_Z;
-      set var.denominator_LevelTwoBrowse_A = var.denominator_LevelTwoBrowse;
-      set var.denominator_LevelTwoBrowse_B = var.denominator_LevelTwoBrowse_A;
-      set var.denominator_LevelTwoBrowse_B -= var.nominator_LevelTwoBrowse_A;
-      if (randombool(var.nominator_LevelTwoBrowse_A, var.denominator_LevelTwoBrowse_A)) {
-        set req.http.GOVUK-ABTest-LevelTwoBrowse = "A";
-      } else if (randombool(var.nominator_LevelTwoBrowse_B, var.denominator_LevelTwoBrowse_B)) {
-        set req.http.GOVUK-ABTest-LevelTwoBrowse = "B";
-      } else {
-        set req.http.GOVUK-ABTest-LevelTwoBrowse = "Z";
-      }
-    }
-  }
 }
 # End dynamic section
 
@@ -537,16 +493,6 @@ sub vcl_deliver {
 
   # Begin dynamic section
   declare local var.expiry TIME;
-  if (req.http.Cookie ~ "cookies_policy") {
-    if (req.http.Cookie:cookies_policy ~ "%22usage%22:true") {
-      if (table.lookup(active_ab_tests, "LevelTwoBrowse") == "true") {
-        if (req.http.Cookie !~ "ABTest-LevelTwoBrowse" || req.url ~ "[\?\&]ABTest-LevelTwoBrowse" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
-          set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "LevelTwoBrowse"))));
-          add resp.http.Set-Cookie = "ABTest-LevelTwoBrowse=" req.http.GOVUK-ABTest-LevelTwoBrowse "; secure; expires=" var.expiry "; path=/";
-        }
-      }
-    }
-  }
   # End dynamic section
 
 #FASTLY deliver

--- a/spec/test-outputs/www-eks-staging.out.vcl
+++ b/spec/test-outputs/www-eks-staging.out.vcl
@@ -347,50 +347,6 @@ if (req.http.Cookie ~ "cookies_policy" && req.http.Cookie:cookies_policy ~ "%22u
       }
     }
   }
-  if (table.lookup(active_ab_tests, "LevelTwoBrowse") == "true") {
-    if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
-      set req.http.GOVUK-ABTest-LevelTwoBrowse = "A";
-    } else if (req.url ~ "[\?\&]ABTest-LevelTwoBrowse=A(&|$)") {
-      # Some users, such as remote testers, will be given a URL with a query string
-      # to place them into a specific bucket.
-      set req.http.GOVUK-ABTest-LevelTwoBrowse = "A";
-    } else if (req.url ~ "[\?\&]ABTest-LevelTwoBrowse=B(&|$)") {
-      # Some users, such as remote testers, will be given a URL with a query string
-      # to place them into a specific bucket.
-      set req.http.GOVUK-ABTest-LevelTwoBrowse = "B";
-    } else if (req.url ~ "[\?\&]ABTest-LevelTwoBrowse=Z(&|$)") {
-      # Some users, such as remote testers, will be given a URL with a query string
-      # to place them into a specific bucket.
-      set req.http.GOVUK-ABTest-LevelTwoBrowse = "Z";
-    } else if (req.http.Cookie ~ "ABTest-LevelTwoBrowse") {
-      # Set the value of the header to whatever decision was previously made
-      set req.http.GOVUK-ABTest-LevelTwoBrowse = req.http.Cookie:ABTest-LevelTwoBrowse;
-    } else {
-      declare local var.denominator_LevelTwoBrowse INTEGER;
-      declare local var.denominator_LevelTwoBrowse_A INTEGER;
-      declare local var.nominator_LevelTwoBrowse_A INTEGER;
-      set var.nominator_LevelTwoBrowse_A = std.atoi(table.lookup(leveltwobrowse_percentages, "A"));
-      set var.denominator_LevelTwoBrowse += var.nominator_LevelTwoBrowse_A;
-      declare local var.denominator_LevelTwoBrowse_B INTEGER;
-      declare local var.nominator_LevelTwoBrowse_B INTEGER;
-      set var.nominator_LevelTwoBrowse_B = std.atoi(table.lookup(leveltwobrowse_percentages, "B"));
-      set var.denominator_LevelTwoBrowse += var.nominator_LevelTwoBrowse_B;
-      declare local var.denominator_LevelTwoBrowse_Z INTEGER;
-      declare local var.nominator_LevelTwoBrowse_Z INTEGER;
-      set var.nominator_LevelTwoBrowse_Z = std.atoi(table.lookup(leveltwobrowse_percentages, "Z"));
-      set var.denominator_LevelTwoBrowse += var.nominator_LevelTwoBrowse_Z;
-      set var.denominator_LevelTwoBrowse_A = var.denominator_LevelTwoBrowse;
-      set var.denominator_LevelTwoBrowse_B = var.denominator_LevelTwoBrowse_A;
-      set var.denominator_LevelTwoBrowse_B -= var.nominator_LevelTwoBrowse_A;
-      if (randombool(var.nominator_LevelTwoBrowse_A, var.denominator_LevelTwoBrowse_A)) {
-        set req.http.GOVUK-ABTest-LevelTwoBrowse = "A";
-      } else if (randombool(var.nominator_LevelTwoBrowse_B, var.denominator_LevelTwoBrowse_B)) {
-        set req.http.GOVUK-ABTest-LevelTwoBrowse = "B";
-      } else {
-        set req.http.GOVUK-ABTest-LevelTwoBrowse = "Z";
-      }
-    }
-  }
 }
 # End dynamic section
 
@@ -545,16 +501,6 @@ sub vcl_deliver {
 
   # Begin dynamic section
   declare local var.expiry TIME;
-  if (req.http.Cookie ~ "cookies_policy") {
-    if (req.http.Cookie:cookies_policy ~ "%22usage%22:true") {
-      if (table.lookup(active_ab_tests, "LevelTwoBrowse") == "true") {
-        if (req.http.Cookie !~ "ABTest-LevelTwoBrowse" || req.url ~ "[\?\&]ABTest-LevelTwoBrowse" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
-          set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "LevelTwoBrowse"))));
-          add resp.http.Set-Cookie = "ABTest-LevelTwoBrowse=" req.http.GOVUK-ABTest-LevelTwoBrowse "; secure; expires=" var.expiry "; path=/";
-        }
-      }
-    }
-  }
   # End dynamic section
 
 #FASTLY deliver

--- a/spec/test-outputs/www-eks-test.out.vcl
+++ b/spec/test-outputs/www-eks-test.out.vcl
@@ -178,50 +178,6 @@ if (req.http.Cookie ~ "cookies_policy" && req.http.Cookie:cookies_policy ~ "%22u
       }
     }
   }
-  if (table.lookup(active_ab_tests, "LevelTwoBrowse") == "true") {
-    if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
-      set req.http.GOVUK-ABTest-LevelTwoBrowse = "A";
-    } else if (req.url ~ "[\?\&]ABTest-LevelTwoBrowse=A(&|$)") {
-      # Some users, such as remote testers, will be given a URL with a query string
-      # to place them into a specific bucket.
-      set req.http.GOVUK-ABTest-LevelTwoBrowse = "A";
-    } else if (req.url ~ "[\?\&]ABTest-LevelTwoBrowse=B(&|$)") {
-      # Some users, such as remote testers, will be given a URL with a query string
-      # to place them into a specific bucket.
-      set req.http.GOVUK-ABTest-LevelTwoBrowse = "B";
-    } else if (req.url ~ "[\?\&]ABTest-LevelTwoBrowse=Z(&|$)") {
-      # Some users, such as remote testers, will be given a URL with a query string
-      # to place them into a specific bucket.
-      set req.http.GOVUK-ABTest-LevelTwoBrowse = "Z";
-    } else if (req.http.Cookie ~ "ABTest-LevelTwoBrowse") {
-      # Set the value of the header to whatever decision was previously made
-      set req.http.GOVUK-ABTest-LevelTwoBrowse = req.http.Cookie:ABTest-LevelTwoBrowse;
-    } else {
-      declare local var.denominator_LevelTwoBrowse INTEGER;
-      declare local var.denominator_LevelTwoBrowse_A INTEGER;
-      declare local var.nominator_LevelTwoBrowse_A INTEGER;
-      set var.nominator_LevelTwoBrowse_A = std.atoi(table.lookup(leveltwobrowse_percentages, "A"));
-      set var.denominator_LevelTwoBrowse += var.nominator_LevelTwoBrowse_A;
-      declare local var.denominator_LevelTwoBrowse_B INTEGER;
-      declare local var.nominator_LevelTwoBrowse_B INTEGER;
-      set var.nominator_LevelTwoBrowse_B = std.atoi(table.lookup(leveltwobrowse_percentages, "B"));
-      set var.denominator_LevelTwoBrowse += var.nominator_LevelTwoBrowse_B;
-      declare local var.denominator_LevelTwoBrowse_Z INTEGER;
-      declare local var.nominator_LevelTwoBrowse_Z INTEGER;
-      set var.nominator_LevelTwoBrowse_Z = std.atoi(table.lookup(leveltwobrowse_percentages, "Z"));
-      set var.denominator_LevelTwoBrowse += var.nominator_LevelTwoBrowse_Z;
-      set var.denominator_LevelTwoBrowse_A = var.denominator_LevelTwoBrowse;
-      set var.denominator_LevelTwoBrowse_B = var.denominator_LevelTwoBrowse_A;
-      set var.denominator_LevelTwoBrowse_B -= var.nominator_LevelTwoBrowse_A;
-      if (randombool(var.nominator_LevelTwoBrowse_A, var.denominator_LevelTwoBrowse_A)) {
-        set req.http.GOVUK-ABTest-LevelTwoBrowse = "A";
-      } else if (randombool(var.nominator_LevelTwoBrowse_B, var.denominator_LevelTwoBrowse_B)) {
-        set req.http.GOVUK-ABTest-LevelTwoBrowse = "B";
-      } else {
-        set req.http.GOVUK-ABTest-LevelTwoBrowse = "Z";
-      }
-    }
-  }
 }
 # End dynamic section
 
@@ -376,16 +332,6 @@ sub vcl_deliver {
 
   # Begin dynamic section
   declare local var.expiry TIME;
-  if (req.http.Cookie ~ "cookies_policy") {
-    if (req.http.Cookie:cookies_policy ~ "%22usage%22:true") {
-      if (table.lookup(active_ab_tests, "LevelTwoBrowse") == "true") {
-        if (req.http.Cookie !~ "ABTest-LevelTwoBrowse" || req.url ~ "[\?\&]ABTest-LevelTwoBrowse" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
-          set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "LevelTwoBrowse"))));
-          add resp.http.Set-Cookie = "ABTest-LevelTwoBrowse=" req.http.GOVUK-ABTest-LevelTwoBrowse "; secure; expires=" var.expiry "; path=/";
-        }
-      }
-    }
-  }
   # End dynamic section
 
 #FASTLY deliver

--- a/spec/test-outputs/www-integration.out.vcl
+++ b/spec/test-outputs/www-integration.out.vcl
@@ -178,50 +178,6 @@ if (req.http.Cookie ~ "cookies_policy" && req.http.Cookie:cookies_policy ~ "%22u
       }
     }
   }
-  if (table.lookup(active_ab_tests, "LevelTwoBrowse") == "true") {
-    if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
-      set req.http.GOVUK-ABTest-LevelTwoBrowse = "A";
-    } else if (req.url ~ "[\?\&]ABTest-LevelTwoBrowse=A(&|$)") {
-      # Some users, such as remote testers, will be given a URL with a query string
-      # to place them into a specific bucket.
-      set req.http.GOVUK-ABTest-LevelTwoBrowse = "A";
-    } else if (req.url ~ "[\?\&]ABTest-LevelTwoBrowse=B(&|$)") {
-      # Some users, such as remote testers, will be given a URL with a query string
-      # to place them into a specific bucket.
-      set req.http.GOVUK-ABTest-LevelTwoBrowse = "B";
-    } else if (req.url ~ "[\?\&]ABTest-LevelTwoBrowse=Z(&|$)") {
-      # Some users, such as remote testers, will be given a URL with a query string
-      # to place them into a specific bucket.
-      set req.http.GOVUK-ABTest-LevelTwoBrowse = "Z";
-    } else if (req.http.Cookie ~ "ABTest-LevelTwoBrowse") {
-      # Set the value of the header to whatever decision was previously made
-      set req.http.GOVUK-ABTest-LevelTwoBrowse = req.http.Cookie:ABTest-LevelTwoBrowse;
-    } else {
-      declare local var.denominator_LevelTwoBrowse INTEGER;
-      declare local var.denominator_LevelTwoBrowse_A INTEGER;
-      declare local var.nominator_LevelTwoBrowse_A INTEGER;
-      set var.nominator_LevelTwoBrowse_A = std.atoi(table.lookup(leveltwobrowse_percentages, "A"));
-      set var.denominator_LevelTwoBrowse += var.nominator_LevelTwoBrowse_A;
-      declare local var.denominator_LevelTwoBrowse_B INTEGER;
-      declare local var.nominator_LevelTwoBrowse_B INTEGER;
-      set var.nominator_LevelTwoBrowse_B = std.atoi(table.lookup(leveltwobrowse_percentages, "B"));
-      set var.denominator_LevelTwoBrowse += var.nominator_LevelTwoBrowse_B;
-      declare local var.denominator_LevelTwoBrowse_Z INTEGER;
-      declare local var.nominator_LevelTwoBrowse_Z INTEGER;
-      set var.nominator_LevelTwoBrowse_Z = std.atoi(table.lookup(leveltwobrowse_percentages, "Z"));
-      set var.denominator_LevelTwoBrowse += var.nominator_LevelTwoBrowse_Z;
-      set var.denominator_LevelTwoBrowse_A = var.denominator_LevelTwoBrowse;
-      set var.denominator_LevelTwoBrowse_B = var.denominator_LevelTwoBrowse_A;
-      set var.denominator_LevelTwoBrowse_B -= var.nominator_LevelTwoBrowse_A;
-      if (randombool(var.nominator_LevelTwoBrowse_A, var.denominator_LevelTwoBrowse_A)) {
-        set req.http.GOVUK-ABTest-LevelTwoBrowse = "A";
-      } else if (randombool(var.nominator_LevelTwoBrowse_B, var.denominator_LevelTwoBrowse_B)) {
-        set req.http.GOVUK-ABTest-LevelTwoBrowse = "B";
-      } else {
-        set req.http.GOVUK-ABTest-LevelTwoBrowse = "Z";
-      }
-    }
-  }
 }
 # End dynamic section
 
@@ -376,16 +332,6 @@ sub vcl_deliver {
 
   # Begin dynamic section
   declare local var.expiry TIME;
-  if (req.http.Cookie ~ "cookies_policy") {
-    if (req.http.Cookie:cookies_policy ~ "%22usage%22:true") {
-      if (table.lookup(active_ab_tests, "LevelTwoBrowse") == "true") {
-        if (req.http.Cookie !~ "ABTest-LevelTwoBrowse" || req.url ~ "[\?\&]ABTest-LevelTwoBrowse" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
-          set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "LevelTwoBrowse"))));
-          add resp.http.Set-Cookie = "ABTest-LevelTwoBrowse=" req.http.GOVUK-ABTest-LevelTwoBrowse "; secure; expires=" var.expiry "; path=/";
-        }
-      }
-    }
-  }
   # End dynamic section
 
 #FASTLY deliver

--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -339,50 +339,6 @@ if (req.http.Cookie ~ "cookies_policy" && req.http.Cookie:cookies_policy ~ "%22u
       }
     }
   }
-  if (table.lookup(active_ab_tests, "LevelTwoBrowse") == "true") {
-    if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
-      set req.http.GOVUK-ABTest-LevelTwoBrowse = "A";
-    } else if (req.url ~ "[\?\&]ABTest-LevelTwoBrowse=A(&|$)") {
-      # Some users, such as remote testers, will be given a URL with a query string
-      # to place them into a specific bucket.
-      set req.http.GOVUK-ABTest-LevelTwoBrowse = "A";
-    } else if (req.url ~ "[\?\&]ABTest-LevelTwoBrowse=B(&|$)") {
-      # Some users, such as remote testers, will be given a URL with a query string
-      # to place them into a specific bucket.
-      set req.http.GOVUK-ABTest-LevelTwoBrowse = "B";
-    } else if (req.url ~ "[\?\&]ABTest-LevelTwoBrowse=Z(&|$)") {
-      # Some users, such as remote testers, will be given a URL with a query string
-      # to place them into a specific bucket.
-      set req.http.GOVUK-ABTest-LevelTwoBrowse = "Z";
-    } else if (req.http.Cookie ~ "ABTest-LevelTwoBrowse") {
-      # Set the value of the header to whatever decision was previously made
-      set req.http.GOVUK-ABTest-LevelTwoBrowse = req.http.Cookie:ABTest-LevelTwoBrowse;
-    } else {
-      declare local var.denominator_LevelTwoBrowse INTEGER;
-      declare local var.denominator_LevelTwoBrowse_A INTEGER;
-      declare local var.nominator_LevelTwoBrowse_A INTEGER;
-      set var.nominator_LevelTwoBrowse_A = std.atoi(table.lookup(leveltwobrowse_percentages, "A"));
-      set var.denominator_LevelTwoBrowse += var.nominator_LevelTwoBrowse_A;
-      declare local var.denominator_LevelTwoBrowse_B INTEGER;
-      declare local var.nominator_LevelTwoBrowse_B INTEGER;
-      set var.nominator_LevelTwoBrowse_B = std.atoi(table.lookup(leveltwobrowse_percentages, "B"));
-      set var.denominator_LevelTwoBrowse += var.nominator_LevelTwoBrowse_B;
-      declare local var.denominator_LevelTwoBrowse_Z INTEGER;
-      declare local var.nominator_LevelTwoBrowse_Z INTEGER;
-      set var.nominator_LevelTwoBrowse_Z = std.atoi(table.lookup(leveltwobrowse_percentages, "Z"));
-      set var.denominator_LevelTwoBrowse += var.nominator_LevelTwoBrowse_Z;
-      set var.denominator_LevelTwoBrowse_A = var.denominator_LevelTwoBrowse;
-      set var.denominator_LevelTwoBrowse_B = var.denominator_LevelTwoBrowse_A;
-      set var.denominator_LevelTwoBrowse_B -= var.nominator_LevelTwoBrowse_A;
-      if (randombool(var.nominator_LevelTwoBrowse_A, var.denominator_LevelTwoBrowse_A)) {
-        set req.http.GOVUK-ABTest-LevelTwoBrowse = "A";
-      } else if (randombool(var.nominator_LevelTwoBrowse_B, var.denominator_LevelTwoBrowse_B)) {
-        set req.http.GOVUK-ABTest-LevelTwoBrowse = "B";
-      } else {
-        set req.http.GOVUK-ABTest-LevelTwoBrowse = "Z";
-      }
-    }
-  }
 }
 # End dynamic section
 
@@ -537,16 +493,6 @@ sub vcl_deliver {
 
   # Begin dynamic section
   declare local var.expiry TIME;
-  if (req.http.Cookie ~ "cookies_policy") {
-    if (req.http.Cookie:cookies_policy ~ "%22usage%22:true") {
-      if (table.lookup(active_ab_tests, "LevelTwoBrowse") == "true") {
-        if (req.http.Cookie !~ "ABTest-LevelTwoBrowse" || req.url ~ "[\?\&]ABTest-LevelTwoBrowse" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
-          set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "LevelTwoBrowse"))));
-          add resp.http.Set-Cookie = "ABTest-LevelTwoBrowse=" req.http.GOVUK-ABTest-LevelTwoBrowse "; secure; expires=" var.expiry "; path=/";
-        }
-      }
-    }
-  }
   # End dynamic section
 
 #FASTLY deliver

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -347,50 +347,6 @@ if (req.http.Cookie ~ "cookies_policy" && req.http.Cookie:cookies_policy ~ "%22u
       }
     }
   }
-  if (table.lookup(active_ab_tests, "LevelTwoBrowse") == "true") {
-    if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
-      set req.http.GOVUK-ABTest-LevelTwoBrowse = "A";
-    } else if (req.url ~ "[\?\&]ABTest-LevelTwoBrowse=A(&|$)") {
-      # Some users, such as remote testers, will be given a URL with a query string
-      # to place them into a specific bucket.
-      set req.http.GOVUK-ABTest-LevelTwoBrowse = "A";
-    } else if (req.url ~ "[\?\&]ABTest-LevelTwoBrowse=B(&|$)") {
-      # Some users, such as remote testers, will be given a URL with a query string
-      # to place them into a specific bucket.
-      set req.http.GOVUK-ABTest-LevelTwoBrowse = "B";
-    } else if (req.url ~ "[\?\&]ABTest-LevelTwoBrowse=Z(&|$)") {
-      # Some users, such as remote testers, will be given a URL with a query string
-      # to place them into a specific bucket.
-      set req.http.GOVUK-ABTest-LevelTwoBrowse = "Z";
-    } else if (req.http.Cookie ~ "ABTest-LevelTwoBrowse") {
-      # Set the value of the header to whatever decision was previously made
-      set req.http.GOVUK-ABTest-LevelTwoBrowse = req.http.Cookie:ABTest-LevelTwoBrowse;
-    } else {
-      declare local var.denominator_LevelTwoBrowse INTEGER;
-      declare local var.denominator_LevelTwoBrowse_A INTEGER;
-      declare local var.nominator_LevelTwoBrowse_A INTEGER;
-      set var.nominator_LevelTwoBrowse_A = std.atoi(table.lookup(leveltwobrowse_percentages, "A"));
-      set var.denominator_LevelTwoBrowse += var.nominator_LevelTwoBrowse_A;
-      declare local var.denominator_LevelTwoBrowse_B INTEGER;
-      declare local var.nominator_LevelTwoBrowse_B INTEGER;
-      set var.nominator_LevelTwoBrowse_B = std.atoi(table.lookup(leveltwobrowse_percentages, "B"));
-      set var.denominator_LevelTwoBrowse += var.nominator_LevelTwoBrowse_B;
-      declare local var.denominator_LevelTwoBrowse_Z INTEGER;
-      declare local var.nominator_LevelTwoBrowse_Z INTEGER;
-      set var.nominator_LevelTwoBrowse_Z = std.atoi(table.lookup(leveltwobrowse_percentages, "Z"));
-      set var.denominator_LevelTwoBrowse += var.nominator_LevelTwoBrowse_Z;
-      set var.denominator_LevelTwoBrowse_A = var.denominator_LevelTwoBrowse;
-      set var.denominator_LevelTwoBrowse_B = var.denominator_LevelTwoBrowse_A;
-      set var.denominator_LevelTwoBrowse_B -= var.nominator_LevelTwoBrowse_A;
-      if (randombool(var.nominator_LevelTwoBrowse_A, var.denominator_LevelTwoBrowse_A)) {
-        set req.http.GOVUK-ABTest-LevelTwoBrowse = "A";
-      } else if (randombool(var.nominator_LevelTwoBrowse_B, var.denominator_LevelTwoBrowse_B)) {
-        set req.http.GOVUK-ABTest-LevelTwoBrowse = "B";
-      } else {
-        set req.http.GOVUK-ABTest-LevelTwoBrowse = "Z";
-      }
-    }
-  }
 }
 # End dynamic section
 
@@ -545,16 +501,6 @@ sub vcl_deliver {
 
   # Begin dynamic section
   declare local var.expiry TIME;
-  if (req.http.Cookie ~ "cookies_policy") {
-    if (req.http.Cookie:cookies_policy ~ "%22usage%22:true") {
-      if (table.lookup(active_ab_tests, "LevelTwoBrowse") == "true") {
-        if (req.http.Cookie !~ "ABTest-LevelTwoBrowse" || req.url ~ "[\?\&]ABTest-LevelTwoBrowse" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
-          set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "LevelTwoBrowse"))));
-          add resp.http.Set-Cookie = "ABTest-LevelTwoBrowse=" req.http.GOVUK-ABTest-LevelTwoBrowse "; secure; expires=" var.expiry "; path=/";
-        }
-      }
-    }
-  }
   # End dynamic section
 
 #FASTLY deliver

--- a/spec/test-outputs/www-test.out.vcl
+++ b/spec/test-outputs/www-test.out.vcl
@@ -178,50 +178,6 @@ if (req.http.Cookie ~ "cookies_policy" && req.http.Cookie:cookies_policy ~ "%22u
       }
     }
   }
-  if (table.lookup(active_ab_tests, "LevelTwoBrowse") == "true") {
-    if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
-      set req.http.GOVUK-ABTest-LevelTwoBrowse = "A";
-    } else if (req.url ~ "[\?\&]ABTest-LevelTwoBrowse=A(&|$)") {
-      # Some users, such as remote testers, will be given a URL with a query string
-      # to place them into a specific bucket.
-      set req.http.GOVUK-ABTest-LevelTwoBrowse = "A";
-    } else if (req.url ~ "[\?\&]ABTest-LevelTwoBrowse=B(&|$)") {
-      # Some users, such as remote testers, will be given a URL with a query string
-      # to place them into a specific bucket.
-      set req.http.GOVUK-ABTest-LevelTwoBrowse = "B";
-    } else if (req.url ~ "[\?\&]ABTest-LevelTwoBrowse=Z(&|$)") {
-      # Some users, such as remote testers, will be given a URL with a query string
-      # to place them into a specific bucket.
-      set req.http.GOVUK-ABTest-LevelTwoBrowse = "Z";
-    } else if (req.http.Cookie ~ "ABTest-LevelTwoBrowse") {
-      # Set the value of the header to whatever decision was previously made
-      set req.http.GOVUK-ABTest-LevelTwoBrowse = req.http.Cookie:ABTest-LevelTwoBrowse;
-    } else {
-      declare local var.denominator_LevelTwoBrowse INTEGER;
-      declare local var.denominator_LevelTwoBrowse_A INTEGER;
-      declare local var.nominator_LevelTwoBrowse_A INTEGER;
-      set var.nominator_LevelTwoBrowse_A = std.atoi(table.lookup(leveltwobrowse_percentages, "A"));
-      set var.denominator_LevelTwoBrowse += var.nominator_LevelTwoBrowse_A;
-      declare local var.denominator_LevelTwoBrowse_B INTEGER;
-      declare local var.nominator_LevelTwoBrowse_B INTEGER;
-      set var.nominator_LevelTwoBrowse_B = std.atoi(table.lookup(leveltwobrowse_percentages, "B"));
-      set var.denominator_LevelTwoBrowse += var.nominator_LevelTwoBrowse_B;
-      declare local var.denominator_LevelTwoBrowse_Z INTEGER;
-      declare local var.nominator_LevelTwoBrowse_Z INTEGER;
-      set var.nominator_LevelTwoBrowse_Z = std.atoi(table.lookup(leveltwobrowse_percentages, "Z"));
-      set var.denominator_LevelTwoBrowse += var.nominator_LevelTwoBrowse_Z;
-      set var.denominator_LevelTwoBrowse_A = var.denominator_LevelTwoBrowse;
-      set var.denominator_LevelTwoBrowse_B = var.denominator_LevelTwoBrowse_A;
-      set var.denominator_LevelTwoBrowse_B -= var.nominator_LevelTwoBrowse_A;
-      if (randombool(var.nominator_LevelTwoBrowse_A, var.denominator_LevelTwoBrowse_A)) {
-        set req.http.GOVUK-ABTest-LevelTwoBrowse = "A";
-      } else if (randombool(var.nominator_LevelTwoBrowse_B, var.denominator_LevelTwoBrowse_B)) {
-        set req.http.GOVUK-ABTest-LevelTwoBrowse = "B";
-      } else {
-        set req.http.GOVUK-ABTest-LevelTwoBrowse = "Z";
-      }
-    }
-  }
 }
 # End dynamic section
 
@@ -376,16 +332,6 @@ sub vcl_deliver {
 
   # Begin dynamic section
   declare local var.expiry TIME;
-  if (req.http.Cookie ~ "cookies_policy") {
-    if (req.http.Cookie:cookies_policy ~ "%22usage%22:true") {
-      if (table.lookup(active_ab_tests, "LevelTwoBrowse") == "true") {
-        if (req.http.Cookie !~ "ABTest-LevelTwoBrowse" || req.url ~ "[\?\&]ABTest-LevelTwoBrowse" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
-          set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "LevelTwoBrowse"))));
-          add resp.http.Set-Cookie = "ABTest-LevelTwoBrowse=" req.http.GOVUK-ABTest-LevelTwoBrowse "; secure; expires=" var.expiry "; path=/";
-        }
-      }
-    }
-  }
   # End dynamic section
 
 #FASTLY deliver


### PR DESCRIPTION
The AB Test has concluded and we have done the analysis on the data.

[Trello](https://trello.com/c/L0QUTJXh/1360-switch-off-bc-test-and-remove-accordions-from-browse-m)

⚠️ The changes need to be deployed manually to all relevant environments. Follow the guidance on [how to deploy Fastly](https://docs.publishing.service.gov.uk/manual/cdn.html#deploying-fastly).
