### PR TITLE
Set X-Forwarded-Host headers

### DIFF
--- a/spec/test-outputs/assets-eks-integration.out.vcl
+++ b/spec/test-outputs/assets-eks-integration.out.vcl
@@ -143,6 +143,11 @@ sub vcl_miss {
 #FASTLY miss
 }
 
+sub vcl_pass {
+  set bereq.http.X-Forwarded-Host = req.http.host;
+#FASTLY pass
+}
+
 sub vcl_deliver {
 #FASTLY deliver
 }
@@ -180,11 +185,6 @@ sub vcl_error {
   return (deliver);
 
 #FASTLY error
-}
-
-sub vcl_pass {
-  set bereq.http.X-Forwarded-Host = req.http.host;
-#FASTLY pass
 }
 
 sub vcl_hash {

--- a/spec/test-outputs/assets-eks-integration.out.vcl
+++ b/spec/test-outputs/assets-eks-integration.out.vcl
@@ -139,6 +139,7 @@ sub vcl_hit {
 }
 
 sub vcl_miss {
+  set bereq.http.X-Forwarded-Host = req.http.host;
 #FASTLY miss
 }
 
@@ -182,6 +183,7 @@ sub vcl_error {
 }
 
 sub vcl_pass {
+  set bereq.http.X-Forwarded-Host = req.http.host;
 #FASTLY pass
 }
 

--- a/spec/test-outputs/assets-eks-production.out.vcl
+++ b/spec/test-outputs/assets-eks-production.out.vcl
@@ -289,6 +289,7 @@ sub vcl_hit {
 }
 
 sub vcl_miss {
+  set bereq.http.X-Forwarded-Host = req.http.host;
 #FASTLY miss
 }
 
@@ -332,6 +333,7 @@ sub vcl_error {
 }
 
 sub vcl_pass {
+  set bereq.http.X-Forwarded-Host = req.http.host;
 #FASTLY pass
 }
 

--- a/spec/test-outputs/assets-eks-production.out.vcl
+++ b/spec/test-outputs/assets-eks-production.out.vcl
@@ -293,6 +293,11 @@ sub vcl_miss {
 #FASTLY miss
 }
 
+sub vcl_pass {
+  set bereq.http.X-Forwarded-Host = req.http.host;
+#FASTLY pass
+}
+
 sub vcl_deliver {
 #FASTLY deliver
 }
@@ -330,11 +335,6 @@ sub vcl_error {
   return (deliver);
 
 #FASTLY error
-}
-
-sub vcl_pass {
-  set bereq.http.X-Forwarded-Host = req.http.host;
-#FASTLY pass
 }
 
 sub vcl_hash {

--- a/spec/test-outputs/assets-eks-staging.out.vcl
+++ b/spec/test-outputs/assets-eks-staging.out.vcl
@@ -289,6 +289,7 @@ sub vcl_hit {
 }
 
 sub vcl_miss {
+  set bereq.http.X-Forwarded-Host = req.http.host;
 #FASTLY miss
 }
 
@@ -332,6 +333,7 @@ sub vcl_error {
 }
 
 sub vcl_pass {
+  set bereq.http.X-Forwarded-Host = req.http.host;
 #FASTLY pass
 }
 

--- a/spec/test-outputs/assets-eks-staging.out.vcl
+++ b/spec/test-outputs/assets-eks-staging.out.vcl
@@ -293,6 +293,11 @@ sub vcl_miss {
 #FASTLY miss
 }
 
+sub vcl_pass {
+  set bereq.http.X-Forwarded-Host = req.http.host;
+#FASTLY pass
+}
+
 sub vcl_deliver {
 #FASTLY deliver
 }
@@ -330,11 +335,6 @@ sub vcl_error {
   return (deliver);
 
 #FASTLY error
-}
-
-sub vcl_pass {
-  set bereq.http.X-Forwarded-Host = req.http.host;
-#FASTLY pass
 }
 
 sub vcl_hash {

--- a/spec/test-outputs/assets-eks-test.out.vcl
+++ b/spec/test-outputs/assets-eks-test.out.vcl
@@ -143,6 +143,11 @@ sub vcl_miss {
 #FASTLY miss
 }
 
+sub vcl_pass {
+  set bereq.http.X-Forwarded-Host = req.http.host;
+#FASTLY pass
+}
+
 sub vcl_deliver {
 #FASTLY deliver
 }
@@ -180,11 +185,6 @@ sub vcl_error {
   return (deliver);
 
 #FASTLY error
-}
-
-sub vcl_pass {
-  set bereq.http.X-Forwarded-Host = req.http.host;
-#FASTLY pass
 }
 
 sub vcl_hash {

--- a/spec/test-outputs/assets-eks-test.out.vcl
+++ b/spec/test-outputs/assets-eks-test.out.vcl
@@ -139,6 +139,7 @@ sub vcl_hit {
 }
 
 sub vcl_miss {
+  set bereq.http.X-Forwarded-Host = req.http.host;
 #FASTLY miss
 }
 
@@ -182,6 +183,7 @@ sub vcl_error {
 }
 
 sub vcl_pass {
+  set bereq.http.X-Forwarded-Host = req.http.host;
 #FASTLY pass
 }
 

--- a/spec/test-outputs/assets-integration.out.vcl
+++ b/spec/test-outputs/assets-integration.out.vcl
@@ -143,6 +143,11 @@ sub vcl_miss {
 #FASTLY miss
 }
 
+sub vcl_pass {
+  set bereq.http.X-Forwarded-Host = req.http.host;
+#FASTLY pass
+}
+
 sub vcl_deliver {
 #FASTLY deliver
 }
@@ -180,11 +185,6 @@ sub vcl_error {
   return (deliver);
 
 #FASTLY error
-}
-
-sub vcl_pass {
-  set bereq.http.X-Forwarded-Host = req.http.host;
-#FASTLY pass
 }
 
 sub vcl_hash {

--- a/spec/test-outputs/assets-integration.out.vcl
+++ b/spec/test-outputs/assets-integration.out.vcl
@@ -139,6 +139,7 @@ sub vcl_hit {
 }
 
 sub vcl_miss {
+  set bereq.http.X-Forwarded-Host = req.http.host;
 #FASTLY miss
 }
 
@@ -182,6 +183,7 @@ sub vcl_error {
 }
 
 sub vcl_pass {
+  set bereq.http.X-Forwarded-Host = req.http.host;
 #FASTLY pass
 }
 

--- a/spec/test-outputs/assets-production.out.vcl
+++ b/spec/test-outputs/assets-production.out.vcl
@@ -289,6 +289,7 @@ sub vcl_hit {
 }
 
 sub vcl_miss {
+  set bereq.http.X-Forwarded-Host = req.http.host;
 #FASTLY miss
 }
 
@@ -332,6 +333,7 @@ sub vcl_error {
 }
 
 sub vcl_pass {
+  set bereq.http.X-Forwarded-Host = req.http.host;
 #FASTLY pass
 }
 

--- a/spec/test-outputs/assets-production.out.vcl
+++ b/spec/test-outputs/assets-production.out.vcl
@@ -293,6 +293,11 @@ sub vcl_miss {
 #FASTLY miss
 }
 
+sub vcl_pass {
+  set bereq.http.X-Forwarded-Host = req.http.host;
+#FASTLY pass
+}
+
 sub vcl_deliver {
 #FASTLY deliver
 }
@@ -330,11 +335,6 @@ sub vcl_error {
   return (deliver);
 
 #FASTLY error
-}
-
-sub vcl_pass {
-  set bereq.http.X-Forwarded-Host = req.http.host;
-#FASTLY pass
 }
 
 sub vcl_hash {

--- a/spec/test-outputs/assets-staging.out.vcl
+++ b/spec/test-outputs/assets-staging.out.vcl
@@ -289,6 +289,7 @@ sub vcl_hit {
 }
 
 sub vcl_miss {
+  set bereq.http.X-Forwarded-Host = req.http.host;
 #FASTLY miss
 }
 
@@ -332,6 +333,7 @@ sub vcl_error {
 }
 
 sub vcl_pass {
+  set bereq.http.X-Forwarded-Host = req.http.host;
 #FASTLY pass
 }
 

--- a/spec/test-outputs/assets-staging.out.vcl
+++ b/spec/test-outputs/assets-staging.out.vcl
@@ -293,6 +293,11 @@ sub vcl_miss {
 #FASTLY miss
 }
 
+sub vcl_pass {
+  set bereq.http.X-Forwarded-Host = req.http.host;
+#FASTLY pass
+}
+
 sub vcl_deliver {
 #FASTLY deliver
 }
@@ -330,11 +335,6 @@ sub vcl_error {
   return (deliver);
 
 #FASTLY error
-}
-
-sub vcl_pass {
-  set bereq.http.X-Forwarded-Host = req.http.host;
-#FASTLY pass
 }
 
 sub vcl_hash {

--- a/spec/test-outputs/assets-test.out.vcl
+++ b/spec/test-outputs/assets-test.out.vcl
@@ -143,6 +143,11 @@ sub vcl_miss {
 #FASTLY miss
 }
 
+sub vcl_pass {
+  set bereq.http.X-Forwarded-Host = req.http.host;
+#FASTLY pass
+}
+
 sub vcl_deliver {
 #FASTLY deliver
 }
@@ -180,11 +185,6 @@ sub vcl_error {
   return (deliver);
 
 #FASTLY error
-}
-
-sub vcl_pass {
-  set bereq.http.X-Forwarded-Host = req.http.host;
-#FASTLY pass
 }
 
 sub vcl_hash {

--- a/spec/test-outputs/assets-test.out.vcl
+++ b/spec/test-outputs/assets-test.out.vcl
@@ -139,6 +139,7 @@ sub vcl_hit {
 }
 
 sub vcl_miss {
+  set bereq.http.X-Forwarded-Host = req.http.host;
 #FASTLY miss
 }
 
@@ -182,6 +183,7 @@ sub vcl_error {
 }
 
 sub vcl_pass {
+  set bereq.http.X-Forwarded-Host = req.http.host;
 #FASTLY pass
 }
 

--- a/spec/test-outputs/www-eks-integration.out.vcl
+++ b/spec/test-outputs/www-eks-integration.out.vcl
@@ -339,6 +339,7 @@ sub vcl_hit {
 }
 
 sub vcl_miss {
+  set bereq.http.X-Forwarded-Host = req.http.host;
 #FASTLY miss
 }
 
@@ -492,6 +493,7 @@ sub vcl_error {
 # pipe cannot be included.
 
 sub vcl_pass {
+  set bereq.http.X-Forwarded-Host = req.http.host;
 #FASTLY pass
 }
 

--- a/spec/test-outputs/www-eks-integration.out.vcl
+++ b/spec/test-outputs/www-eks-integration.out.vcl
@@ -343,6 +343,11 @@ sub vcl_miss {
 #FASTLY miss
 }
 
+sub vcl_pass {
+  set bereq.http.X-Forwarded-Host = req.http.host;
+#FASTLY pass
+}
+
 sub vcl_deliver {
   # GOV.UK accounts
   if (resp.http.GOVUK-Account-End-Session) {
@@ -491,11 +496,6 @@ sub vcl_error {
 }
 
 # pipe cannot be included.
-
-sub vcl_pass {
-  set bereq.http.X-Forwarded-Host = req.http.host;
-#FASTLY pass
-}
 
 sub vcl_hash {
 #FASTLY hash

--- a/spec/test-outputs/www-eks-production.out.vcl
+++ b/spec/test-outputs/www-eks-production.out.vcl
@@ -500,6 +500,7 @@ sub vcl_hit {
 }
 
 sub vcl_miss {
+  set bereq.http.X-Forwarded-Host = req.http.host;
 #FASTLY miss
 }
 
@@ -653,6 +654,7 @@ sub vcl_error {
 # pipe cannot be included.
 
 sub vcl_pass {
+  set bereq.http.X-Forwarded-Host = req.http.host;
 #FASTLY pass
 }
 

--- a/spec/test-outputs/www-eks-production.out.vcl
+++ b/spec/test-outputs/www-eks-production.out.vcl
@@ -504,6 +504,11 @@ sub vcl_miss {
 #FASTLY miss
 }
 
+sub vcl_pass {
+  set bereq.http.X-Forwarded-Host = req.http.host;
+#FASTLY pass
+}
+
 sub vcl_deliver {
   # GOV.UK accounts
   if (resp.http.GOVUK-Account-End-Session) {
@@ -652,11 +657,6 @@ sub vcl_error {
 }
 
 # pipe cannot be included.
-
-sub vcl_pass {
-  set bereq.http.X-Forwarded-Host = req.http.host;
-#FASTLY pass
-}
 
 sub vcl_hash {
 #FASTLY hash

--- a/spec/test-outputs/www-eks-staging.out.vcl
+++ b/spec/test-outputs/www-eks-staging.out.vcl
@@ -512,6 +512,11 @@ sub vcl_miss {
 #FASTLY miss
 }
 
+sub vcl_pass {
+  set bereq.http.X-Forwarded-Host = req.http.host;
+#FASTLY pass
+}
+
 sub vcl_deliver {
   # GOV.UK accounts
   if (resp.http.GOVUK-Account-End-Session) {
@@ -660,11 +665,6 @@ sub vcl_error {
 }
 
 # pipe cannot be included.
-
-sub vcl_pass {
-  set bereq.http.X-Forwarded-Host = req.http.host;
-#FASTLY pass
-}
 
 sub vcl_hash {
 #FASTLY hash

--- a/spec/test-outputs/www-eks-staging.out.vcl
+++ b/spec/test-outputs/www-eks-staging.out.vcl
@@ -508,6 +508,7 @@ sub vcl_hit {
 }
 
 sub vcl_miss {
+  set bereq.http.X-Forwarded-Host = req.http.host;
 #FASTLY miss
 }
 
@@ -661,6 +662,7 @@ sub vcl_error {
 # pipe cannot be included.
 
 sub vcl_pass {
+  set bereq.http.X-Forwarded-Host = req.http.host;
 #FASTLY pass
 }
 

--- a/spec/test-outputs/www-eks-test.out.vcl
+++ b/spec/test-outputs/www-eks-test.out.vcl
@@ -339,6 +339,7 @@ sub vcl_hit {
 }
 
 sub vcl_miss {
+  set bereq.http.X-Forwarded-Host = req.http.host;
 #FASTLY miss
 }
 
@@ -492,6 +493,7 @@ sub vcl_error {
 # pipe cannot be included.
 
 sub vcl_pass {
+  set bereq.http.X-Forwarded-Host = req.http.host;
 #FASTLY pass
 }
 

--- a/spec/test-outputs/www-eks-test.out.vcl
+++ b/spec/test-outputs/www-eks-test.out.vcl
@@ -343,6 +343,11 @@ sub vcl_miss {
 #FASTLY miss
 }
 
+sub vcl_pass {
+  set bereq.http.X-Forwarded-Host = req.http.host;
+#FASTLY pass
+}
+
 sub vcl_deliver {
   # GOV.UK accounts
   if (resp.http.GOVUK-Account-End-Session) {
@@ -491,11 +496,6 @@ sub vcl_error {
 }
 
 # pipe cannot be included.
-
-sub vcl_pass {
-  set bereq.http.X-Forwarded-Host = req.http.host;
-#FASTLY pass
-}
 
 sub vcl_hash {
 #FASTLY hash

--- a/spec/test-outputs/www-integration.out.vcl
+++ b/spec/test-outputs/www-integration.out.vcl
@@ -339,6 +339,7 @@ sub vcl_hit {
 }
 
 sub vcl_miss {
+  set bereq.http.X-Forwarded-Host = req.http.host;
 #FASTLY miss
 }
 
@@ -492,6 +493,7 @@ sub vcl_error {
 # pipe cannot be included.
 
 sub vcl_pass {
+  set bereq.http.X-Forwarded-Host = req.http.host;
 #FASTLY pass
 }
 

--- a/spec/test-outputs/www-integration.out.vcl
+++ b/spec/test-outputs/www-integration.out.vcl
@@ -343,6 +343,11 @@ sub vcl_miss {
 #FASTLY miss
 }
 
+sub vcl_pass {
+  set bereq.http.X-Forwarded-Host = req.http.host;
+#FASTLY pass
+}
+
 sub vcl_deliver {
   # GOV.UK accounts
   if (resp.http.GOVUK-Account-End-Session) {
@@ -491,11 +496,6 @@ sub vcl_error {
 }
 
 # pipe cannot be included.
-
-sub vcl_pass {
-  set bereq.http.X-Forwarded-Host = req.http.host;
-#FASTLY pass
-}
 
 sub vcl_hash {
 #FASTLY hash

--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -500,6 +500,7 @@ sub vcl_hit {
 }
 
 sub vcl_miss {
+  set bereq.http.X-Forwarded-Host = req.http.host;
 #FASTLY miss
 }
 
@@ -653,6 +654,7 @@ sub vcl_error {
 # pipe cannot be included.
 
 sub vcl_pass {
+  set bereq.http.X-Forwarded-Host = req.http.host;
 #FASTLY pass
 }
 

--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -504,6 +504,11 @@ sub vcl_miss {
 #FASTLY miss
 }
 
+sub vcl_pass {
+  set bereq.http.X-Forwarded-Host = req.http.host;
+#FASTLY pass
+}
+
 sub vcl_deliver {
   # GOV.UK accounts
   if (resp.http.GOVUK-Account-End-Session) {
@@ -652,11 +657,6 @@ sub vcl_error {
 }
 
 # pipe cannot be included.
-
-sub vcl_pass {
-  set bereq.http.X-Forwarded-Host = req.http.host;
-#FASTLY pass
-}
 
 sub vcl_hash {
 #FASTLY hash

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -512,6 +512,11 @@ sub vcl_miss {
 #FASTLY miss
 }
 
+sub vcl_pass {
+  set bereq.http.X-Forwarded-Host = req.http.host;
+#FASTLY pass
+}
+
 sub vcl_deliver {
   # GOV.UK accounts
   if (resp.http.GOVUK-Account-End-Session) {
@@ -660,11 +665,6 @@ sub vcl_error {
 }
 
 # pipe cannot be included.
-
-sub vcl_pass {
-  set bereq.http.X-Forwarded-Host = req.http.host;
-#FASTLY pass
-}
 
 sub vcl_hash {
 #FASTLY hash

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -508,6 +508,7 @@ sub vcl_hit {
 }
 
 sub vcl_miss {
+  set bereq.http.X-Forwarded-Host = req.http.host;
 #FASTLY miss
 }
 
@@ -661,6 +662,7 @@ sub vcl_error {
 # pipe cannot be included.
 
 sub vcl_pass {
+  set bereq.http.X-Forwarded-Host = req.http.host;
 #FASTLY pass
 }
 

--- a/spec/test-outputs/www-test.out.vcl
+++ b/spec/test-outputs/www-test.out.vcl
@@ -339,6 +339,7 @@ sub vcl_hit {
 }
 
 sub vcl_miss {
+  set bereq.http.X-Forwarded-Host = req.http.host;
 #FASTLY miss
 }
 
@@ -492,6 +493,7 @@ sub vcl_error {
 # pipe cannot be included.
 
 sub vcl_pass {
+  set bereq.http.X-Forwarded-Host = req.http.host;
 #FASTLY pass
 }
 

--- a/spec/test-outputs/www-test.out.vcl
+++ b/spec/test-outputs/www-test.out.vcl
@@ -343,6 +343,11 @@ sub vcl_miss {
 #FASTLY miss
 }
 
+sub vcl_pass {
+  set bereq.http.X-Forwarded-Host = req.http.host;
+#FASTLY pass
+}
+
 sub vcl_deliver {
   # GOV.UK accounts
   if (resp.http.GOVUK-Account-End-Session) {
@@ -491,11 +496,6 @@ sub vcl_error {
 }
 
 # pipe cannot be included.
-
-sub vcl_pass {
-  set bereq.http.X-Forwarded-Host = req.http.host;
-#FASTLY pass
-}
 
 sub vcl_hash {
 #FASTLY hash

--- a/vcl_templates/assets.vcl.erb
+++ b/vcl_templates/assets.vcl.erb
@@ -313,6 +313,11 @@ sub vcl_miss {
 #FASTLY miss
 }
 
+sub vcl_pass {
+  set bereq.http.X-Forwarded-Host = req.http.host;
+#FASTLY pass
+}
+
 sub vcl_deliver {
 #FASTLY deliver
 }
@@ -350,11 +355,6 @@ sub vcl_error {
   return (deliver);
 
 #FASTLY error
-}
-
-sub vcl_pass {
-  set bereq.http.X-Forwarded-Host = req.http.host;
-#FASTLY pass
 }
 
 sub vcl_hash {

--- a/vcl_templates/assets.vcl.erb
+++ b/vcl_templates/assets.vcl.erb
@@ -309,6 +309,7 @@ sub vcl_hit {
 }
 
 sub vcl_miss {
+  set bereq.http.X-Forwarded-Host = req.http.host;
 #FASTLY miss
 }
 
@@ -352,6 +353,7 @@ sub vcl_error {
 }
 
 sub vcl_pass {
+  set bereq.http.X-Forwarded-Host = req.http.host;
 #FASTLY pass
 }
 

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -533,6 +533,7 @@ sub vcl_hit {
 }
 
 sub vcl_miss {
+  set bereq.http.X-Forwarded-Host = req.http.host;
 #FASTLY miss
 }
 
@@ -700,6 +701,7 @@ sub vcl_error {
 # pipe cannot be included.
 
 sub vcl_pass {
+  set bereq.http.X-Forwarded-Host = req.http.host;
 #FASTLY pass
 }
 

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -537,6 +537,11 @@ sub vcl_miss {
 #FASTLY miss
 }
 
+sub vcl_pass {
+  set bereq.http.X-Forwarded-Host = req.http.host;
+#FASTLY pass
+}
+
 sub vcl_deliver {
   # GOV.UK accounts
   if (resp.http.GOVUK-Account-End-Session) {
@@ -699,11 +704,6 @@ sub vcl_error {
 }
 
 # pipe cannot be included.
-
-sub vcl_pass {
-  set bereq.http.X-Forwarded-Host = req.http.host;
-#FASTLY pass
-}
 
 sub vcl_hash {
 #FASTLY hash


### PR DESCRIPTION
This ensures that Fastly sets the X-Forwarded-Host headers to a single value that is the same original request host. This helps mitigates against clients for spoofing the X-Forwarded-Host header and prevents cache poisoning. This must be set in the vcl_miss and vcl_pass subroutines as they occur before backend requests and have access to the the `bereq` token.

This is suggested from the Fastly docs here:
https://developer.fastly.com/reference/http/http-headers/X-Forwarded-Host/ 

This assumes that backend requests are only for client requests that have valid and non-spoofed hosts, which is fine as Fastly will only be dealing with request that have to correct Host header for the service.

e.g. curl -H 'Host: phishing.com' https://assets.publishing.service.gov.uk/ won't be handled by our Fastly service, as Fastly will look for the "phishing.com" service, not the "assets.publishing.service.gov.uk" service.

⚠️ The changes need to be deployed manually to all relevant environments. Follow the guidance on [how to deploy Fastly](https://docs.publishing.service.gov.uk/manual/cdn.html#deploying-fastly).
