### PR TITLE
Consistently set headers in Fastly as public boundary

### DIFF
--- a/spec/test-outputs/apt-integration.out.vcl
+++ b/spec/test-outputs/apt-integration.out.vcl
@@ -23,15 +23,29 @@ backend F_apt {
 }
 
 sub vcl_recv {
+  # Protect header from modification at the edge of the Fastly network
+  # https://developer.fastly.com/reference/http-headers/Fastly-Client-IP
+  if (fastly.ff.visits_this_service == 0 && req.restarts == 0) {
+    set req.http.Fastly-Client-IP = client.ip;
+  }
+
+  # Original client address (e.g. for rate limiting).
+  set req.http.True-Client-IP = req.http.Fastly-Client-IP;
+
+  # Reset proxy headers at the boundary to our network so we can trust them in our stack
+  set req.http.X-Forwarded-For = req.http.Fastly-Client-IP;
+  set req.http.X-Forwarded-Host = req.http.host;
+  set req.http.X-Forwarded-Server = server.hostname;
+
+  # Discard user specified headers that we don't want to trust
+  unset req.http.Client-IP;
+
 #FASTLY recv
 
     # Require authentication for FASTLYPURGE requests
     if (req.request == "FASTLYPURGE") {
       set req.http.Fastly-Purge-Requires-Auth = "1";
     }
-
-    # Unspoofable original client address
-    set req.http.True-Client-IP = req.http.Fastly-Client-IP;
 
     if (req.request != "HEAD" && req.request != "GET" && req.request != "FASTLYPURGE") {
       return(pass);

--- a/spec/test-outputs/apt-production.out.vcl
+++ b/spec/test-outputs/apt-production.out.vcl
@@ -23,15 +23,29 @@ backend F_apt {
 }
 
 sub vcl_recv {
+  # Protect header from modification at the edge of the Fastly network
+  # https://developer.fastly.com/reference/http-headers/Fastly-Client-IP
+  if (fastly.ff.visits_this_service == 0 && req.restarts == 0) {
+    set req.http.Fastly-Client-IP = client.ip;
+  }
+
+  # Original client address (e.g. for rate limiting).
+  set req.http.True-Client-IP = req.http.Fastly-Client-IP;
+
+  # Reset proxy headers at the boundary to our network so we can trust them in our stack
+  set req.http.X-Forwarded-For = req.http.Fastly-Client-IP;
+  set req.http.X-Forwarded-Host = req.http.host;
+  set req.http.X-Forwarded-Server = server.hostname;
+
+  # Discard user specified headers that we don't want to trust
+  unset req.http.Client-IP;
+
 #FASTLY recv
 
     # Require authentication for FASTLYPURGE requests
     if (req.request == "FASTLYPURGE") {
       set req.http.Fastly-Purge-Requires-Auth = "1";
     }
-
-    # Unspoofable original client address
-    set req.http.True-Client-IP = req.http.Fastly-Client-IP;
 
     if (req.request != "HEAD" && req.request != "GET" && req.request != "FASTLYPURGE") {
       return(pass);

--- a/spec/test-outputs/apt-staging.out.vcl
+++ b/spec/test-outputs/apt-staging.out.vcl
@@ -23,15 +23,29 @@ backend F_apt {
 }
 
 sub vcl_recv {
+  # Protect header from modification at the edge of the Fastly network
+  # https://developer.fastly.com/reference/http-headers/Fastly-Client-IP
+  if (fastly.ff.visits_this_service == 0 && req.restarts == 0) {
+    set req.http.Fastly-Client-IP = client.ip;
+  }
+
+  # Original client address (e.g. for rate limiting).
+  set req.http.True-Client-IP = req.http.Fastly-Client-IP;
+
+  # Reset proxy headers at the boundary to our network so we can trust them in our stack
+  set req.http.X-Forwarded-For = req.http.Fastly-Client-IP;
+  set req.http.X-Forwarded-Host = req.http.host;
+  set req.http.X-Forwarded-Server = server.hostname;
+
+  # Discard user specified headers that we don't want to trust
+  unset req.http.Client-IP;
+
 #FASTLY recv
 
     # Require authentication for FASTLYPURGE requests
     if (req.request == "FASTLYPURGE") {
       set req.http.Fastly-Purge-Requires-Auth = "1";
     }
-
-    # Unspoofable original client address
-    set req.http.True-Client-IP = req.http.Fastly-Client-IP;
 
     if (req.request != "HEAD" && req.request != "GET" && req.request != "FASTLYPURGE") {
       return(pass);

--- a/spec/test-outputs/apt-test.out.vcl
+++ b/spec/test-outputs/apt-test.out.vcl
@@ -23,15 +23,29 @@ backend F_apt {
 }
 
 sub vcl_recv {
+  # Protect header from modification at the edge of the Fastly network
+  # https://developer.fastly.com/reference/http-headers/Fastly-Client-IP
+  if (fastly.ff.visits_this_service == 0 && req.restarts == 0) {
+    set req.http.Fastly-Client-IP = client.ip;
+  }
+
+  # Original client address (e.g. for rate limiting).
+  set req.http.True-Client-IP = req.http.Fastly-Client-IP;
+
+  # Reset proxy headers at the boundary to our network so we can trust them in our stack
+  set req.http.X-Forwarded-For = req.http.Fastly-Client-IP;
+  set req.http.X-Forwarded-Host = req.http.host;
+  set req.http.X-Forwarded-Server = server.hostname;
+
+  # Discard user specified headers that we don't want to trust
+  unset req.http.Client-IP;
+
 #FASTLY recv
 
     # Require authentication for FASTLYPURGE requests
     if (req.request == "FASTLYPURGE") {
       set req.http.Fastly-Purge-Requires-Auth = "1";
     }
-
-    # Unspoofable original client address
-    set req.http.True-Client-IP = req.http.Fastly-Client-IP;
 
     if (req.request != "HEAD" && req.request != "GET" && req.request != "FASTLYPURGE") {
       return(pass);

--- a/spec/test-outputs/assets-eks-integration.out.vcl
+++ b/spec/test-outputs/assets-eks-integration.out.vcl
@@ -36,8 +36,22 @@ acl purge_ip_allowlist {
 }
 
 sub vcl_recv {
-  # Reset proxy headers at the boundary to our network.
+  # Protect header from modification at the edge of the Fastly network
+  # https://developer.fastly.com/reference/http-headers/Fastly-Client-IP
+  if (fastly.ff.visits_this_service == 0 && req.restarts == 0) {
+    set req.http.Fastly-Client-IP = client.ip;
+  }
+
+  # Original client address (e.g. for rate limiting).
+  set req.http.True-Client-IP = req.http.Fastly-Client-IP;
+
+  # Reset proxy headers at the boundary to our network so we can trust them in our stack
+  set req.http.X-Forwarded-For = req.http.Fastly-Client-IP;
   set req.http.X-Forwarded-Host = req.http.host;
+  set req.http.X-Forwarded-Server = server.hostname;
+
+  # Discard user specified headers that we don't want to trust
+  unset req.http.Client-IP;
 
   # Require authentication for FASTLYPURGE requests unless from IP in ACL
   if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_allowlist) {
@@ -63,9 +77,6 @@ sub vcl_recv {
   set req.http.host = "foo";
 
   
-
-  # Unspoofable original client address.
-  set req.http.True-Client-IP = req.http.Fastly-Client-IP;
 
 #FASTLY recv
 

--- a/spec/test-outputs/assets-eks-test.out.vcl
+++ b/spec/test-outputs/assets-eks-test.out.vcl
@@ -36,8 +36,22 @@ acl purge_ip_allowlist {
 }
 
 sub vcl_recv {
-  # Reset proxy headers at the boundary to our network.
+  # Protect header from modification at the edge of the Fastly network
+  # https://developer.fastly.com/reference/http-headers/Fastly-Client-IP
+  if (fastly.ff.visits_this_service == 0 && req.restarts == 0) {
+    set req.http.Fastly-Client-IP = client.ip;
+  }
+
+  # Original client address (e.g. for rate limiting).
+  set req.http.True-Client-IP = req.http.Fastly-Client-IP;
+
+  # Reset proxy headers at the boundary to our network so we can trust them in our stack
+  set req.http.X-Forwarded-For = req.http.Fastly-Client-IP;
   set req.http.X-Forwarded-Host = req.http.host;
+  set req.http.X-Forwarded-Server = server.hostname;
+
+  # Discard user specified headers that we don't want to trust
+  unset req.http.Client-IP;
 
   # Require authentication for FASTLYPURGE requests unless from IP in ACL
   if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_allowlist) {
@@ -63,9 +77,6 @@ sub vcl_recv {
   set req.http.host = "foo";
 
   
-
-  # Unspoofable original client address.
-  set req.http.True-Client-IP = req.http.Fastly-Client-IP;
 
 #FASTLY recv
 

--- a/spec/test-outputs/assets-integration.out.vcl
+++ b/spec/test-outputs/assets-integration.out.vcl
@@ -36,8 +36,22 @@ acl purge_ip_allowlist {
 }
 
 sub vcl_recv {
-  # Reset proxy headers at the boundary to our network.
+  # Protect header from modification at the edge of the Fastly network
+  # https://developer.fastly.com/reference/http-headers/Fastly-Client-IP
+  if (fastly.ff.visits_this_service == 0 && req.restarts == 0) {
+    set req.http.Fastly-Client-IP = client.ip;
+  }
+
+  # Original client address (e.g. for rate limiting).
+  set req.http.True-Client-IP = req.http.Fastly-Client-IP;
+
+  # Reset proxy headers at the boundary to our network so we can trust them in our stack
+  set req.http.X-Forwarded-For = req.http.Fastly-Client-IP;
   set req.http.X-Forwarded-Host = req.http.host;
+  set req.http.X-Forwarded-Server = server.hostname;
+
+  # Discard user specified headers that we don't want to trust
+  unset req.http.Client-IP;
 
   # Require authentication for FASTLYPURGE requests unless from IP in ACL
   if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_allowlist) {
@@ -63,9 +77,6 @@ sub vcl_recv {
   set req.http.host = "foo";
 
   
-
-  # Unspoofable original client address.
-  set req.http.True-Client-IP = req.http.Fastly-Client-IP;
 
 #FASTLY recv
 

--- a/spec/test-outputs/assets-test.out.vcl
+++ b/spec/test-outputs/assets-test.out.vcl
@@ -36,8 +36,22 @@ acl purge_ip_allowlist {
 }
 
 sub vcl_recv {
-  # Reset proxy headers at the boundary to our network.
+  # Protect header from modification at the edge of the Fastly network
+  # https://developer.fastly.com/reference/http-headers/Fastly-Client-IP
+  if (fastly.ff.visits_this_service == 0 && req.restarts == 0) {
+    set req.http.Fastly-Client-IP = client.ip;
+  }
+
+  # Original client address (e.g. for rate limiting).
+  set req.http.True-Client-IP = req.http.Fastly-Client-IP;
+
+  # Reset proxy headers at the boundary to our network so we can trust them in our stack
+  set req.http.X-Forwarded-For = req.http.Fastly-Client-IP;
   set req.http.X-Forwarded-Host = req.http.host;
+  set req.http.X-Forwarded-Server = server.hostname;
+
+  # Discard user specified headers that we don't want to trust
+  unset req.http.Client-IP;
 
   # Require authentication for FASTLYPURGE requests unless from IP in ACL
   if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_allowlist) {
@@ -63,9 +77,6 @@ sub vcl_recv {
   set req.http.host = "foo";
 
   
-
-  # Unspoofable original client address.
-  set req.http.True-Client-IP = req.http.Fastly-Client-IP;
 
 #FASTLY recv
 

--- a/spec/test-outputs/bouncer-integration.out.vcl
+++ b/spec/test-outputs/bouncer-integration.out.vcl
@@ -44,6 +44,22 @@ acl purge_ip_allowlist {
 }
 
 sub vcl_recv {
+  # Protect header from modification at the edge of the Fastly network
+  # https://developer.fastly.com/reference/http-headers/Fastly-Client-IP
+  if (fastly.ff.visits_this_service == 0 && req.restarts == 0) {
+    set req.http.Fastly-Client-IP = client.ip;
+  }
+
+  # Original client address (e.g. for rate limiting).
+  set req.http.True-Client-IP = req.http.Fastly-Client-IP;
+
+  # Reset proxy headers at the boundary to our network so we can trust them in our stack
+  set req.http.X-Forwarded-For = req.http.Fastly-Client-IP;
+  set req.http.X-Forwarded-Host = req.http.host;
+  set req.http.X-Forwarded-Server = server.hostname;
+
+  # Discard user specified headers that we don't want to trust
+  unset req.http.Client-IP;
 
   # Require authentication for FASTLYPURGE requests unless from IP in ACL
   if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_allowlist) {
@@ -53,13 +69,6 @@ sub vcl_recv {
   # Serve a 404 Not Found response if request URL matches "/autodiscover/autodiscover.xml"
   if (req.url.path ~ "(?i)/autodiscover/autodiscover.xml$") {
     error 804 "Not Found";
-  }
-
-  # Append to XFF. Unsure about this restart condition?
-  if (!req.http.Fastly-FF) {
-    set req.http.Fastly-Temp-XFF = req.http.X-Forwarded-For ", " client.ip;
-  } else {
-    set req.http.Fastly-Temp-XFF = req.http.X-Forwarded-For;
   }
 
   # Keep stale.

--- a/spec/test-outputs/bouncer-production.out.vcl
+++ b/spec/test-outputs/bouncer-production.out.vcl
@@ -44,6 +44,22 @@ acl purge_ip_allowlist {
 }
 
 sub vcl_recv {
+  # Protect header from modification at the edge of the Fastly network
+  # https://developer.fastly.com/reference/http-headers/Fastly-Client-IP
+  if (fastly.ff.visits_this_service == 0 && req.restarts == 0) {
+    set req.http.Fastly-Client-IP = client.ip;
+  }
+
+  # Original client address (e.g. for rate limiting).
+  set req.http.True-Client-IP = req.http.Fastly-Client-IP;
+
+  # Reset proxy headers at the boundary to our network so we can trust them in our stack
+  set req.http.X-Forwarded-For = req.http.Fastly-Client-IP;
+  set req.http.X-Forwarded-Host = req.http.host;
+  set req.http.X-Forwarded-Server = server.hostname;
+
+  # Discard user specified headers that we don't want to trust
+  unset req.http.Client-IP;
 
   # Require authentication for FASTLYPURGE requests unless from IP in ACL
   if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_allowlist) {
@@ -53,13 +69,6 @@ sub vcl_recv {
   # Serve a 404 Not Found response if request URL matches "/autodiscover/autodiscover.xml"
   if (req.url.path ~ "(?i)/autodiscover/autodiscover.xml$") {
     error 804 "Not Found";
-  }
-
-  # Append to XFF. Unsure about this restart condition?
-  if (!req.http.Fastly-FF) {
-    set req.http.Fastly-Temp-XFF = req.http.X-Forwarded-For ", " client.ip;
-  } else {
-    set req.http.Fastly-Temp-XFF = req.http.X-Forwarded-For;
   }
 
   # Keep stale.

--- a/spec/test-outputs/bouncer-staging.out.vcl
+++ b/spec/test-outputs/bouncer-staging.out.vcl
@@ -44,6 +44,22 @@ acl purge_ip_allowlist {
 }
 
 sub vcl_recv {
+  # Protect header from modification at the edge of the Fastly network
+  # https://developer.fastly.com/reference/http-headers/Fastly-Client-IP
+  if (fastly.ff.visits_this_service == 0 && req.restarts == 0) {
+    set req.http.Fastly-Client-IP = client.ip;
+  }
+
+  # Original client address (e.g. for rate limiting).
+  set req.http.True-Client-IP = req.http.Fastly-Client-IP;
+
+  # Reset proxy headers at the boundary to our network so we can trust them in our stack
+  set req.http.X-Forwarded-For = req.http.Fastly-Client-IP;
+  set req.http.X-Forwarded-Host = req.http.host;
+  set req.http.X-Forwarded-Server = server.hostname;
+
+  # Discard user specified headers that we don't want to trust
+  unset req.http.Client-IP;
 
   # Require authentication for FASTLYPURGE requests unless from IP in ACL
   if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_allowlist) {
@@ -53,13 +69,6 @@ sub vcl_recv {
   # Serve a 404 Not Found response if request URL matches "/autodiscover/autodiscover.xml"
   if (req.url.path ~ "(?i)/autodiscover/autodiscover.xml$") {
     error 804 "Not Found";
-  }
-
-  # Append to XFF. Unsure about this restart condition?
-  if (!req.http.Fastly-FF) {
-    set req.http.Fastly-Temp-XFF = req.http.X-Forwarded-For ", " client.ip;
-  } else {
-    set req.http.Fastly-Temp-XFF = req.http.X-Forwarded-For;
   }
 
   # Keep stale.

--- a/spec/test-outputs/bouncer-test.out.vcl
+++ b/spec/test-outputs/bouncer-test.out.vcl
@@ -44,6 +44,22 @@ acl purge_ip_allowlist {
 }
 
 sub vcl_recv {
+  # Protect header from modification at the edge of the Fastly network
+  # https://developer.fastly.com/reference/http-headers/Fastly-Client-IP
+  if (fastly.ff.visits_this_service == 0 && req.restarts == 0) {
+    set req.http.Fastly-Client-IP = client.ip;
+  }
+
+  # Original client address (e.g. for rate limiting).
+  set req.http.True-Client-IP = req.http.Fastly-Client-IP;
+
+  # Reset proxy headers at the boundary to our network so we can trust them in our stack
+  set req.http.X-Forwarded-For = req.http.Fastly-Client-IP;
+  set req.http.X-Forwarded-Host = req.http.host;
+  set req.http.X-Forwarded-Server = server.hostname;
+
+  # Discard user specified headers that we don't want to trust
+  unset req.http.Client-IP;
 
   # Require authentication for FASTLYPURGE requests unless from IP in ACL
   if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_allowlist) {
@@ -53,13 +69,6 @@ sub vcl_recv {
   # Serve a 404 Not Found response if request URL matches "/autodiscover/autodiscover.xml"
   if (req.url.path ~ "(?i)/autodiscover/autodiscover.xml$") {
     error 804 "Not Found";
-  }
-
-  # Append to XFF. Unsure about this restart condition?
-  if (!req.http.Fastly-FF) {
-    set req.http.Fastly-Temp-XFF = req.http.X-Forwarded-For ", " client.ip;
-  } else {
-    set req.http.Fastly-Temp-XFF = req.http.X-Forwarded-For;
   }
 
   # Keep stale.

--- a/spec/test-outputs/mirror-integration.out.vcl
+++ b/spec/test-outputs/mirror-integration.out.vcl
@@ -41,6 +41,22 @@ acl allowed_ip_addresses {
 }
 
 sub vcl_recv {
+  # Protect header from modification at the edge of the Fastly network
+  # https://developer.fastly.com/reference/http-headers/Fastly-Client-IP
+  if (fastly.ff.visits_this_service == 0 && req.restarts == 0) {
+    set req.http.Fastly-Client-IP = client.ip;
+  }
+
+  # Original client address (e.g. for rate limiting).
+  set req.http.True-Client-IP = req.http.Fastly-Client-IP;
+
+  # Reset proxy headers at the boundary to our network so we can trust them in our stack
+  set req.http.X-Forwarded-For = req.http.Fastly-Client-IP;
+  set req.http.X-Forwarded-Host = req.http.host;
+  set req.http.X-Forwarded-Server = server.hostname;
+
+  # Discard user specified headers that we don't want to trust
+  unset req.http.Client-IP;
 
   # Require authentication for FASTLYPURGE requests unless from IP in ACL
   if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_allowlist) {
@@ -78,9 +94,6 @@ sub vcl_recv {
   set req.http.Fastly-Backend-Name = "origin";
 
   
-
-  # Unspoofable original client address.
-  set req.http.True-Client-IP = req.http.Fastly-Client-IP;
 
   # Set a TLSversion request header for requests going to the Licensify application
   # This is used to block unsecure requests at the application level for payment security reasons and an absence of caching in Licensify

--- a/spec/test-outputs/mirror-production.out.vcl
+++ b/spec/test-outputs/mirror-production.out.vcl
@@ -137,6 +137,22 @@ acl allowed_ip_addresses {
 }
 
 sub vcl_recv {
+  # Protect header from modification at the edge of the Fastly network
+  # https://developer.fastly.com/reference/http-headers/Fastly-Client-IP
+  if (fastly.ff.visits_this_service == 0 && req.restarts == 0) {
+    set req.http.Fastly-Client-IP = client.ip;
+  }
+
+  # Original client address (e.g. for rate limiting).
+  set req.http.True-Client-IP = req.http.Fastly-Client-IP;
+
+  # Reset proxy headers at the boundary to our network so we can trust them in our stack
+  set req.http.X-Forwarded-For = req.http.Fastly-Client-IP;
+  set req.http.X-Forwarded-Host = req.http.host;
+  set req.http.X-Forwarded-Server = server.hostname;
+
+  # Discard user specified headers that we don't want to trust
+  unset req.http.Client-IP;
 
   # Require authentication for FASTLYPURGE requests unless from IP in ACL
   if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_allowlist) {
@@ -235,9 +251,6 @@ sub vcl_recv {
     set req.http.Authorization = "AWS gcs-mirror-access-id:" digest.hmac_sha1_base64("gcs-mirror-secret-key", "GET" LF LF LF now LF "/gcs-bucket" req.url.path);
   }
   
-
-  # Unspoofable original client address.
-  set req.http.True-Client-IP = req.http.Fastly-Client-IP;
 
   # Set a TLSversion request header for requests going to the Licensify application
   # This is used to block unsecure requests at the application level for payment security reasons and an absence of caching in Licensify

--- a/spec/test-outputs/mirror-staging.out.vcl
+++ b/spec/test-outputs/mirror-staging.out.vcl
@@ -137,6 +137,22 @@ acl allowed_ip_addresses {
 }
 
 sub vcl_recv {
+  # Protect header from modification at the edge of the Fastly network
+  # https://developer.fastly.com/reference/http-headers/Fastly-Client-IP
+  if (fastly.ff.visits_this_service == 0 && req.restarts == 0) {
+    set req.http.Fastly-Client-IP = client.ip;
+  }
+
+  # Original client address (e.g. for rate limiting).
+  set req.http.True-Client-IP = req.http.Fastly-Client-IP;
+
+  # Reset proxy headers at the boundary to our network so we can trust them in our stack
+  set req.http.X-Forwarded-For = req.http.Fastly-Client-IP;
+  set req.http.X-Forwarded-Host = req.http.host;
+  set req.http.X-Forwarded-Server = server.hostname;
+
+  # Discard user specified headers that we don't want to trust
+  unset req.http.Client-IP;
 
   # Require authentication for FASTLYPURGE requests unless from IP in ACL
   if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_allowlist) {
@@ -235,9 +251,6 @@ sub vcl_recv {
     set req.http.Authorization = "AWS gcs-mirror-access-id:" digest.hmac_sha1_base64("gcs-mirror-secret-key", "GET" LF LF LF now LF "/gcs-bucket" req.url.path);
   }
   
-
-  # Unspoofable original client address.
-  set req.http.True-Client-IP = req.http.Fastly-Client-IP;
 
   # Set a TLSversion request header for requests going to the Licensify application
   # This is used to block unsecure requests at the application level for payment security reasons and an absence of caching in Licensify

--- a/spec/test-outputs/www-eks-integration.out.vcl
+++ b/spec/test-outputs/www-eks-integration.out.vcl
@@ -39,6 +39,22 @@ acl allowed_ip_addresses {
 
 
 sub vcl_recv {
+  # Protect header from modification at the edge of the Fastly network
+  # https://developer.fastly.com/reference/http-headers/Fastly-Client-IP
+  if (fastly.ff.visits_this_service == 0 && req.restarts == 0) {
+    set req.http.Fastly-Client-IP = client.ip;
+  }
+
+  # Original client address (e.g. for rate limiting).
+  set req.http.True-Client-IP = req.http.Fastly-Client-IP;
+
+  # Reset proxy headers at the boundary to our network so we can trust them in our stack
+  set req.http.X-Forwarded-For = req.http.Fastly-Client-IP;
+  set req.http.X-Forwarded-Host = req.http.host;
+  set req.http.X-Forwarded-Server = server.hostname;
+
+  # Discard user specified headers that we don't want to trust
+  unset req.http.Client-IP;
 
   # Require authentication for PURGE requests
   set req.http.Fastly-Purge-Requires-Auth = "1";
@@ -109,15 +125,6 @@ sub vcl_recv {
   }
 
   
-
-  # Protect header from modification at the edge of the Fastly network
-  # https://developer.fastly.com/reference/http-headers/Fastly-Client-IP
-  if (fastly.ff.visits_this_service == 0 && req.restarts == 0) {
-    set req.http.Fastly-Client-IP = client.ip;
-  }
-
-  # Unspoofable original client address (e.g. for rate limiting).
-  set req.http.True-Client-IP = req.http.Fastly-Client-IP;
 
   # Set a TLSversion request header for requests going to the Licensify application
   # This is used to block unsecure requests at the application level for payment security reasons and an absence of caching in Licensify

--- a/spec/test-outputs/www-eks-production.out.vcl
+++ b/spec/test-outputs/www-eks-production.out.vcl
@@ -135,6 +135,22 @@ acl allowed_ip_addresses {
 
 
 sub vcl_recv {
+  # Protect header from modification at the edge of the Fastly network
+  # https://developer.fastly.com/reference/http-headers/Fastly-Client-IP
+  if (fastly.ff.visits_this_service == 0 && req.restarts == 0) {
+    set req.http.Fastly-Client-IP = client.ip;
+  }
+
+  # Original client address (e.g. for rate limiting).
+  set req.http.True-Client-IP = req.http.Fastly-Client-IP;
+
+  # Reset proxy headers at the boundary to our network so we can trust them in our stack
+  set req.http.X-Forwarded-For = req.http.Fastly-Client-IP;
+  set req.http.X-Forwarded-Host = req.http.host;
+  set req.http.X-Forwarded-Server = server.hostname;
+
+  # Discard user specified headers that we don't want to trust
+  unset req.http.Client-IP;
 
   # Require authentication for PURGE requests
   set req.http.Fastly-Purge-Requires-Auth = "1";
@@ -278,15 +294,6 @@ sub vcl_recv {
     }
   }
   
-
-  # Protect header from modification at the edge of the Fastly network
-  # https://developer.fastly.com/reference/http-headers/Fastly-Client-IP
-  if (fastly.ff.visits_this_service == 0 && req.restarts == 0) {
-    set req.http.Fastly-Client-IP = client.ip;
-  }
-
-  # Unspoofable original client address (e.g. for rate limiting).
-  set req.http.True-Client-IP = req.http.Fastly-Client-IP;
 
   # Set a TLSversion request header for requests going to the Licensify application
   # This is used to block unsecure requests at the application level for payment security reasons and an absence of caching in Licensify

--- a/spec/test-outputs/www-eks-staging.out.vcl
+++ b/spec/test-outputs/www-eks-staging.out.vcl
@@ -135,6 +135,22 @@ acl allowed_ip_addresses {
 
 
 sub vcl_recv {
+  # Protect header from modification at the edge of the Fastly network
+  # https://developer.fastly.com/reference/http-headers/Fastly-Client-IP
+  if (fastly.ff.visits_this_service == 0 && req.restarts == 0) {
+    set req.http.Fastly-Client-IP = client.ip;
+  }
+
+  # Original client address (e.g. for rate limiting).
+  set req.http.True-Client-IP = req.http.Fastly-Client-IP;
+
+  # Reset proxy headers at the boundary to our network so we can trust them in our stack
+  set req.http.X-Forwarded-For = req.http.Fastly-Client-IP;
+  set req.http.X-Forwarded-Host = req.http.host;
+  set req.http.X-Forwarded-Server = server.hostname;
+
+  # Discard user specified headers that we don't want to trust
+  unset req.http.Client-IP;
 
   # Require authentication for PURGE requests
   set req.http.Fastly-Purge-Requires-Auth = "1";
@@ -278,15 +294,6 @@ sub vcl_recv {
     }
   }
   
-
-  # Protect header from modification at the edge of the Fastly network
-  # https://developer.fastly.com/reference/http-headers/Fastly-Client-IP
-  if (fastly.ff.visits_this_service == 0 && req.restarts == 0) {
-    set req.http.Fastly-Client-IP = client.ip;
-  }
-
-  # Unspoofable original client address (e.g. for rate limiting).
-  set req.http.True-Client-IP = req.http.Fastly-Client-IP;
 
   # Set a TLSversion request header for requests going to the Licensify application
   # This is used to block unsecure requests at the application level for payment security reasons and an absence of caching in Licensify

--- a/spec/test-outputs/www-eks-test.out.vcl
+++ b/spec/test-outputs/www-eks-test.out.vcl
@@ -39,6 +39,22 @@ acl allowed_ip_addresses {
 
 
 sub vcl_recv {
+  # Protect header from modification at the edge of the Fastly network
+  # https://developer.fastly.com/reference/http-headers/Fastly-Client-IP
+  if (fastly.ff.visits_this_service == 0 && req.restarts == 0) {
+    set req.http.Fastly-Client-IP = client.ip;
+  }
+
+  # Original client address (e.g. for rate limiting).
+  set req.http.True-Client-IP = req.http.Fastly-Client-IP;
+
+  # Reset proxy headers at the boundary to our network so we can trust them in our stack
+  set req.http.X-Forwarded-For = req.http.Fastly-Client-IP;
+  set req.http.X-Forwarded-Host = req.http.host;
+  set req.http.X-Forwarded-Server = server.hostname;
+
+  # Discard user specified headers that we don't want to trust
+  unset req.http.Client-IP;
 
   # Require authentication for PURGE requests
   set req.http.Fastly-Purge-Requires-Auth = "1";
@@ -109,15 +125,6 @@ sub vcl_recv {
   }
 
   
-
-  # Protect header from modification at the edge of the Fastly network
-  # https://developer.fastly.com/reference/http-headers/Fastly-Client-IP
-  if (fastly.ff.visits_this_service == 0 && req.restarts == 0) {
-    set req.http.Fastly-Client-IP = client.ip;
-  }
-
-  # Unspoofable original client address (e.g. for rate limiting).
-  set req.http.True-Client-IP = req.http.Fastly-Client-IP;
 
   # Set a TLSversion request header for requests going to the Licensify application
   # This is used to block unsecure requests at the application level for payment security reasons and an absence of caching in Licensify

--- a/spec/test-outputs/www-integration.out.vcl
+++ b/spec/test-outputs/www-integration.out.vcl
@@ -39,6 +39,22 @@ acl allowed_ip_addresses {
 
 
 sub vcl_recv {
+  # Protect header from modification at the edge of the Fastly network
+  # https://developer.fastly.com/reference/http-headers/Fastly-Client-IP
+  if (fastly.ff.visits_this_service == 0 && req.restarts == 0) {
+    set req.http.Fastly-Client-IP = client.ip;
+  }
+
+  # Original client address (e.g. for rate limiting).
+  set req.http.True-Client-IP = req.http.Fastly-Client-IP;
+
+  # Reset proxy headers at the boundary to our network so we can trust them in our stack
+  set req.http.X-Forwarded-For = req.http.Fastly-Client-IP;
+  set req.http.X-Forwarded-Host = req.http.host;
+  set req.http.X-Forwarded-Server = server.hostname;
+
+  # Discard user specified headers that we don't want to trust
+  unset req.http.Client-IP;
 
   # Require authentication for PURGE requests
   set req.http.Fastly-Purge-Requires-Auth = "1";
@@ -109,15 +125,6 @@ sub vcl_recv {
   }
 
   
-
-  # Protect header from modification at the edge of the Fastly network
-  # https://developer.fastly.com/reference/http-headers/Fastly-Client-IP
-  if (fastly.ff.visits_this_service == 0 && req.restarts == 0) {
-    set req.http.Fastly-Client-IP = client.ip;
-  }
-
-  # Unspoofable original client address (e.g. for rate limiting).
-  set req.http.True-Client-IP = req.http.Fastly-Client-IP;
 
   # Set a TLSversion request header for requests going to the Licensify application
   # This is used to block unsecure requests at the application level for payment security reasons and an absence of caching in Licensify

--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -132,6 +132,22 @@ backend F_mirrorGCS {
 
 
 sub vcl_recv {
+  # Protect header from modification at the edge of the Fastly network
+  # https://developer.fastly.com/reference/http-headers/Fastly-Client-IP
+  if (fastly.ff.visits_this_service == 0 && req.restarts == 0) {
+    set req.http.Fastly-Client-IP = client.ip;
+  }
+
+  # Original client address (e.g. for rate limiting).
+  set req.http.True-Client-IP = req.http.Fastly-Client-IP;
+
+  # Reset proxy headers at the boundary to our network so we can trust them in our stack
+  set req.http.X-Forwarded-For = req.http.Fastly-Client-IP;
+  set req.http.X-Forwarded-Host = req.http.host;
+  set req.http.X-Forwarded-Server = server.hostname;
+
+  # Discard user specified headers that we don't want to trust
+  unset req.http.Client-IP;
 
   # Require authentication for PURGE requests
   set req.http.Fastly-Purge-Requires-Auth = "1";
@@ -270,15 +286,6 @@ sub vcl_recv {
     }
   }
   
-
-  # Protect header from modification at the edge of the Fastly network
-  # https://developer.fastly.com/reference/http-headers/Fastly-Client-IP
-  if (fastly.ff.visits_this_service == 0 && req.restarts == 0) {
-    set req.http.Fastly-Client-IP = client.ip;
-  }
-
-  # Unspoofable original client address (e.g. for rate limiting).
-  set req.http.True-Client-IP = req.http.Fastly-Client-IP;
 
   # Set a TLSversion request header for requests going to the Licensify application
   # This is used to block unsecure requests at the application level for payment security reasons and an absence of caching in Licensify

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -135,6 +135,22 @@ acl allowed_ip_addresses {
 
 
 sub vcl_recv {
+  # Protect header from modification at the edge of the Fastly network
+  # https://developer.fastly.com/reference/http-headers/Fastly-Client-IP
+  if (fastly.ff.visits_this_service == 0 && req.restarts == 0) {
+    set req.http.Fastly-Client-IP = client.ip;
+  }
+
+  # Original client address (e.g. for rate limiting).
+  set req.http.True-Client-IP = req.http.Fastly-Client-IP;
+
+  # Reset proxy headers at the boundary to our network so we can trust them in our stack
+  set req.http.X-Forwarded-For = req.http.Fastly-Client-IP;
+  set req.http.X-Forwarded-Host = req.http.host;
+  set req.http.X-Forwarded-Server = server.hostname;
+
+  # Discard user specified headers that we don't want to trust
+  unset req.http.Client-IP;
 
   # Require authentication for PURGE requests
   set req.http.Fastly-Purge-Requires-Auth = "1";
@@ -278,15 +294,6 @@ sub vcl_recv {
     }
   }
   
-
-  # Protect header from modification at the edge of the Fastly network
-  # https://developer.fastly.com/reference/http-headers/Fastly-Client-IP
-  if (fastly.ff.visits_this_service == 0 && req.restarts == 0) {
-    set req.http.Fastly-Client-IP = client.ip;
-  }
-
-  # Unspoofable original client address (e.g. for rate limiting).
-  set req.http.True-Client-IP = req.http.Fastly-Client-IP;
 
   # Set a TLSversion request header for requests going to the Licensify application
   # This is used to block unsecure requests at the application level for payment security reasons and an absence of caching in Licensify

--- a/spec/test-outputs/www-test.out.vcl
+++ b/spec/test-outputs/www-test.out.vcl
@@ -39,6 +39,22 @@ acl allowed_ip_addresses {
 
 
 sub vcl_recv {
+  # Protect header from modification at the edge of the Fastly network
+  # https://developer.fastly.com/reference/http-headers/Fastly-Client-IP
+  if (fastly.ff.visits_this_service == 0 && req.restarts == 0) {
+    set req.http.Fastly-Client-IP = client.ip;
+  }
+
+  # Original client address (e.g. for rate limiting).
+  set req.http.True-Client-IP = req.http.Fastly-Client-IP;
+
+  # Reset proxy headers at the boundary to our network so we can trust them in our stack
+  set req.http.X-Forwarded-For = req.http.Fastly-Client-IP;
+  set req.http.X-Forwarded-Host = req.http.host;
+  set req.http.X-Forwarded-Server = server.hostname;
+
+  # Discard user specified headers that we don't want to trust
+  unset req.http.Client-IP;
 
   # Require authentication for PURGE requests
   set req.http.Fastly-Purge-Requires-Auth = "1";
@@ -109,15 +125,6 @@ sub vcl_recv {
   }
 
   
-
-  # Protect header from modification at the edge of the Fastly network
-  # https://developer.fastly.com/reference/http-headers/Fastly-Client-IP
-  if (fastly.ff.visits_this_service == 0 && req.restarts == 0) {
-    set req.http.Fastly-Client-IP = client.ip;
-  }
-
-  # Unspoofable original client address (e.g. for rate limiting).
-  set req.http.True-Client-IP = req.http.Fastly-Client-IP;
 
   # Set a TLSversion request header for requests going to the Licensify application
   # This is used to block unsecure requests at the application level for payment security reasons and an absence of caching in Licensify

--- a/vcl_templates/_boundary_headers.vcl.erb
+++ b/vcl_templates/_boundary_headers.vcl.erb
@@ -1,0 +1,16 @@
+# Protect header from modification at the edge of the Fastly network
+# https://developer.fastly.com/reference/http-headers/Fastly-Client-IP
+if (fastly.ff.visits_this_service == 0 && req.restarts == 0) {
+  set req.http.Fastly-Client-IP = client.ip;
+}
+
+# Original client address (e.g. for rate limiting).
+set req.http.True-Client-IP = req.http.Fastly-Client-IP;
+
+# Reset proxy headers at the boundary to our network so we can trust them in our stack
+set req.http.X-Forwarded-For = req.http.Fastly-Client-IP;
+set req.http.X-Forwarded-Host = req.http.host;
+set req.http.X-Forwarded-Server = server.hostname;
+
+# Discard user specified headers that we don't want to trust
+unset req.http.Client-IP;

--- a/vcl_templates/apt.vcl.erb
+++ b/vcl_templates/apt.vcl.erb
@@ -23,15 +23,14 @@ backend F_apt {
 }
 
 sub vcl_recv {
+<%= render_partial("boundary_headers", indentation: "  ") %>
+
 #FASTLY recv
 
     # Require authentication for FASTLYPURGE requests
     if (req.request == "FASTLYPURGE") {
       set req.http.Fastly-Purge-Requires-Auth = "1";
     }
-
-    # Unspoofable original client address
-    set req.http.True-Client-IP = req.http.Fastly-Client-IP;
 
     if (req.request != "HEAD" && req.request != "GET" && req.request != "FASTLYPURGE") {
       return(pass);

--- a/vcl_templates/assets.vcl.erb
+++ b/vcl_templates/assets.vcl.erb
@@ -155,8 +155,7 @@ acl purge_ip_allowlist {
 }
 
 sub vcl_recv {
-  # Reset proxy headers at the boundary to our network.
-  set req.http.X-Forwarded-Host = req.http.host;
+<%= render_partial("boundary_headers", indentation: "  ") %>
 
   # Require authentication for FASTLYPURGE requests unless from IP in ACL
   if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_allowlist) {
@@ -233,9 +232,6 @@ sub vcl_recv {
     set req.http.Authorization = "AWS <%= config.fetch('gcs_mirror_access_id') %>:" digest.hmac_sha1_base64("<%= config.fetch('gcs_mirror_secret_key') %>", "GET" LF LF LF now LF "/<%= config.fetch('gcs_mirror_bucket_name') %>" req.url.path);
   }
   <% end %>
-
-  # Unspoofable original client address.
-  set req.http.True-Client-IP = req.http.Fastly-Client-IP;
 
 #FASTLY recv
 

--- a/vcl_templates/bouncer.vcl.erb
+++ b/vcl_templates/bouncer.vcl.erb
@@ -44,6 +44,7 @@ acl purge_ip_allowlist {
 }
 
 sub vcl_recv {
+<%= render_partial("boundary_headers", indentation: "  ") %>
 
   # Require authentication for FASTLYPURGE requests unless from IP in ACL
   if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_allowlist) {
@@ -53,13 +54,6 @@ sub vcl_recv {
   # Serve a 404 Not Found response if request URL matches "/autodiscover/autodiscover.xml"
   if (req.url.path ~ "(?i)/autodiscover/autodiscover.xml$") {
     error 804 "Not Found";
-  }
-
-  # Append to XFF. Unsure about this restart condition?
-  if (!req.http.Fastly-FF) {
-    set req.http.Fastly-Temp-XFF = req.http.X-Forwarded-For ", " client.ip;
-  } else {
-    set req.http.Fastly-Temp-XFF = req.http.X-Forwarded-For;
   }
 
   # Keep stale.

--- a/vcl_templates/mirror.vcl.erb
+++ b/vcl_templates/mirror.vcl.erb
@@ -173,6 +173,7 @@ acl allowed_ip_addresses {
 }
 
 sub vcl_recv {
+<%= render_partial("boundary_headers", indentation: "  ") %>
 
   # Require authentication for FASTLYPURGE requests unless from IP in ACL
   if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_allowlist) {
@@ -278,9 +279,6 @@ sub vcl_recv {
     set req.http.Authorization = "AWS <%= config.fetch('gcs_mirror_access_id') %>:" digest.hmac_sha1_base64("<%= config.fetch('gcs_mirror_secret_key') %>", "GET" LF LF LF now LF "/<%= config.fetch('gcs_mirror_bucket_name') %>" req.url.path);
   }
   <% end %>
-
-  # Unspoofable original client address.
-  set req.http.True-Client-IP = req.http.Fastly-Client-IP;
 
   # Set a TLSversion request header for requests going to the Licensify application
   # This is used to block unsecure requests at the application level for payment security reasons and an absence of caching in Licensify

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -210,6 +210,7 @@ acl allowed_ip_addresses {
 <% end %>
 
 sub vcl_recv {
+<%= render_partial("boundary_headers", indentation: "  ") %>
 
   # Require authentication for PURGE requests
   set req.http.Fastly-Purge-Requires-Auth = "1";
@@ -360,15 +361,6 @@ sub vcl_recv {
     }
   }
   <% end %>
-
-  # Protect header from modification at the edge of the Fastly network
-  # https://developer.fastly.com/reference/http-headers/Fastly-Client-IP
-  if (fastly.ff.visits_this_service == 0 && req.restarts == 0) {
-    set req.http.Fastly-Client-IP = client.ip;
-  }
-
-  # Unspoofable original client address (e.g. for rate limiting).
-  set req.http.True-Client-IP = req.http.Fastly-Client-IP;
 
   # Set a TLSversion request header for requests going to the Licensify application
   # This is used to block unsecure requests at the application level for payment security reasons and an absence of caching in Licensify


### PR DESCRIPTION
⚠️ The changes need to be deployed manually to all relevant environments. Follow the guidance on [how to deploy Fastly](https://docs.publishing.service.gov.uk/manual/cdn.html#deploying-fastly).

This is a draft that requires: https://github.com/alphagov/govuk-cdn-config/pull/415 and will need rebasing after: https://github.com/alphagov/govuk-cdn-config/pull/414 is merged. I've opened it up to show the intention of boundary headers as a) motivation for #415 and b) to get feedback on what is set.

It's easiest to look at the first commit https://github.com/alphagov/govuk-cdn-config/commit/ca109d332638435d81995fa5b1357c8dbceb0645 to get a gist of this PR as the second commit is a lot of test output churn.

---


This applies the same header setting approach for requests at the Fastly
boundary of all our Fastly services that proxy.

The motivation for this is to be clearer in what we trust header wise
and not risk situations where our applications can behave differently
based on headers a user sets (cache poisoning).

This moves the same client-IP header code that was in most of the files
to one place. This sets a header of True-Client-IP based on the IP that
connected to Fastly. We also remove the Client-IP header, I'm continuing
to do that based on the precedence but I couldn't identify what that
precedent was.

We set the X-Forwarded-For header to be the IP that communicated with
Fastly, prior to a request reaching Fastly we can't trust that the data
in here isn't a user specifying a fake IP address.

We reset the X-Forwarded-Host to be the host that Fastly received a
request for, this prevents a user pretending that the request originated
from a different host. By default Fastly will append to this header, as
Fastly doesn't know if the request to it is from a trusted source or
not.

We set X-Forwarded-Server to the Fastly server hostname. I'm not sure if
this is actually of value, but it seems better to override it than ever
be caught out by a user setting this and we think it's from within our
network.