### PR TITLE
Set proxy headers with original request headers

### DIFF
--- a/spec/test-outputs/assets-eks-integration.out.vcl
+++ b/spec/test-outputs/assets-eks-integration.out.vcl
@@ -36,6 +36,8 @@ acl purge_ip_allowlist {
 }
 
 sub vcl_recv {
+  # Reset proxy headers at the boundary to our network.
+  set req.http.X-Forwarded-Host = req.http.host;
 
   # Require authentication for FASTLYPURGE requests unless from IP in ACL
   if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_allowlist) {
@@ -64,9 +66,6 @@ sub vcl_recv {
 
   # Unspoofable original client address.
   set req.http.True-Client-IP = req.http.Fastly-Client-IP;
-
-  # Reset proxy headers at the boundary to our network.
-  set req.http.X-Forwarded-Host = req.http.host;
 
 #FASTLY recv
 

--- a/spec/test-outputs/assets-eks-production.out.vcl
+++ b/spec/test-outputs/assets-eks-production.out.vcl
@@ -135,6 +135,8 @@ acl purge_ip_allowlist {
 }
 
 sub vcl_recv {
+  # Reset proxy headers at the boundary to our network.
+  set req.http.X-Forwarded-Host = req.http.host;
 
   # Require authentication for FASTLYPURGE requests unless from IP in ACL
   if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_allowlist) {
@@ -214,9 +216,6 @@ sub vcl_recv {
 
   # Unspoofable original client address.
   set req.http.True-Client-IP = req.http.Fastly-Client-IP;
-
-  # Reset proxy headers at the boundary to our network.
-  set req.http.X-Forwarded-Host = req.http.host;
 
 #FASTLY recv
 

--- a/spec/test-outputs/assets-eks-staging.out.vcl
+++ b/spec/test-outputs/assets-eks-staging.out.vcl
@@ -135,6 +135,8 @@ acl purge_ip_allowlist {
 }
 
 sub vcl_recv {
+  # Reset proxy headers at the boundary to our network.
+  set req.http.X-Forwarded-Host = req.http.host;
 
   # Require authentication for FASTLYPURGE requests unless from IP in ACL
   if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_allowlist) {
@@ -214,9 +216,6 @@ sub vcl_recv {
 
   # Unspoofable original client address.
   set req.http.True-Client-IP = req.http.Fastly-Client-IP;
-
-  # Reset proxy headers at the boundary to our network.
-  set req.http.X-Forwarded-Host = req.http.host;
 
 #FASTLY recv
 

--- a/spec/test-outputs/assets-eks-test.out.vcl
+++ b/spec/test-outputs/assets-eks-test.out.vcl
@@ -36,6 +36,8 @@ acl purge_ip_allowlist {
 }
 
 sub vcl_recv {
+  # Reset proxy headers at the boundary to our network.
+  set req.http.X-Forwarded-Host = req.http.host;
 
   # Require authentication for FASTLYPURGE requests unless from IP in ACL
   if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_allowlist) {
@@ -64,9 +66,6 @@ sub vcl_recv {
 
   # Unspoofable original client address.
   set req.http.True-Client-IP = req.http.Fastly-Client-IP;
-
-  # Reset proxy headers at the boundary to our network.
-  set req.http.X-Forwarded-Host = req.http.host;
 
 #FASTLY recv
 

--- a/spec/test-outputs/assets-integration.out.vcl
+++ b/spec/test-outputs/assets-integration.out.vcl
@@ -36,6 +36,8 @@ acl purge_ip_allowlist {
 }
 
 sub vcl_recv {
+  # Reset proxy headers at the boundary to our network.
+  set req.http.X-Forwarded-Host = req.http.host;
 
   # Require authentication for FASTLYPURGE requests unless from IP in ACL
   if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_allowlist) {
@@ -64,9 +66,6 @@ sub vcl_recv {
 
   # Unspoofable original client address.
   set req.http.True-Client-IP = req.http.Fastly-Client-IP;
-
-  # Reset proxy headers at the boundary to our network.
-  set req.http.X-Forwarded-Host = req.http.host;
 
 #FASTLY recv
 

--- a/spec/test-outputs/assets-production.out.vcl
+++ b/spec/test-outputs/assets-production.out.vcl
@@ -135,6 +135,8 @@ acl purge_ip_allowlist {
 }
 
 sub vcl_recv {
+  # Reset proxy headers at the boundary to our network.
+  set req.http.X-Forwarded-Host = req.http.host;
 
   # Require authentication for FASTLYPURGE requests unless from IP in ACL
   if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_allowlist) {
@@ -214,9 +216,6 @@ sub vcl_recv {
 
   # Unspoofable original client address.
   set req.http.True-Client-IP = req.http.Fastly-Client-IP;
-
-  # Reset proxy headers at the boundary to our network.
-  set req.http.X-Forwarded-Host = req.http.host;
 
 #FASTLY recv
 

--- a/spec/test-outputs/assets-staging.out.vcl
+++ b/spec/test-outputs/assets-staging.out.vcl
@@ -135,6 +135,8 @@ acl purge_ip_allowlist {
 }
 
 sub vcl_recv {
+  # Reset proxy headers at the boundary to our network.
+  set req.http.X-Forwarded-Host = req.http.host;
 
   # Require authentication for FASTLYPURGE requests unless from IP in ACL
   if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_allowlist) {
@@ -214,9 +216,6 @@ sub vcl_recv {
 
   # Unspoofable original client address.
   set req.http.True-Client-IP = req.http.Fastly-Client-IP;
-
-  # Reset proxy headers at the boundary to our network.
-  set req.http.X-Forwarded-Host = req.http.host;
 
 #FASTLY recv
 

--- a/spec/test-outputs/assets-test.out.vcl
+++ b/spec/test-outputs/assets-test.out.vcl
@@ -36,6 +36,8 @@ acl purge_ip_allowlist {
 }
 
 sub vcl_recv {
+  # Reset proxy headers at the boundary to our network.
+  set req.http.X-Forwarded-Host = req.http.host;
 
   # Require authentication for FASTLYPURGE requests unless from IP in ACL
   if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_allowlist) {
@@ -64,9 +66,6 @@ sub vcl_recv {
 
   # Unspoofable original client address.
   set req.http.True-Client-IP = req.http.Fastly-Client-IP;
-
-  # Reset proxy headers at the boundary to our network.
-  set req.http.X-Forwarded-Host = req.http.host;
 
 #FASTLY recv
 

--- a/spec/test-outputs/www-eks-integration.out.vcl
+++ b/spec/test-outputs/www-eks-integration.out.vcl
@@ -43,6 +43,11 @@ sub vcl_recv {
   # Require authentication for PURGE requests
   set req.http.Fastly-Purge-Requires-Auth = "1";
 
+  # Reset proxy headers at the boundary to our network.
+  unset req.http.Client-IP;
+  set req.http.X-Forwarded-For = req.http.Fastly-Client-IP;
+  set req.http.X-Forwarded-Host = req.http.host;
+
   
 
   # Check whether the remote IP address is in the list of blocked IPs
@@ -113,11 +118,6 @@ sub vcl_recv {
 
   # Unspoofable original client address (e.g. for rate limiting).
   set req.http.True-Client-IP = req.http.Fastly-Client-IP;
-
-  # Reset proxy headers at the boundary to our network.
-  unset req.http.Client-IP;
-  set req.http.X-Forwarded-For = req.http.Fastly-Client-IP;
-  set req.http.X-Forwarded-Host = req.http.host;
 
   # Set a TLSversion request header for requests going to the Licensify application
   # This is used to block unsecure requests at the application level for payment security reasons and an absence of caching in Licensify

--- a/spec/test-outputs/www-eks-production.out.vcl
+++ b/spec/test-outputs/www-eks-production.out.vcl
@@ -136,6 +136,11 @@ sub vcl_recv {
   # Require authentication for PURGE requests
   set req.http.Fastly-Purge-Requires-Auth = "1";
 
+  # Reset proxy headers at the boundary to our network.
+  unset req.http.Client-IP;
+  set req.http.X-Forwarded-For = req.http.Fastly-Client-IP;
+  set req.http.X-Forwarded-Host = req.http.host;
+
   
 
   # Check whether the remote IP address is in the list of blocked IPs
@@ -274,11 +279,6 @@ sub vcl_recv {
 
   # Unspoofable original client address (e.g. for rate limiting).
   set req.http.True-Client-IP = req.http.Fastly-Client-IP;
-
-  # Reset proxy headers at the boundary to our network.
-  unset req.http.Client-IP;
-  set req.http.X-Forwarded-For = req.http.Fastly-Client-IP;
-  set req.http.X-Forwarded-Host = req.http.host;
 
   # Set a TLSversion request header for requests going to the Licensify application
   # This is used to block unsecure requests at the application level for payment security reasons and an absence of caching in Licensify

--- a/spec/test-outputs/www-eks-staging.out.vcl
+++ b/spec/test-outputs/www-eks-staging.out.vcl
@@ -139,6 +139,11 @@ sub vcl_recv {
   # Require authentication for PURGE requests
   set req.http.Fastly-Purge-Requires-Auth = "1";
 
+  # Reset proxy headers at the boundary to our network.
+  unset req.http.Client-IP;
+  set req.http.X-Forwarded-For = req.http.Fastly-Client-IP;
+  set req.http.X-Forwarded-Host = req.http.host;
+
   
   # Only allow connections from allowed IP addresses in staging
   if (! (client.ip ~ allowed_ip_addresses)) {
@@ -282,11 +287,6 @@ sub vcl_recv {
 
   # Unspoofable original client address (e.g. for rate limiting).
   set req.http.True-Client-IP = req.http.Fastly-Client-IP;
-
-  # Reset proxy headers at the boundary to our network.
-  unset req.http.Client-IP;
-  set req.http.X-Forwarded-For = req.http.Fastly-Client-IP;
-  set req.http.X-Forwarded-Host = req.http.host;
 
   # Set a TLSversion request header for requests going to the Licensify application
   # This is used to block unsecure requests at the application level for payment security reasons and an absence of caching in Licensify

--- a/spec/test-outputs/www-eks-test.out.vcl
+++ b/spec/test-outputs/www-eks-test.out.vcl
@@ -43,6 +43,11 @@ sub vcl_recv {
   # Require authentication for PURGE requests
   set req.http.Fastly-Purge-Requires-Auth = "1";
 
+  # Reset proxy headers at the boundary to our network.
+  unset req.http.Client-IP;
+  set req.http.X-Forwarded-For = req.http.Fastly-Client-IP;
+  set req.http.X-Forwarded-Host = req.http.host;
+
   
 
   # Check whether the remote IP address is in the list of blocked IPs
@@ -113,11 +118,6 @@ sub vcl_recv {
 
   # Unspoofable original client address (e.g. for rate limiting).
   set req.http.True-Client-IP = req.http.Fastly-Client-IP;
-
-  # Reset proxy headers at the boundary to our network.
-  unset req.http.Client-IP;
-  set req.http.X-Forwarded-For = req.http.Fastly-Client-IP;
-  set req.http.X-Forwarded-Host = req.http.host;
 
   # Set a TLSversion request header for requests going to the Licensify application
   # This is used to block unsecure requests at the application level for payment security reasons and an absence of caching in Licensify

--- a/spec/test-outputs/www-integration.out.vcl
+++ b/spec/test-outputs/www-integration.out.vcl
@@ -43,6 +43,11 @@ sub vcl_recv {
   # Require authentication for PURGE requests
   set req.http.Fastly-Purge-Requires-Auth = "1";
 
+  # Reset proxy headers at the boundary to our network.
+  unset req.http.Client-IP;
+  set req.http.X-Forwarded-For = req.http.Fastly-Client-IP;
+  set req.http.X-Forwarded-Host = req.http.host;
+
   
 
   # Check whether the remote IP address is in the list of blocked IPs
@@ -113,11 +118,6 @@ sub vcl_recv {
 
   # Unspoofable original client address (e.g. for rate limiting).
   set req.http.True-Client-IP = req.http.Fastly-Client-IP;
-
-  # Reset proxy headers at the boundary to our network.
-  unset req.http.Client-IP;
-  set req.http.X-Forwarded-For = req.http.Fastly-Client-IP;
-  set req.http.X-Forwarded-Host = req.http.host;
 
   # Set a TLSversion request header for requests going to the Licensify application
   # This is used to block unsecure requests at the application level for payment security reasons and an absence of caching in Licensify

--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -136,6 +136,11 @@ sub vcl_recv {
   # Require authentication for PURGE requests
   set req.http.Fastly-Purge-Requires-Auth = "1";
 
+  # Reset proxy headers at the boundary to our network.
+  unset req.http.Client-IP;
+  set req.http.X-Forwarded-For = req.http.Fastly-Client-IP;
+  set req.http.X-Forwarded-Host = req.http.host;
+
   
 
   # Check whether the remote IP address is in the list of blocked IPs
@@ -274,11 +279,6 @@ sub vcl_recv {
 
   # Unspoofable original client address (e.g. for rate limiting).
   set req.http.True-Client-IP = req.http.Fastly-Client-IP;
-
-  # Reset proxy headers at the boundary to our network.
-  unset req.http.Client-IP;
-  set req.http.X-Forwarded-For = req.http.Fastly-Client-IP;
-  set req.http.X-Forwarded-Host = req.http.host;
 
   # Set a TLSversion request header for requests going to the Licensify application
   # This is used to block unsecure requests at the application level for payment security reasons and an absence of caching in Licensify

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -139,6 +139,11 @@ sub vcl_recv {
   # Require authentication for PURGE requests
   set req.http.Fastly-Purge-Requires-Auth = "1";
 
+  # Reset proxy headers at the boundary to our network.
+  unset req.http.Client-IP;
+  set req.http.X-Forwarded-For = req.http.Fastly-Client-IP;
+  set req.http.X-Forwarded-Host = req.http.host;
+
   
   # Only allow connections from allowed IP addresses in staging
   if (! (client.ip ~ allowed_ip_addresses)) {
@@ -282,11 +287,6 @@ sub vcl_recv {
 
   # Unspoofable original client address (e.g. for rate limiting).
   set req.http.True-Client-IP = req.http.Fastly-Client-IP;
-
-  # Reset proxy headers at the boundary to our network.
-  unset req.http.Client-IP;
-  set req.http.X-Forwarded-For = req.http.Fastly-Client-IP;
-  set req.http.X-Forwarded-Host = req.http.host;
 
   # Set a TLSversion request header for requests going to the Licensify application
   # This is used to block unsecure requests at the application level for payment security reasons and an absence of caching in Licensify

--- a/spec/test-outputs/www-test.out.vcl
+++ b/spec/test-outputs/www-test.out.vcl
@@ -43,6 +43,11 @@ sub vcl_recv {
   # Require authentication for PURGE requests
   set req.http.Fastly-Purge-Requires-Auth = "1";
 
+  # Reset proxy headers at the boundary to our network.
+  unset req.http.Client-IP;
+  set req.http.X-Forwarded-For = req.http.Fastly-Client-IP;
+  set req.http.X-Forwarded-Host = req.http.host;
+
   
 
   # Check whether the remote IP address is in the list of blocked IPs
@@ -113,11 +118,6 @@ sub vcl_recv {
 
   # Unspoofable original client address (e.g. for rate limiting).
   set req.http.True-Client-IP = req.http.Fastly-Client-IP;
-
-  # Reset proxy headers at the boundary to our network.
-  unset req.http.Client-IP;
-  set req.http.X-Forwarded-For = req.http.Fastly-Client-IP;
-  set req.http.X-Forwarded-Host = req.http.host;
 
   # Set a TLSversion request header for requests going to the Licensify application
   # This is used to block unsecure requests at the application level for payment security reasons and an absence of caching in Licensify

--- a/vcl_templates/assets.vcl.erb
+++ b/vcl_templates/assets.vcl.erb
@@ -155,6 +155,8 @@ acl purge_ip_allowlist {
 }
 
 sub vcl_recv {
+  # Reset proxy headers at the boundary to our network.
+  set req.http.X-Forwarded-Host = req.http.host;
 
   # Require authentication for FASTLYPURGE requests unless from IP in ACL
   if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_allowlist) {
@@ -234,9 +236,6 @@ sub vcl_recv {
 
   # Unspoofable original client address.
   set req.http.True-Client-IP = req.http.Fastly-Client-IP;
-
-  # Reset proxy headers at the boundary to our network.
-  set req.http.X-Forwarded-Host = req.http.host;
 
 #FASTLY recv
 

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -214,6 +214,11 @@ sub vcl_recv {
   # Require authentication for PURGE requests
   set req.http.Fastly-Purge-Requires-Auth = "1";
 
+  # Reset proxy headers at the boundary to our network.
+  unset req.http.Client-IP;
+  set req.http.X-Forwarded-For = req.http.Fastly-Client-IP;
+  set req.http.X-Forwarded-Host = req.http.host;
+
   <% if %w(staging production-eks).include?(environment) %>
   # Only allow connections from allowed IP addresses in staging
   if (! (client.ip ~ allowed_ip_addresses)) {
@@ -364,11 +369,6 @@ sub vcl_recv {
 
   # Unspoofable original client address (e.g. for rate limiting).
   set req.http.True-Client-IP = req.http.Fastly-Client-IP;
-
-  # Reset proxy headers at the boundary to our network.
-  unset req.http.Client-IP;
-  set req.http.X-Forwarded-For = req.http.Fastly-Client-IP;
-  set req.http.X-Forwarded-Host = req.http.host;
 
   # Set a TLSversion request header for requests going to the Licensify application
   # This is used to block unsecure requests at the application level for payment security reasons and an absence of caching in Licensify


### PR DESCRIPTION
This fixes an issue where the X-Forwarded-Host header was incorrect, as it was being set from the request Host header which was being re-written previously. This moves the logic to set the proxy headers earlier in the vcl_recv subroutine as to ensure they are using the original header information.

Been tested in integration - fixed the X-Forwarded-Host header to actually be set as the request Host.

⚠️ The changes need to be deployed manually to all relevant environments. Follow the guidance on [how to deploy Fastly](https://docs.publishing.service.gov.uk/manual/cdn.html#deploying-fastly).
