### PR TITLE
Reinstate #420

### DIFF
--- a/lib/deploy_bouncer.rb
+++ b/lib/deploy_bouncer.rb
@@ -149,9 +149,8 @@ class DeployBouncer < DeployBase
   end
 
   def render_vcl(service_id, app_domain)
-    @app_domain = app_domain
+    locals = { service_id: service_id, app_domain: app_domain }
 
-    vcl_file = File.join(File.dirname(__FILE__), "..", "vcl_templates", "bouncer.vcl.erb")
-    ERB.new(File.read(vcl_file)).result(binding)
+    RenderTemplate.call("bouncer", locals: locals)
   end
 end

--- a/lib/deploy_service.rb
+++ b/lib/deploy_service.rb
@@ -16,6 +16,7 @@ class DeployService < DeployBase
     vcl = RenderTemplate.call(
       configuration,
       locals: {
+        configuration: configuration,
         environment: environment,
         config: config,
         version: version,

--- a/lib/deploy_service.rb
+++ b/lib/deploy_service.rb
@@ -13,7 +13,15 @@ class DeployService < DeployBase
     puts "Configuration: #{configuration}"
     puts "Environment: #{environment}"
 
-    vcl = RenderTemplate.render_template(configuration, environment, config, version)
+    vcl = RenderTemplate.call(
+      configuration,
+      locals: {
+        environment: environment,
+        config: config,
+        version: version,
+        ab_tests: ab_tests_config,
+      },
+    )
 
     dry_run = ENV.fetch("FASTLY_DRY_RUN", "").downcase
     unless ["", "0", "false"].include?(dry_run)
@@ -33,6 +41,10 @@ class DeployService < DeployBase
   end
 
 private
+
+  def ab_tests_config
+    @ab_tests_config ||= YAML.load_file(File.join(__dir__, "..", "ab_tests", "ab_tests.yaml"))
+  end
 
   def get_config(args)
     raise "Usage: #{$PROGRAM_NAME} <configuration> <environment>" unless args.size == 2

--- a/lib/render_template.rb
+++ b/lib/render_template.rb
@@ -1,8 +1,46 @@
 class RenderTemplate
-  def self.render_template(configuration, environment, config, version)
-    # Both config and ab_tests are used inside the vcl.erb template
-    vcl_file = File.join(File.dirname(__FILE__), "..", "vcl_templates", "#{configuration}.vcl.erb")
-    ab_tests = YAML.load_file(File.join(__dir__, "..", "ab_tests", "ab_tests.yaml"))
-    ERB.new(File.read(vcl_file), trim_mode: "-").result(binding)
+  attr_reader :template, :locals
+
+  def self.call(...)
+    new(...).call
+  end
+
+  def initialize(template, locals: {})
+    @template = template
+    @locals = locals
+  end
+
+  def call
+    embedded_ruby = File.read("#{__dir__}/../vcl_templates/#{template}.vcl.erb")
+    ERB.new(embedded_ruby, trim_mode: "-")
+       .result(binding_with_local_variables(locals))
+  end
+
+  def render_partial(partial, indentation: "", locals: {})
+    embedded_ruby = File.read("#{__dir__}/../vcl_templates/_#{partial}.vcl.erb")
+    # this is a variable name that ERB sets it output too, we need to set this
+    # to be distinct from other renderings that are progressing
+    erb_output_var = "_#{partial}_eoutvar"
+
+    output = ERB
+      .new(embedded_ruby, trim_mode: "-", eoutvar: erb_output_var)
+      .result(binding_with_local_variables(locals))
+
+    if indentation != ""
+      output
+        .split("\n")
+        .map { |line| line.length.positive? ? "#{indentation}#{line}" : line }
+        .join("\n")
+    else
+      output
+    end
+  end
+
+private
+
+  def binding_with_local_variables(variables)
+    binding.tap do |bind|
+      variables.each { |k, v| bind.local_variable_set(k, v) }
+    end
   end
 end

--- a/spec/render_template_spec.rb
+++ b/spec/render_template_spec.rb
@@ -1,9 +1,55 @@
 RSpec.describe RenderTemplate do
-  describe ".render_template" do
+  describe ".call" do
     it "renders the ERB template" do
-      result = RenderTemplate.render_template("test", {}, "my_variable", {})
+      allow(File)
+        .to receive(:read)
+        .with(/template.vcl.erb\z/)
+        .and_return("<%= my_var %>\n")
 
-      expect(result).to eql("my_variable\n")
+      result = described_class.call("template", locals: { my_var: "foobar" })
+
+      expect(result).to eql("foobar\n")
+    end
+  end
+
+  describe "#render_partial" do
+    it "can render a partial" do
+      allow(File)
+        .to receive(:read)
+        .with(/template.vcl.erb\z/)
+        .and_return("<%= render_partial('partial', locals: { my_var: 'foobar' }) %>\n")
+
+      allow(File)
+        .to receive(:read)
+        .with(/_partial.vcl.erb\z/)
+        .and_return("<%= my_var -%>\n")
+
+      result = described_class.call("template")
+
+      expect(result).to eql("foobar\n")
+    end
+
+    it "can indent partial output" do
+      allow(File)
+        .to receive(:read)
+        .with(/template.vcl.erb\z/)
+        .and_return("{\n<%= render_partial('partial', indentation: '  ') %>\n}\n")
+
+      allow(File)
+        .to receive(:read)
+        .with(/_partial.vcl.erb\z/)
+        .and_return("line-1\nline-2\n\nline-3")
+
+      result = described_class.call("template", locals: { my_var: "foobar" })
+
+      expect(result).to eql <<~HEREDOC
+        {
+          line-1
+          line-2
+
+          line-3
+        }
+      HEREDOC
     end
   end
 end

--- a/spec/test-outputs/bouncer-integration.out.vcl
+++ b/spec/test-outputs/bouncer-integration.out.vcl
@@ -1,0 +1,204 @@
+
+backend F_origin0 {
+    .connect_timeout = 1s;
+    .dynamic = true;
+    .port = "80";
+    .host = "bouncer.test.gov.uk";
+    .first_byte_timeout = 15s;
+    .max_connections = 200;
+    .between_bytes_timeout = 10s;
+    .share_key = "12345";
+
+    .probe = {
+        .request = "HEAD /healthcheck/ready HTTP/1.1"  "Host: bouncer.test.gov.uk" "Connection: close";
+        .window = 2;
+        .threshold = 1;
+        .timeout = 2s;
+        .interval = 5m;
+      }
+}
+
+backend sick_force_grace {
+  .host = "127.0.0.1";
+  .port = "1";
+  .probe = {
+    .request = "invalid";
+    .interval = 365d;
+    .initial = 0;
+  }
+}
+
+
+acl purge_ip_allowlist {
+  # See https://sites.google.com/a/digital.cabinet-office.gov.uk/gds/working-at-the-white-chapel-building/gds-internal-it/gds-internal-it-network-public-ip-addresses
+  "213.86.153.211";  # GDS Office (BYOD VPN)
+  "213.86.153.212";  # GDS Office
+  "213.86.153.213";  # GDS Office
+  "213.86.153.214";  # GDS Office
+  "213.86.153.231";  # GDS Office (BYOD VPN)
+  "213.86.153.235";  # GDS Office
+  "213.86.153.236";  # GDS Office
+  "213.86.153.237";  # GDS Office
+  "51.149.8.0"/25;   # GDS Office (DR VPN)
+  "51.149.8.128"/29; # GDS Office (DR BYOD VPN)
+}
+
+sub vcl_recv {
+
+  # Require authentication for FASTLYPURGE requests unless from IP in ACL
+  if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_allowlist) {
+    set req.http.Fastly-Purge-Requires-Auth = "1";
+  }
+
+  # Serve a 404 Not Found response if request URL matches "/autodiscover/autodiscover.xml"
+  if (req.url.path ~ "(?i)/autodiscover/autodiscover.xml$") {
+    error 804 "Not Found";
+  }
+
+  # Append to XFF. Unsure about this restart condition?
+  if (!req.http.Fastly-FF) {
+    set req.http.Fastly-Temp-XFF = req.http.X-Forwarded-For ", " client.ip;
+  } else {
+    set req.http.Fastly-Temp-XFF = req.http.X-Forwarded-For;
+  }
+
+  # Keep stale.
+  set req.grace = 86400s;
+
+  # Default backend.
+  set req.backend = F_origin0;
+
+  # Serve stale if it exists.
+  if (req.restarts > 0) {
+    set req.backend = sick_force_grace;
+    set req.http.Fastly-Backend-Name = "stale";
+  }
+
+
+#FASTLY recv
+
+  if (req.request != "HEAD" && req.request != "GET" && req.request != "PURGE") {
+    return(pass);
+  }
+
+  return(lookup);
+}
+
+sub vcl_fetch {
+#FASTLY fetch
+
+
+  set beresp.grace = 86400s;
+
+  if ((beresp.status == 500 || beresp.status == 503) && req.restarts < 2 && (req.request == "GET" || req.request == "HEAD")) {
+    set beresp.saintmode = 5s;
+    return (restart);
+  }
+
+  if(req.restarts > 0 ) {
+    set beresp.http.Fastly-Restarts = req.restarts;
+  }
+
+  if (beresp.http.Set-Cookie) {
+    set req.http.Fastly-Cachetype = "SETCOOKIE";
+    return (pass);
+  }
+
+  if (beresp.http.Cache-Control ~ "private") {
+    set req.http.Fastly-Cachetype = "PRIVATE";
+    return (pass);
+  }
+
+  if (beresp.status == 500 || beresp.status == 503) {
+    set req.http.Fastly-Cachetype = "ERROR";
+    set beresp.ttl = 1s;
+    set beresp.grace = 5s;
+    return (deliver);
+  }
+
+  if (beresp.http.Expires || beresp.http.Surrogate-Control ~ "max-age" || beresp.http.Cache-Control ~"(s-maxage|max-age)") {
+    # keep the ttl here
+  } else {
+    # apply the default ttl
+    set beresp.ttl = 3600s;
+  }
+}
+
+sub vcl_hit {
+#FASTLY hit
+}
+
+sub vcl_miss {
+#FASTLY miss
+}
+
+sub vcl_deliver {
+#FASTLY deliver
+}
+
+sub vcl_error {
+  if (obj.status == 804) {
+    set obj.status = 404;
+    set obj.response = "Not Found";
+    set obj.http.Fastly-Backend-Name = "force_not_found";
+
+    synthetic {"
+      <!DOCTYPE html>
+      <html>
+        <head>
+          <title>Welcome to GOV.UK</title>
+          <style>
+            body { font-family: Arial, sans-serif; margin: 0; }
+            header { background: black; }
+            h1 { color: white; font-size: 29px; margin: 0 auto; padding: 10px; max-width: 990px; }
+            p { color: black; margin: 30px auto; max-width: 990px; }
+          </style>
+        </head>
+        <body>
+          <header><h1>GOV.UK</h1></header>
+          <p>We cannot find the page you're looking for. Please try searching on <a href="https://www.gov.uk/">GOV.UK</a>.</p>
+        </body>
+      </html>"};
+
+    return (deliver);
+  }
+
+  # Assume we've hit vcl_error() because the backend is unavailable
+  if (req.restarts < 2) {
+    return (restart);
+  }
+
+  synthetic {"
+    <!DOCTYPE html>
+    <html>
+      <head>
+        <title>GOV.UK Redirect</title>
+        <style>
+          body { font-family: Arial, sans-serif; margin: 0; }
+          header { background: black; }
+          h1 { color: white; font-size: 29px; margin: 0 auto; padding: 10px; max-width: 990px; }
+          p { color: black; margin: 30px auto; max-width: 990px; }
+        </style>
+      </head>
+      <body>
+        <header><h1>GOV.UK</h1></header>
+        <p>We are experiencing technical difficulties.</p>
+        <p>The page you requested may be available on <a href='https://www.gov.uk'>GOV.UK</a> or the <a href='http://www.nationalarchives.gov.uk/webarchive/'>UK Government Web Archive</a>.</p>
+      </body>
+    </html>"};
+
+  set obj.status = 503;
+  return (deliver);
+
+#FASTLY error
+}
+
+# pipe cannot be included.
+
+sub vcl_pass {
+#FASTLY pass
+}
+
+sub vcl_hash {
+#FASTLY hash
+}

--- a/spec/test-outputs/bouncer-production.out.vcl
+++ b/spec/test-outputs/bouncer-production.out.vcl
@@ -1,0 +1,204 @@
+
+backend F_origin0 {
+    .connect_timeout = 1s;
+    .dynamic = true;
+    .port = "80";
+    .host = "bouncer.test.gov.uk";
+    .first_byte_timeout = 15s;
+    .max_connections = 200;
+    .between_bytes_timeout = 10s;
+    .share_key = "12345";
+
+    .probe = {
+        .request = "HEAD /healthcheck/ready HTTP/1.1"  "Host: bouncer.test.gov.uk" "Connection: close";
+        .window = 2;
+        .threshold = 1;
+        .timeout = 2s;
+        .interval = 5m;
+      }
+}
+
+backend sick_force_grace {
+  .host = "127.0.0.1";
+  .port = "1";
+  .probe = {
+    .request = "invalid";
+    .interval = 365d;
+    .initial = 0;
+  }
+}
+
+
+acl purge_ip_allowlist {
+  # See https://sites.google.com/a/digital.cabinet-office.gov.uk/gds/working-at-the-white-chapel-building/gds-internal-it/gds-internal-it-network-public-ip-addresses
+  "213.86.153.211";  # GDS Office (BYOD VPN)
+  "213.86.153.212";  # GDS Office
+  "213.86.153.213";  # GDS Office
+  "213.86.153.214";  # GDS Office
+  "213.86.153.231";  # GDS Office (BYOD VPN)
+  "213.86.153.235";  # GDS Office
+  "213.86.153.236";  # GDS Office
+  "213.86.153.237";  # GDS Office
+  "51.149.8.0"/25;   # GDS Office (DR VPN)
+  "51.149.8.128"/29; # GDS Office (DR BYOD VPN)
+}
+
+sub vcl_recv {
+
+  # Require authentication for FASTLYPURGE requests unless from IP in ACL
+  if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_allowlist) {
+    set req.http.Fastly-Purge-Requires-Auth = "1";
+  }
+
+  # Serve a 404 Not Found response if request URL matches "/autodiscover/autodiscover.xml"
+  if (req.url.path ~ "(?i)/autodiscover/autodiscover.xml$") {
+    error 804 "Not Found";
+  }
+
+  # Append to XFF. Unsure about this restart condition?
+  if (!req.http.Fastly-FF) {
+    set req.http.Fastly-Temp-XFF = req.http.X-Forwarded-For ", " client.ip;
+  } else {
+    set req.http.Fastly-Temp-XFF = req.http.X-Forwarded-For;
+  }
+
+  # Keep stale.
+  set req.grace = 86400s;
+
+  # Default backend.
+  set req.backend = F_origin0;
+
+  # Serve stale if it exists.
+  if (req.restarts > 0) {
+    set req.backend = sick_force_grace;
+    set req.http.Fastly-Backend-Name = "stale";
+  }
+
+
+#FASTLY recv
+
+  if (req.request != "HEAD" && req.request != "GET" && req.request != "PURGE") {
+    return(pass);
+  }
+
+  return(lookup);
+}
+
+sub vcl_fetch {
+#FASTLY fetch
+
+
+  set beresp.grace = 86400s;
+
+  if ((beresp.status == 500 || beresp.status == 503) && req.restarts < 2 && (req.request == "GET" || req.request == "HEAD")) {
+    set beresp.saintmode = 5s;
+    return (restart);
+  }
+
+  if(req.restarts > 0 ) {
+    set beresp.http.Fastly-Restarts = req.restarts;
+  }
+
+  if (beresp.http.Set-Cookie) {
+    set req.http.Fastly-Cachetype = "SETCOOKIE";
+    return (pass);
+  }
+
+  if (beresp.http.Cache-Control ~ "private") {
+    set req.http.Fastly-Cachetype = "PRIVATE";
+    return (pass);
+  }
+
+  if (beresp.status == 500 || beresp.status == 503) {
+    set req.http.Fastly-Cachetype = "ERROR";
+    set beresp.ttl = 1s;
+    set beresp.grace = 5s;
+    return (deliver);
+  }
+
+  if (beresp.http.Expires || beresp.http.Surrogate-Control ~ "max-age" || beresp.http.Cache-Control ~"(s-maxage|max-age)") {
+    # keep the ttl here
+  } else {
+    # apply the default ttl
+    set beresp.ttl = 3600s;
+  }
+}
+
+sub vcl_hit {
+#FASTLY hit
+}
+
+sub vcl_miss {
+#FASTLY miss
+}
+
+sub vcl_deliver {
+#FASTLY deliver
+}
+
+sub vcl_error {
+  if (obj.status == 804) {
+    set obj.status = 404;
+    set obj.response = "Not Found";
+    set obj.http.Fastly-Backend-Name = "force_not_found";
+
+    synthetic {"
+      <!DOCTYPE html>
+      <html>
+        <head>
+          <title>Welcome to GOV.UK</title>
+          <style>
+            body { font-family: Arial, sans-serif; margin: 0; }
+            header { background: black; }
+            h1 { color: white; font-size: 29px; margin: 0 auto; padding: 10px; max-width: 990px; }
+            p { color: black; margin: 30px auto; max-width: 990px; }
+          </style>
+        </head>
+        <body>
+          <header><h1>GOV.UK</h1></header>
+          <p>We cannot find the page you're looking for. Please try searching on <a href="https://www.gov.uk/">GOV.UK</a>.</p>
+        </body>
+      </html>"};
+
+    return (deliver);
+  }
+
+  # Assume we've hit vcl_error() because the backend is unavailable
+  if (req.restarts < 2) {
+    return (restart);
+  }
+
+  synthetic {"
+    <!DOCTYPE html>
+    <html>
+      <head>
+        <title>GOV.UK Redirect</title>
+        <style>
+          body { font-family: Arial, sans-serif; margin: 0; }
+          header { background: black; }
+          h1 { color: white; font-size: 29px; margin: 0 auto; padding: 10px; max-width: 990px; }
+          p { color: black; margin: 30px auto; max-width: 990px; }
+        </style>
+      </head>
+      <body>
+        <header><h1>GOV.UK</h1></header>
+        <p>We are experiencing technical difficulties.</p>
+        <p>The page you requested may be available on <a href='https://www.gov.uk'>GOV.UK</a> or the <a href='http://www.nationalarchives.gov.uk/webarchive/'>UK Government Web Archive</a>.</p>
+      </body>
+    </html>"};
+
+  set obj.status = 503;
+  return (deliver);
+
+#FASTLY error
+}
+
+# pipe cannot be included.
+
+sub vcl_pass {
+#FASTLY pass
+}
+
+sub vcl_hash {
+#FASTLY hash
+}

--- a/spec/test-outputs/bouncer-staging.out.vcl
+++ b/spec/test-outputs/bouncer-staging.out.vcl
@@ -1,0 +1,204 @@
+
+backend F_origin0 {
+    .connect_timeout = 1s;
+    .dynamic = true;
+    .port = "80";
+    .host = "bouncer.test.gov.uk";
+    .first_byte_timeout = 15s;
+    .max_connections = 200;
+    .between_bytes_timeout = 10s;
+    .share_key = "12345";
+
+    .probe = {
+        .request = "HEAD /healthcheck/ready HTTP/1.1"  "Host: bouncer.test.gov.uk" "Connection: close";
+        .window = 2;
+        .threshold = 1;
+        .timeout = 2s;
+        .interval = 5m;
+      }
+}
+
+backend sick_force_grace {
+  .host = "127.0.0.1";
+  .port = "1";
+  .probe = {
+    .request = "invalid";
+    .interval = 365d;
+    .initial = 0;
+  }
+}
+
+
+acl purge_ip_allowlist {
+  # See https://sites.google.com/a/digital.cabinet-office.gov.uk/gds/working-at-the-white-chapel-building/gds-internal-it/gds-internal-it-network-public-ip-addresses
+  "213.86.153.211";  # GDS Office (BYOD VPN)
+  "213.86.153.212";  # GDS Office
+  "213.86.153.213";  # GDS Office
+  "213.86.153.214";  # GDS Office
+  "213.86.153.231";  # GDS Office (BYOD VPN)
+  "213.86.153.235";  # GDS Office
+  "213.86.153.236";  # GDS Office
+  "213.86.153.237";  # GDS Office
+  "51.149.8.0"/25;   # GDS Office (DR VPN)
+  "51.149.8.128"/29; # GDS Office (DR BYOD VPN)
+}
+
+sub vcl_recv {
+
+  # Require authentication for FASTLYPURGE requests unless from IP in ACL
+  if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_allowlist) {
+    set req.http.Fastly-Purge-Requires-Auth = "1";
+  }
+
+  # Serve a 404 Not Found response if request URL matches "/autodiscover/autodiscover.xml"
+  if (req.url.path ~ "(?i)/autodiscover/autodiscover.xml$") {
+    error 804 "Not Found";
+  }
+
+  # Append to XFF. Unsure about this restart condition?
+  if (!req.http.Fastly-FF) {
+    set req.http.Fastly-Temp-XFF = req.http.X-Forwarded-For ", " client.ip;
+  } else {
+    set req.http.Fastly-Temp-XFF = req.http.X-Forwarded-For;
+  }
+
+  # Keep stale.
+  set req.grace = 86400s;
+
+  # Default backend.
+  set req.backend = F_origin0;
+
+  # Serve stale if it exists.
+  if (req.restarts > 0) {
+    set req.backend = sick_force_grace;
+    set req.http.Fastly-Backend-Name = "stale";
+  }
+
+
+#FASTLY recv
+
+  if (req.request != "HEAD" && req.request != "GET" && req.request != "PURGE") {
+    return(pass);
+  }
+
+  return(lookup);
+}
+
+sub vcl_fetch {
+#FASTLY fetch
+
+
+  set beresp.grace = 86400s;
+
+  if ((beresp.status == 500 || beresp.status == 503) && req.restarts < 2 && (req.request == "GET" || req.request == "HEAD")) {
+    set beresp.saintmode = 5s;
+    return (restart);
+  }
+
+  if(req.restarts > 0 ) {
+    set beresp.http.Fastly-Restarts = req.restarts;
+  }
+
+  if (beresp.http.Set-Cookie) {
+    set req.http.Fastly-Cachetype = "SETCOOKIE";
+    return (pass);
+  }
+
+  if (beresp.http.Cache-Control ~ "private") {
+    set req.http.Fastly-Cachetype = "PRIVATE";
+    return (pass);
+  }
+
+  if (beresp.status == 500 || beresp.status == 503) {
+    set req.http.Fastly-Cachetype = "ERROR";
+    set beresp.ttl = 1s;
+    set beresp.grace = 5s;
+    return (deliver);
+  }
+
+  if (beresp.http.Expires || beresp.http.Surrogate-Control ~ "max-age" || beresp.http.Cache-Control ~"(s-maxage|max-age)") {
+    # keep the ttl here
+  } else {
+    # apply the default ttl
+    set beresp.ttl = 3600s;
+  }
+}
+
+sub vcl_hit {
+#FASTLY hit
+}
+
+sub vcl_miss {
+#FASTLY miss
+}
+
+sub vcl_deliver {
+#FASTLY deliver
+}
+
+sub vcl_error {
+  if (obj.status == 804) {
+    set obj.status = 404;
+    set obj.response = "Not Found";
+    set obj.http.Fastly-Backend-Name = "force_not_found";
+
+    synthetic {"
+      <!DOCTYPE html>
+      <html>
+        <head>
+          <title>Welcome to GOV.UK</title>
+          <style>
+            body { font-family: Arial, sans-serif; margin: 0; }
+            header { background: black; }
+            h1 { color: white; font-size: 29px; margin: 0 auto; padding: 10px; max-width: 990px; }
+            p { color: black; margin: 30px auto; max-width: 990px; }
+          </style>
+        </head>
+        <body>
+          <header><h1>GOV.UK</h1></header>
+          <p>We cannot find the page you're looking for. Please try searching on <a href="https://www.gov.uk/">GOV.UK</a>.</p>
+        </body>
+      </html>"};
+
+    return (deliver);
+  }
+
+  # Assume we've hit vcl_error() because the backend is unavailable
+  if (req.restarts < 2) {
+    return (restart);
+  }
+
+  synthetic {"
+    <!DOCTYPE html>
+    <html>
+      <head>
+        <title>GOV.UK Redirect</title>
+        <style>
+          body { font-family: Arial, sans-serif; margin: 0; }
+          header { background: black; }
+          h1 { color: white; font-size: 29px; margin: 0 auto; padding: 10px; max-width: 990px; }
+          p { color: black; margin: 30px auto; max-width: 990px; }
+        </style>
+      </head>
+      <body>
+        <header><h1>GOV.UK</h1></header>
+        <p>We are experiencing technical difficulties.</p>
+        <p>The page you requested may be available on <a href='https://www.gov.uk'>GOV.UK</a> or the <a href='http://www.nationalarchives.gov.uk/webarchive/'>UK Government Web Archive</a>.</p>
+      </body>
+    </html>"};
+
+  set obj.status = 503;
+  return (deliver);
+
+#FASTLY error
+}
+
+# pipe cannot be included.
+
+sub vcl_pass {
+#FASTLY pass
+}
+
+sub vcl_hash {
+#FASTLY hash
+}

--- a/spec/test-outputs/bouncer-test.out.vcl
+++ b/spec/test-outputs/bouncer-test.out.vcl
@@ -1,0 +1,204 @@
+
+backend F_origin0 {
+    .connect_timeout = 1s;
+    .dynamic = true;
+    .port = "80";
+    .host = "bouncer.test.gov.uk";
+    .first_byte_timeout = 15s;
+    .max_connections = 200;
+    .between_bytes_timeout = 10s;
+    .share_key = "12345";
+
+    .probe = {
+        .request = "HEAD /healthcheck/ready HTTP/1.1"  "Host: bouncer.test.gov.uk" "Connection: close";
+        .window = 2;
+        .threshold = 1;
+        .timeout = 2s;
+        .interval = 5m;
+      }
+}
+
+backend sick_force_grace {
+  .host = "127.0.0.1";
+  .port = "1";
+  .probe = {
+    .request = "invalid";
+    .interval = 365d;
+    .initial = 0;
+  }
+}
+
+
+acl purge_ip_allowlist {
+  # See https://sites.google.com/a/digital.cabinet-office.gov.uk/gds/working-at-the-white-chapel-building/gds-internal-it/gds-internal-it-network-public-ip-addresses
+  "213.86.153.211";  # GDS Office (BYOD VPN)
+  "213.86.153.212";  # GDS Office
+  "213.86.153.213";  # GDS Office
+  "213.86.153.214";  # GDS Office
+  "213.86.153.231";  # GDS Office (BYOD VPN)
+  "213.86.153.235";  # GDS Office
+  "213.86.153.236";  # GDS Office
+  "213.86.153.237";  # GDS Office
+  "51.149.8.0"/25;   # GDS Office (DR VPN)
+  "51.149.8.128"/29; # GDS Office (DR BYOD VPN)
+}
+
+sub vcl_recv {
+
+  # Require authentication for FASTLYPURGE requests unless from IP in ACL
+  if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_allowlist) {
+    set req.http.Fastly-Purge-Requires-Auth = "1";
+  }
+
+  # Serve a 404 Not Found response if request URL matches "/autodiscover/autodiscover.xml"
+  if (req.url.path ~ "(?i)/autodiscover/autodiscover.xml$") {
+    error 804 "Not Found";
+  }
+
+  # Append to XFF. Unsure about this restart condition?
+  if (!req.http.Fastly-FF) {
+    set req.http.Fastly-Temp-XFF = req.http.X-Forwarded-For ", " client.ip;
+  } else {
+    set req.http.Fastly-Temp-XFF = req.http.X-Forwarded-For;
+  }
+
+  # Keep stale.
+  set req.grace = 86400s;
+
+  # Default backend.
+  set req.backend = F_origin0;
+
+  # Serve stale if it exists.
+  if (req.restarts > 0) {
+    set req.backend = sick_force_grace;
+    set req.http.Fastly-Backend-Name = "stale";
+  }
+
+
+#FASTLY recv
+
+  if (req.request != "HEAD" && req.request != "GET" && req.request != "PURGE") {
+    return(pass);
+  }
+
+  return(lookup);
+}
+
+sub vcl_fetch {
+#FASTLY fetch
+
+
+  set beresp.grace = 86400s;
+
+  if ((beresp.status == 500 || beresp.status == 503) && req.restarts < 2 && (req.request == "GET" || req.request == "HEAD")) {
+    set beresp.saintmode = 5s;
+    return (restart);
+  }
+
+  if(req.restarts > 0 ) {
+    set beresp.http.Fastly-Restarts = req.restarts;
+  }
+
+  if (beresp.http.Set-Cookie) {
+    set req.http.Fastly-Cachetype = "SETCOOKIE";
+    return (pass);
+  }
+
+  if (beresp.http.Cache-Control ~ "private") {
+    set req.http.Fastly-Cachetype = "PRIVATE";
+    return (pass);
+  }
+
+  if (beresp.status == 500 || beresp.status == 503) {
+    set req.http.Fastly-Cachetype = "ERROR";
+    set beresp.ttl = 1s;
+    set beresp.grace = 5s;
+    return (deliver);
+  }
+
+  if (beresp.http.Expires || beresp.http.Surrogate-Control ~ "max-age" || beresp.http.Cache-Control ~"(s-maxage|max-age)") {
+    # keep the ttl here
+  } else {
+    # apply the default ttl
+    set beresp.ttl = 3600s;
+  }
+}
+
+sub vcl_hit {
+#FASTLY hit
+}
+
+sub vcl_miss {
+#FASTLY miss
+}
+
+sub vcl_deliver {
+#FASTLY deliver
+}
+
+sub vcl_error {
+  if (obj.status == 804) {
+    set obj.status = 404;
+    set obj.response = "Not Found";
+    set obj.http.Fastly-Backend-Name = "force_not_found";
+
+    synthetic {"
+      <!DOCTYPE html>
+      <html>
+        <head>
+          <title>Welcome to GOV.UK</title>
+          <style>
+            body { font-family: Arial, sans-serif; margin: 0; }
+            header { background: black; }
+            h1 { color: white; font-size: 29px; margin: 0 auto; padding: 10px; max-width: 990px; }
+            p { color: black; margin: 30px auto; max-width: 990px; }
+          </style>
+        </head>
+        <body>
+          <header><h1>GOV.UK</h1></header>
+          <p>We cannot find the page you're looking for. Please try searching on <a href="https://www.gov.uk/">GOV.UK</a>.</p>
+        </body>
+      </html>"};
+
+    return (deliver);
+  }
+
+  # Assume we've hit vcl_error() because the backend is unavailable
+  if (req.restarts < 2) {
+    return (restart);
+  }
+
+  synthetic {"
+    <!DOCTYPE html>
+    <html>
+      <head>
+        <title>GOV.UK Redirect</title>
+        <style>
+          body { font-family: Arial, sans-serif; margin: 0; }
+          header { background: black; }
+          h1 { color: white; font-size: 29px; margin: 0 auto; padding: 10px; max-width: 990px; }
+          p { color: black; margin: 30px auto; max-width: 990px; }
+        </style>
+      </head>
+      <body>
+        <header><h1>GOV.UK</h1></header>
+        <p>We are experiencing technical difficulties.</p>
+        <p>The page you requested may be available on <a href='https://www.gov.uk'>GOV.UK</a> or the <a href='http://www.nationalarchives.gov.uk/webarchive/'>UK Government Web Archive</a>.</p>
+      </body>
+    </html>"};
+
+  set obj.status = 503;
+  return (deliver);
+
+#FASTLY error
+}
+
+# pipe cannot be included.
+
+sub vcl_pass {
+#FASTLY pass
+}
+
+sub vcl_hash {
+#FASTLY hash
+}

--- a/spec/test-outputs/www-eks-integration.out.vcl
+++ b/spec/test-outputs/www-eks-integration.out.vcl
@@ -145,43 +145,42 @@ sub vcl_recv {
     return(pass);
   }
 
-    # Begin dynamic section
-if (req.http.Cookie ~ "cookies_policy" && req.http.Cookie:cookies_policy ~ "%22usage%22:true") {
-  if (table.lookup(active_ab_tests, "Example") == "true") {
-    if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
-      set req.http.GOVUK-ABTest-Example = "A";
-    } else if (req.url ~ "[\?\&]ABTest-Example=A(&|$)") {
-      # Some users, such as remote testers, will be given a URL with a query string
-      # to place them into a specific bucket.
-      set req.http.GOVUK-ABTest-Example = "A";
-    } else if (req.url ~ "[\?\&]ABTest-Example=B(&|$)") {
-      # Some users, such as remote testers, will be given a URL with a query string
-      # to place them into a specific bucket.
-      set req.http.GOVUK-ABTest-Example = "B";
-    } else if (req.http.Cookie ~ "ABTest-Example") {
-      # Set the value of the header to whatever decision was previously made
-      set req.http.GOVUK-ABTest-Example = req.http.Cookie:ABTest-Example;
-    } else {
-      declare local var.denominator_Example INTEGER;
-      declare local var.denominator_Example_A INTEGER;
-      declare local var.nominator_Example_A INTEGER;
-      set var.nominator_Example_A = std.atoi(table.lookup(example_percentages, "A"));
-      set var.denominator_Example += var.nominator_Example_A;
-      declare local var.denominator_Example_B INTEGER;
-      declare local var.nominator_Example_B INTEGER;
-      set var.nominator_Example_B = std.atoi(table.lookup(example_percentages, "B"));
-      set var.denominator_Example += var.nominator_Example_B;
-      set var.denominator_Example_A = var.denominator_Example;
-      if (randombool(var.nominator_Example_A, var.denominator_Example_A)) {
+  # Begin dynamic section
+  if (req.http.Cookie ~ "cookies_policy" && req.http.Cookie:cookies_policy ~ "%22usage%22:true") {
+    if (table.lookup(active_ab_tests, "Example") == "true") {
+      if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
         set req.http.GOVUK-ABTest-Example = "A";
-      } else {
+      } else if (req.url ~ "[\?\&]ABTest-Example=A(&|$)") {
+        # Some users, such as remote testers, will be given a URL with a query string
+        # to place them into a specific bucket.
+        set req.http.GOVUK-ABTest-Example = "A";
+      } else if (req.url ~ "[\?\&]ABTest-Example=B(&|$)") {
+        # Some users, such as remote testers, will be given a URL with a query string
+        # to place them into a specific bucket.
         set req.http.GOVUK-ABTest-Example = "B";
+      } else if (req.http.Cookie ~ "ABTest-Example") {
+        # Set the value of the header to whatever decision was previously made
+        set req.http.GOVUK-ABTest-Example = req.http.Cookie:ABTest-Example;
+      } else {
+        declare local var.denominator_Example INTEGER;
+        declare local var.denominator_Example_A INTEGER;
+        declare local var.nominator_Example_A INTEGER;
+        set var.nominator_Example_A = std.atoi(table.lookup(example_percentages, "A"));
+        set var.denominator_Example += var.nominator_Example_A;
+        declare local var.denominator_Example_B INTEGER;
+        declare local var.nominator_Example_B INTEGER;
+        set var.nominator_Example_B = std.atoi(table.lookup(example_percentages, "B"));
+        set var.denominator_Example += var.nominator_Example_B;
+        set var.denominator_Example_A = var.denominator_Example;
+        if (randombool(var.nominator_Example_A, var.denominator_Example_A)) {
+          set req.http.GOVUK-ABTest-Example = "A";
+        } else {
+          set req.http.GOVUK-ABTest-Example = "B";
+        }
       }
     }
   }
-}
-# End dynamic section
-
+  # End dynamic section
 
   return(lookup);
 }

--- a/spec/test-outputs/www-eks-production.out.vcl
+++ b/spec/test-outputs/www-eks-production.out.vcl
@@ -314,43 +314,42 @@ sub vcl_recv {
     return(pass);
   }
 
-    # Begin dynamic section
-if (req.http.Cookie ~ "cookies_policy" && req.http.Cookie:cookies_policy ~ "%22usage%22:true") {
-  if (table.lookup(active_ab_tests, "Example") == "true") {
-    if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
-      set req.http.GOVUK-ABTest-Example = "A";
-    } else if (req.url ~ "[\?\&]ABTest-Example=A(&|$)") {
-      # Some users, such as remote testers, will be given a URL with a query string
-      # to place them into a specific bucket.
-      set req.http.GOVUK-ABTest-Example = "A";
-    } else if (req.url ~ "[\?\&]ABTest-Example=B(&|$)") {
-      # Some users, such as remote testers, will be given a URL with a query string
-      # to place them into a specific bucket.
-      set req.http.GOVUK-ABTest-Example = "B";
-    } else if (req.http.Cookie ~ "ABTest-Example") {
-      # Set the value of the header to whatever decision was previously made
-      set req.http.GOVUK-ABTest-Example = req.http.Cookie:ABTest-Example;
-    } else {
-      declare local var.denominator_Example INTEGER;
-      declare local var.denominator_Example_A INTEGER;
-      declare local var.nominator_Example_A INTEGER;
-      set var.nominator_Example_A = std.atoi(table.lookup(example_percentages, "A"));
-      set var.denominator_Example += var.nominator_Example_A;
-      declare local var.denominator_Example_B INTEGER;
-      declare local var.nominator_Example_B INTEGER;
-      set var.nominator_Example_B = std.atoi(table.lookup(example_percentages, "B"));
-      set var.denominator_Example += var.nominator_Example_B;
-      set var.denominator_Example_A = var.denominator_Example;
-      if (randombool(var.nominator_Example_A, var.denominator_Example_A)) {
+  # Begin dynamic section
+  if (req.http.Cookie ~ "cookies_policy" && req.http.Cookie:cookies_policy ~ "%22usage%22:true") {
+    if (table.lookup(active_ab_tests, "Example") == "true") {
+      if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
         set req.http.GOVUK-ABTest-Example = "A";
-      } else {
+      } else if (req.url ~ "[\?\&]ABTest-Example=A(&|$)") {
+        # Some users, such as remote testers, will be given a URL with a query string
+        # to place them into a specific bucket.
+        set req.http.GOVUK-ABTest-Example = "A";
+      } else if (req.url ~ "[\?\&]ABTest-Example=B(&|$)") {
+        # Some users, such as remote testers, will be given a URL with a query string
+        # to place them into a specific bucket.
         set req.http.GOVUK-ABTest-Example = "B";
+      } else if (req.http.Cookie ~ "ABTest-Example") {
+        # Set the value of the header to whatever decision was previously made
+        set req.http.GOVUK-ABTest-Example = req.http.Cookie:ABTest-Example;
+      } else {
+        declare local var.denominator_Example INTEGER;
+        declare local var.denominator_Example_A INTEGER;
+        declare local var.nominator_Example_A INTEGER;
+        set var.nominator_Example_A = std.atoi(table.lookup(example_percentages, "A"));
+        set var.denominator_Example += var.nominator_Example_A;
+        declare local var.denominator_Example_B INTEGER;
+        declare local var.nominator_Example_B INTEGER;
+        set var.nominator_Example_B = std.atoi(table.lookup(example_percentages, "B"));
+        set var.denominator_Example += var.nominator_Example_B;
+        set var.denominator_Example_A = var.denominator_Example;
+        if (randombool(var.nominator_Example_A, var.denominator_Example_A)) {
+          set req.http.GOVUK-ABTest-Example = "A";
+        } else {
+          set req.http.GOVUK-ABTest-Example = "B";
+        }
       }
     }
   }
-}
-# End dynamic section
-
+  # End dynamic section
 
   return(lookup);
 }

--- a/spec/test-outputs/www-eks-staging.out.vcl
+++ b/spec/test-outputs/www-eks-staging.out.vcl
@@ -314,43 +314,42 @@ sub vcl_recv {
     return(pass);
   }
 
-    # Begin dynamic section
-if (req.http.Cookie ~ "cookies_policy" && req.http.Cookie:cookies_policy ~ "%22usage%22:true") {
-  if (table.lookup(active_ab_tests, "Example") == "true") {
-    if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
-      set req.http.GOVUK-ABTest-Example = "A";
-    } else if (req.url ~ "[\?\&]ABTest-Example=A(&|$)") {
-      # Some users, such as remote testers, will be given a URL with a query string
-      # to place them into a specific bucket.
-      set req.http.GOVUK-ABTest-Example = "A";
-    } else if (req.url ~ "[\?\&]ABTest-Example=B(&|$)") {
-      # Some users, such as remote testers, will be given a URL with a query string
-      # to place them into a specific bucket.
-      set req.http.GOVUK-ABTest-Example = "B";
-    } else if (req.http.Cookie ~ "ABTest-Example") {
-      # Set the value of the header to whatever decision was previously made
-      set req.http.GOVUK-ABTest-Example = req.http.Cookie:ABTest-Example;
-    } else {
-      declare local var.denominator_Example INTEGER;
-      declare local var.denominator_Example_A INTEGER;
-      declare local var.nominator_Example_A INTEGER;
-      set var.nominator_Example_A = std.atoi(table.lookup(example_percentages, "A"));
-      set var.denominator_Example += var.nominator_Example_A;
-      declare local var.denominator_Example_B INTEGER;
-      declare local var.nominator_Example_B INTEGER;
-      set var.nominator_Example_B = std.atoi(table.lookup(example_percentages, "B"));
-      set var.denominator_Example += var.nominator_Example_B;
-      set var.denominator_Example_A = var.denominator_Example;
-      if (randombool(var.nominator_Example_A, var.denominator_Example_A)) {
+  # Begin dynamic section
+  if (req.http.Cookie ~ "cookies_policy" && req.http.Cookie:cookies_policy ~ "%22usage%22:true") {
+    if (table.lookup(active_ab_tests, "Example") == "true") {
+      if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
         set req.http.GOVUK-ABTest-Example = "A";
-      } else {
+      } else if (req.url ~ "[\?\&]ABTest-Example=A(&|$)") {
+        # Some users, such as remote testers, will be given a URL with a query string
+        # to place them into a specific bucket.
+        set req.http.GOVUK-ABTest-Example = "A";
+      } else if (req.url ~ "[\?\&]ABTest-Example=B(&|$)") {
+        # Some users, such as remote testers, will be given a URL with a query string
+        # to place them into a specific bucket.
         set req.http.GOVUK-ABTest-Example = "B";
+      } else if (req.http.Cookie ~ "ABTest-Example") {
+        # Set the value of the header to whatever decision was previously made
+        set req.http.GOVUK-ABTest-Example = req.http.Cookie:ABTest-Example;
+      } else {
+        declare local var.denominator_Example INTEGER;
+        declare local var.denominator_Example_A INTEGER;
+        declare local var.nominator_Example_A INTEGER;
+        set var.nominator_Example_A = std.atoi(table.lookup(example_percentages, "A"));
+        set var.denominator_Example += var.nominator_Example_A;
+        declare local var.denominator_Example_B INTEGER;
+        declare local var.nominator_Example_B INTEGER;
+        set var.nominator_Example_B = std.atoi(table.lookup(example_percentages, "B"));
+        set var.denominator_Example += var.nominator_Example_B;
+        set var.denominator_Example_A = var.denominator_Example;
+        if (randombool(var.nominator_Example_A, var.denominator_Example_A)) {
+          set req.http.GOVUK-ABTest-Example = "A";
+        } else {
+          set req.http.GOVUK-ABTest-Example = "B";
+        }
       }
     }
   }
-}
-# End dynamic section
-
+  # End dynamic section
 
   return(lookup);
 }

--- a/spec/test-outputs/www-eks-test.out.vcl
+++ b/spec/test-outputs/www-eks-test.out.vcl
@@ -145,43 +145,42 @@ sub vcl_recv {
     return(pass);
   }
 
-    # Begin dynamic section
-if (req.http.Cookie ~ "cookies_policy" && req.http.Cookie:cookies_policy ~ "%22usage%22:true") {
-  if (table.lookup(active_ab_tests, "Example") == "true") {
-    if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
-      set req.http.GOVUK-ABTest-Example = "A";
-    } else if (req.url ~ "[\?\&]ABTest-Example=A(&|$)") {
-      # Some users, such as remote testers, will be given a URL with a query string
-      # to place them into a specific bucket.
-      set req.http.GOVUK-ABTest-Example = "A";
-    } else if (req.url ~ "[\?\&]ABTest-Example=B(&|$)") {
-      # Some users, such as remote testers, will be given a URL with a query string
-      # to place them into a specific bucket.
-      set req.http.GOVUK-ABTest-Example = "B";
-    } else if (req.http.Cookie ~ "ABTest-Example") {
-      # Set the value of the header to whatever decision was previously made
-      set req.http.GOVUK-ABTest-Example = req.http.Cookie:ABTest-Example;
-    } else {
-      declare local var.denominator_Example INTEGER;
-      declare local var.denominator_Example_A INTEGER;
-      declare local var.nominator_Example_A INTEGER;
-      set var.nominator_Example_A = std.atoi(table.lookup(example_percentages, "A"));
-      set var.denominator_Example += var.nominator_Example_A;
-      declare local var.denominator_Example_B INTEGER;
-      declare local var.nominator_Example_B INTEGER;
-      set var.nominator_Example_B = std.atoi(table.lookup(example_percentages, "B"));
-      set var.denominator_Example += var.nominator_Example_B;
-      set var.denominator_Example_A = var.denominator_Example;
-      if (randombool(var.nominator_Example_A, var.denominator_Example_A)) {
+  # Begin dynamic section
+  if (req.http.Cookie ~ "cookies_policy" && req.http.Cookie:cookies_policy ~ "%22usage%22:true") {
+    if (table.lookup(active_ab_tests, "Example") == "true") {
+      if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
         set req.http.GOVUK-ABTest-Example = "A";
-      } else {
+      } else if (req.url ~ "[\?\&]ABTest-Example=A(&|$)") {
+        # Some users, such as remote testers, will be given a URL with a query string
+        # to place them into a specific bucket.
+        set req.http.GOVUK-ABTest-Example = "A";
+      } else if (req.url ~ "[\?\&]ABTest-Example=B(&|$)") {
+        # Some users, such as remote testers, will be given a URL with a query string
+        # to place them into a specific bucket.
         set req.http.GOVUK-ABTest-Example = "B";
+      } else if (req.http.Cookie ~ "ABTest-Example") {
+        # Set the value of the header to whatever decision was previously made
+        set req.http.GOVUK-ABTest-Example = req.http.Cookie:ABTest-Example;
+      } else {
+        declare local var.denominator_Example INTEGER;
+        declare local var.denominator_Example_A INTEGER;
+        declare local var.nominator_Example_A INTEGER;
+        set var.nominator_Example_A = std.atoi(table.lookup(example_percentages, "A"));
+        set var.denominator_Example += var.nominator_Example_A;
+        declare local var.denominator_Example_B INTEGER;
+        declare local var.nominator_Example_B INTEGER;
+        set var.nominator_Example_B = std.atoi(table.lookup(example_percentages, "B"));
+        set var.denominator_Example += var.nominator_Example_B;
+        set var.denominator_Example_A = var.denominator_Example;
+        if (randombool(var.nominator_Example_A, var.denominator_Example_A)) {
+          set req.http.GOVUK-ABTest-Example = "A";
+        } else {
+          set req.http.GOVUK-ABTest-Example = "B";
+        }
       }
     }
   }
-}
-# End dynamic section
-
+  # End dynamic section
 
   return(lookup);
 }

--- a/spec/test-outputs/www-integration.out.vcl
+++ b/spec/test-outputs/www-integration.out.vcl
@@ -145,43 +145,42 @@ sub vcl_recv {
     return(pass);
   }
 
-    # Begin dynamic section
-if (req.http.Cookie ~ "cookies_policy" && req.http.Cookie:cookies_policy ~ "%22usage%22:true") {
-  if (table.lookup(active_ab_tests, "Example") == "true") {
-    if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
-      set req.http.GOVUK-ABTest-Example = "A";
-    } else if (req.url ~ "[\?\&]ABTest-Example=A(&|$)") {
-      # Some users, such as remote testers, will be given a URL with a query string
-      # to place them into a specific bucket.
-      set req.http.GOVUK-ABTest-Example = "A";
-    } else if (req.url ~ "[\?\&]ABTest-Example=B(&|$)") {
-      # Some users, such as remote testers, will be given a URL with a query string
-      # to place them into a specific bucket.
-      set req.http.GOVUK-ABTest-Example = "B";
-    } else if (req.http.Cookie ~ "ABTest-Example") {
-      # Set the value of the header to whatever decision was previously made
-      set req.http.GOVUK-ABTest-Example = req.http.Cookie:ABTest-Example;
-    } else {
-      declare local var.denominator_Example INTEGER;
-      declare local var.denominator_Example_A INTEGER;
-      declare local var.nominator_Example_A INTEGER;
-      set var.nominator_Example_A = std.atoi(table.lookup(example_percentages, "A"));
-      set var.denominator_Example += var.nominator_Example_A;
-      declare local var.denominator_Example_B INTEGER;
-      declare local var.nominator_Example_B INTEGER;
-      set var.nominator_Example_B = std.atoi(table.lookup(example_percentages, "B"));
-      set var.denominator_Example += var.nominator_Example_B;
-      set var.denominator_Example_A = var.denominator_Example;
-      if (randombool(var.nominator_Example_A, var.denominator_Example_A)) {
+  # Begin dynamic section
+  if (req.http.Cookie ~ "cookies_policy" && req.http.Cookie:cookies_policy ~ "%22usage%22:true") {
+    if (table.lookup(active_ab_tests, "Example") == "true") {
+      if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
         set req.http.GOVUK-ABTest-Example = "A";
-      } else {
+      } else if (req.url ~ "[\?\&]ABTest-Example=A(&|$)") {
+        # Some users, such as remote testers, will be given a URL with a query string
+        # to place them into a specific bucket.
+        set req.http.GOVUK-ABTest-Example = "A";
+      } else if (req.url ~ "[\?\&]ABTest-Example=B(&|$)") {
+        # Some users, such as remote testers, will be given a URL with a query string
+        # to place them into a specific bucket.
         set req.http.GOVUK-ABTest-Example = "B";
+      } else if (req.http.Cookie ~ "ABTest-Example") {
+        # Set the value of the header to whatever decision was previously made
+        set req.http.GOVUK-ABTest-Example = req.http.Cookie:ABTest-Example;
+      } else {
+        declare local var.denominator_Example INTEGER;
+        declare local var.denominator_Example_A INTEGER;
+        declare local var.nominator_Example_A INTEGER;
+        set var.nominator_Example_A = std.atoi(table.lookup(example_percentages, "A"));
+        set var.denominator_Example += var.nominator_Example_A;
+        declare local var.denominator_Example_B INTEGER;
+        declare local var.nominator_Example_B INTEGER;
+        set var.nominator_Example_B = std.atoi(table.lookup(example_percentages, "B"));
+        set var.denominator_Example += var.nominator_Example_B;
+        set var.denominator_Example_A = var.denominator_Example;
+        if (randombool(var.nominator_Example_A, var.denominator_Example_A)) {
+          set req.http.GOVUK-ABTest-Example = "A";
+        } else {
+          set req.http.GOVUK-ABTest-Example = "B";
+        }
       }
     }
   }
-}
-# End dynamic section
-
+  # End dynamic section
 
   return(lookup);
 }

--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -306,43 +306,42 @@ sub vcl_recv {
     return(pass);
   }
 
-    # Begin dynamic section
-if (req.http.Cookie ~ "cookies_policy" && req.http.Cookie:cookies_policy ~ "%22usage%22:true") {
-  if (table.lookup(active_ab_tests, "Example") == "true") {
-    if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
-      set req.http.GOVUK-ABTest-Example = "A";
-    } else if (req.url ~ "[\?\&]ABTest-Example=A(&|$)") {
-      # Some users, such as remote testers, will be given a URL with a query string
-      # to place them into a specific bucket.
-      set req.http.GOVUK-ABTest-Example = "A";
-    } else if (req.url ~ "[\?\&]ABTest-Example=B(&|$)") {
-      # Some users, such as remote testers, will be given a URL with a query string
-      # to place them into a specific bucket.
-      set req.http.GOVUK-ABTest-Example = "B";
-    } else if (req.http.Cookie ~ "ABTest-Example") {
-      # Set the value of the header to whatever decision was previously made
-      set req.http.GOVUK-ABTest-Example = req.http.Cookie:ABTest-Example;
-    } else {
-      declare local var.denominator_Example INTEGER;
-      declare local var.denominator_Example_A INTEGER;
-      declare local var.nominator_Example_A INTEGER;
-      set var.nominator_Example_A = std.atoi(table.lookup(example_percentages, "A"));
-      set var.denominator_Example += var.nominator_Example_A;
-      declare local var.denominator_Example_B INTEGER;
-      declare local var.nominator_Example_B INTEGER;
-      set var.nominator_Example_B = std.atoi(table.lookup(example_percentages, "B"));
-      set var.denominator_Example += var.nominator_Example_B;
-      set var.denominator_Example_A = var.denominator_Example;
-      if (randombool(var.nominator_Example_A, var.denominator_Example_A)) {
+  # Begin dynamic section
+  if (req.http.Cookie ~ "cookies_policy" && req.http.Cookie:cookies_policy ~ "%22usage%22:true") {
+    if (table.lookup(active_ab_tests, "Example") == "true") {
+      if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
         set req.http.GOVUK-ABTest-Example = "A";
-      } else {
+      } else if (req.url ~ "[\?\&]ABTest-Example=A(&|$)") {
+        # Some users, such as remote testers, will be given a URL with a query string
+        # to place them into a specific bucket.
+        set req.http.GOVUK-ABTest-Example = "A";
+      } else if (req.url ~ "[\?\&]ABTest-Example=B(&|$)") {
+        # Some users, such as remote testers, will be given a URL with a query string
+        # to place them into a specific bucket.
         set req.http.GOVUK-ABTest-Example = "B";
+      } else if (req.http.Cookie ~ "ABTest-Example") {
+        # Set the value of the header to whatever decision was previously made
+        set req.http.GOVUK-ABTest-Example = req.http.Cookie:ABTest-Example;
+      } else {
+        declare local var.denominator_Example INTEGER;
+        declare local var.denominator_Example_A INTEGER;
+        declare local var.nominator_Example_A INTEGER;
+        set var.nominator_Example_A = std.atoi(table.lookup(example_percentages, "A"));
+        set var.denominator_Example += var.nominator_Example_A;
+        declare local var.denominator_Example_B INTEGER;
+        declare local var.nominator_Example_B INTEGER;
+        set var.nominator_Example_B = std.atoi(table.lookup(example_percentages, "B"));
+        set var.denominator_Example += var.nominator_Example_B;
+        set var.denominator_Example_A = var.denominator_Example;
+        if (randombool(var.nominator_Example_A, var.denominator_Example_A)) {
+          set req.http.GOVUK-ABTest-Example = "A";
+        } else {
+          set req.http.GOVUK-ABTest-Example = "B";
+        }
       }
     }
   }
-}
-# End dynamic section
-
+  # End dynamic section
 
   return(lookup);
 }

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -314,43 +314,42 @@ sub vcl_recv {
     return(pass);
   }
 
-    # Begin dynamic section
-if (req.http.Cookie ~ "cookies_policy" && req.http.Cookie:cookies_policy ~ "%22usage%22:true") {
-  if (table.lookup(active_ab_tests, "Example") == "true") {
-    if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
-      set req.http.GOVUK-ABTest-Example = "A";
-    } else if (req.url ~ "[\?\&]ABTest-Example=A(&|$)") {
-      # Some users, such as remote testers, will be given a URL with a query string
-      # to place them into a specific bucket.
-      set req.http.GOVUK-ABTest-Example = "A";
-    } else if (req.url ~ "[\?\&]ABTest-Example=B(&|$)") {
-      # Some users, such as remote testers, will be given a URL with a query string
-      # to place them into a specific bucket.
-      set req.http.GOVUK-ABTest-Example = "B";
-    } else if (req.http.Cookie ~ "ABTest-Example") {
-      # Set the value of the header to whatever decision was previously made
-      set req.http.GOVUK-ABTest-Example = req.http.Cookie:ABTest-Example;
-    } else {
-      declare local var.denominator_Example INTEGER;
-      declare local var.denominator_Example_A INTEGER;
-      declare local var.nominator_Example_A INTEGER;
-      set var.nominator_Example_A = std.atoi(table.lookup(example_percentages, "A"));
-      set var.denominator_Example += var.nominator_Example_A;
-      declare local var.denominator_Example_B INTEGER;
-      declare local var.nominator_Example_B INTEGER;
-      set var.nominator_Example_B = std.atoi(table.lookup(example_percentages, "B"));
-      set var.denominator_Example += var.nominator_Example_B;
-      set var.denominator_Example_A = var.denominator_Example;
-      if (randombool(var.nominator_Example_A, var.denominator_Example_A)) {
+  # Begin dynamic section
+  if (req.http.Cookie ~ "cookies_policy" && req.http.Cookie:cookies_policy ~ "%22usage%22:true") {
+    if (table.lookup(active_ab_tests, "Example") == "true") {
+      if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
         set req.http.GOVUK-ABTest-Example = "A";
-      } else {
+      } else if (req.url ~ "[\?\&]ABTest-Example=A(&|$)") {
+        # Some users, such as remote testers, will be given a URL with a query string
+        # to place them into a specific bucket.
+        set req.http.GOVUK-ABTest-Example = "A";
+      } else if (req.url ~ "[\?\&]ABTest-Example=B(&|$)") {
+        # Some users, such as remote testers, will be given a URL with a query string
+        # to place them into a specific bucket.
         set req.http.GOVUK-ABTest-Example = "B";
+      } else if (req.http.Cookie ~ "ABTest-Example") {
+        # Set the value of the header to whatever decision was previously made
+        set req.http.GOVUK-ABTest-Example = req.http.Cookie:ABTest-Example;
+      } else {
+        declare local var.denominator_Example INTEGER;
+        declare local var.denominator_Example_A INTEGER;
+        declare local var.nominator_Example_A INTEGER;
+        set var.nominator_Example_A = std.atoi(table.lookup(example_percentages, "A"));
+        set var.denominator_Example += var.nominator_Example_A;
+        declare local var.denominator_Example_B INTEGER;
+        declare local var.nominator_Example_B INTEGER;
+        set var.nominator_Example_B = std.atoi(table.lookup(example_percentages, "B"));
+        set var.denominator_Example += var.nominator_Example_B;
+        set var.denominator_Example_A = var.denominator_Example;
+        if (randombool(var.nominator_Example_A, var.denominator_Example_A)) {
+          set req.http.GOVUK-ABTest-Example = "A";
+        } else {
+          set req.http.GOVUK-ABTest-Example = "B";
+        }
       }
     }
   }
-}
-# End dynamic section
-
+  # End dynamic section
 
   return(lookup);
 }

--- a/spec/test-outputs/www-test.out.vcl
+++ b/spec/test-outputs/www-test.out.vcl
@@ -145,43 +145,42 @@ sub vcl_recv {
     return(pass);
   }
 
-    # Begin dynamic section
-if (req.http.Cookie ~ "cookies_policy" && req.http.Cookie:cookies_policy ~ "%22usage%22:true") {
-  if (table.lookup(active_ab_tests, "Example") == "true") {
-    if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
-      set req.http.GOVUK-ABTest-Example = "A";
-    } else if (req.url ~ "[\?\&]ABTest-Example=A(&|$)") {
-      # Some users, such as remote testers, will be given a URL with a query string
-      # to place them into a specific bucket.
-      set req.http.GOVUK-ABTest-Example = "A";
-    } else if (req.url ~ "[\?\&]ABTest-Example=B(&|$)") {
-      # Some users, such as remote testers, will be given a URL with a query string
-      # to place them into a specific bucket.
-      set req.http.GOVUK-ABTest-Example = "B";
-    } else if (req.http.Cookie ~ "ABTest-Example") {
-      # Set the value of the header to whatever decision was previously made
-      set req.http.GOVUK-ABTest-Example = req.http.Cookie:ABTest-Example;
-    } else {
-      declare local var.denominator_Example INTEGER;
-      declare local var.denominator_Example_A INTEGER;
-      declare local var.nominator_Example_A INTEGER;
-      set var.nominator_Example_A = std.atoi(table.lookup(example_percentages, "A"));
-      set var.denominator_Example += var.nominator_Example_A;
-      declare local var.denominator_Example_B INTEGER;
-      declare local var.nominator_Example_B INTEGER;
-      set var.nominator_Example_B = std.atoi(table.lookup(example_percentages, "B"));
-      set var.denominator_Example += var.nominator_Example_B;
-      set var.denominator_Example_A = var.denominator_Example;
-      if (randombool(var.nominator_Example_A, var.denominator_Example_A)) {
+  # Begin dynamic section
+  if (req.http.Cookie ~ "cookies_policy" && req.http.Cookie:cookies_policy ~ "%22usage%22:true") {
+    if (table.lookup(active_ab_tests, "Example") == "true") {
+      if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
         set req.http.GOVUK-ABTest-Example = "A";
-      } else {
+      } else if (req.url ~ "[\?\&]ABTest-Example=A(&|$)") {
+        # Some users, such as remote testers, will be given a URL with a query string
+        # to place them into a specific bucket.
+        set req.http.GOVUK-ABTest-Example = "A";
+      } else if (req.url ~ "[\?\&]ABTest-Example=B(&|$)") {
+        # Some users, such as remote testers, will be given a URL with a query string
+        # to place them into a specific bucket.
         set req.http.GOVUK-ABTest-Example = "B";
+      } else if (req.http.Cookie ~ "ABTest-Example") {
+        # Set the value of the header to whatever decision was previously made
+        set req.http.GOVUK-ABTest-Example = req.http.Cookie:ABTest-Example;
+      } else {
+        declare local var.denominator_Example INTEGER;
+        declare local var.denominator_Example_A INTEGER;
+        declare local var.nominator_Example_A INTEGER;
+        set var.nominator_Example_A = std.atoi(table.lookup(example_percentages, "A"));
+        set var.denominator_Example += var.nominator_Example_A;
+        declare local var.denominator_Example_B INTEGER;
+        declare local var.nominator_Example_B INTEGER;
+        set var.nominator_Example_B = std.atoi(table.lookup(example_percentages, "B"));
+        set var.denominator_Example += var.nominator_Example_B;
+        set var.denominator_Example_A = var.denominator_Example;
+        if (randombool(var.nominator_Example_A, var.denominator_Example_A)) {
+          set req.http.GOVUK-ABTest-Example = "A";
+        } else {
+          set req.http.GOVUK-ABTest-Example = "B";
+        }
       }
     }
   }
-}
-# End dynamic section
-
+  # End dynamic section
 
   return(lookup);
 }

--- a/spec/vcl_generation_spec.rb
+++ b/spec/vcl_generation_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe "VCL generation" do
                            when "bouncer"
                              { app_domain: "test.gov.uk", service_id: "12345" }
                            else
-                             { environment: environment, config: config, version: "unused variable", ab_tests: ab_tests }
+                             { configuration: service, environment: environment, config: config, version: "unused variable", ab_tests: ab_tests }
                            end
 
       it "renders the #{service} VCL for #{environment} correctly" do

--- a/spec/vcl_generation_spec.rb
+++ b/spec/vcl_generation_spec.rb
@@ -23,15 +23,23 @@ RSpec.describe "VCL generation" do
     "probe" => "/",
   }
 
+  ab_tests = YAML.load_file(File.join(__dir__, "..", "ab_tests", "ab_tests.yaml"))
+
   Dir.glob("vcl_templates/*.erb").each do |template|
     service = template.sub("vcl_templates/", "").sub(".vcl.erb", "")
     next if service[0] == "_" # Skip partials
-    next if service == "bouncer" # Bouncer is not deployed from this repo
     next if service == "test" # For another test
 
     %w[production staging integration test].each do |environment|
+      template_variables = case service
+                           when "bouncer"
+                             { app_domain: "test.gov.uk", service_id: "12345" }
+                           else
+                             { environment: environment, config: config, version: "unused variable", ab_tests: ab_tests }
+                           end
+
       it "renders the #{service} VCL for #{environment} correctly" do
-        generated_vcl = RenderTemplate.render_template(service, environment, config, "unused variable")
+        generated_vcl = RenderTemplate.call(service, locals: template_variables)
         expected_vcl_filename = "spec/test-outputs/#{service}-#{environment}.out.vcl"
 
         if ENV["REGENERATE_EXPECTATIONS"]

--- a/spec/www_vcl_erb_spec.rb
+++ b/spec/www_vcl_erb_spec.rb
@@ -18,44 +18,21 @@ RSpec.describe "VCL template" do
   let!(:environment) { "test" }
   let!(:ab_tests) { [{ "ATest" => %w[meh boom] }, { "Example" => %w[A B] }] }
 
-  subject do
-    template_path = File.join(cwd, "../vcl_templates/www.vcl.erb")
-    @rendered_vcl ||= ERB.new(File.new(template_path).read, trim_mode: "-", eoutvar: "_test_erbout").result(binding)
+  subject(:rendered) do
+    RenderTemplate.call("www", locals: { config: config, environment: environment, ab_tests: ab_tests })
   end
 
   it "renders the AB tests partial" do
-    expect(subject).to include(%(set req.http.GOVUK-ABTest-ATest = \"meh\";))
+    expect(rendered).to include(%(set req.http.GOVUK-ABTest-ATest = \"meh\";))
   end
 
   it "renders the expiry statements" do
     statement = %(set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "ATest"))));)
-    expect(subject).to include(statement)
+    expect(rendered).to include(statement)
   end
 
   it "doesn't set a cookie for the 'Example' test" do
-    expect(subject).not_to include(%(add resp.http.Set-Cookie = "ABTest-<%= test %>=))
-  end
-end
-
-describe "AB Tests partial" do
-  let(:expected) do
-    @expected ||= File.new(File.join(cwd, "fixtures/_multivariate_tests.vcl.erb.out")).read
-  end
-
-  let!(:ab_tests) do
-    [
-      { "MyTest" => %w[foo bar] },
-      { "YourTest" => %w[variant1 variant2 variant3 variant4] },
-    ]
-  end
-
-  subject do
-    partial_path = File.join(cwd, "../vcl_templates/_multivariate_tests.vcl.erb")
-    @rendered ||= ERB.new(File.new(partial_path).read, trim_mode: "-").result(binding)
-  end
-
-  it "renders ab test output for each test in the configuration" do
-    expect(subject).to eq(expected)
+    expect(rendered).not_to include(%(add resp.http.Set-Cookie = "ABTest-<%= test %>=))
   end
 end
 

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -412,8 +412,7 @@ sub vcl_recv {
     return(pass);
   }
 
-  <% template_path = File.join(File.dirname(__FILE__), "vcl_templates/_multivariate_tests.vcl.erb") -%>
-  <%= ERB.new(File.new(template_path).read, nil, "-", "_erbout2").result(binding) %>
+<%= render_partial("multivariate_tests", indentation: "  ", locals: { ab_tests: ab_tests }) %>
 
   return(lookup);
 }


### PR DESCRIPTION
⚠️ The changes need to be deployed manually to all relevant environments. Follow the guidance on [how to deploy Fastly](https://docs.publishing.service.gov.uk/manual/cdn.html#deploying-fastly).

This reintroduces the reverted code from https://github.com/alphagov/govuk-cdn-config/pull/420 and fixes the issue that blocked it - which was the introduction of a new variable configuration into the template from https://github.com/alphagov/govuk-cdn-config/pull/419

As https://github.com/alphagov/govuk-cdn-config/pull/420 was already reviewed it's easiest to review this PR by looking at just the 2nd commit.