### PR TITLE
Stop setting http_host for requests to assets-origin

### DIFF
--- a/spec/test-outputs/assets-eks-integration.out.vcl
+++ b/spec/test-outputs/assets-eks-integration.out.vcl
@@ -74,7 +74,6 @@ sub vcl_recv {
   # Default backend.
   set req.backend = F_awsorigin;
   set req.http.Fastly-Backend-Name = "awsorigin";
-  set req.http.host = "foo";
 
   
 

--- a/spec/test-outputs/assets-eks-production.out.vcl
+++ b/spec/test-outputs/assets-eks-production.out.vcl
@@ -173,7 +173,6 @@ sub vcl_recv {
   # Default backend.
   set req.backend = F_awsorigin;
   set req.http.Fastly-Backend-Name = "awsorigin";
-  set req.http.host = "foo";
 
   
 

--- a/spec/test-outputs/assets-eks-staging.out.vcl
+++ b/spec/test-outputs/assets-eks-staging.out.vcl
@@ -173,7 +173,6 @@ sub vcl_recv {
   # Default backend.
   set req.backend = F_awsorigin;
   set req.http.Fastly-Backend-Name = "awsorigin";
-  set req.http.host = "foo";
 
   
 

--- a/spec/test-outputs/assets-eks-test.out.vcl
+++ b/spec/test-outputs/assets-eks-test.out.vcl
@@ -74,7 +74,6 @@ sub vcl_recv {
   # Default backend.
   set req.backend = F_awsorigin;
   set req.http.Fastly-Backend-Name = "awsorigin";
-  set req.http.host = "foo";
 
   
 

--- a/spec/test-outputs/assets-integration.out.vcl
+++ b/spec/test-outputs/assets-integration.out.vcl
@@ -74,7 +74,6 @@ sub vcl_recv {
   # Default backend.
   set req.backend = F_awsorigin;
   set req.http.Fastly-Backend-Name = "awsorigin";
-  set req.http.host = "foo";
 
   
 

--- a/spec/test-outputs/assets-production.out.vcl
+++ b/spec/test-outputs/assets-production.out.vcl
@@ -173,7 +173,6 @@ sub vcl_recv {
   # Default backend.
   set req.backend = F_awsorigin;
   set req.http.Fastly-Backend-Name = "awsorigin";
-  set req.http.host = "foo";
 
   
 

--- a/spec/test-outputs/assets-staging.out.vcl
+++ b/spec/test-outputs/assets-staging.out.vcl
@@ -173,7 +173,6 @@ sub vcl_recv {
   # Default backend.
   set req.backend = F_awsorigin;
   set req.http.Fastly-Backend-Name = "awsorigin";
-  set req.http.host = "foo";
 
   
 

--- a/spec/test-outputs/assets-test.out.vcl
+++ b/spec/test-outputs/assets-test.out.vcl
@@ -74,7 +74,6 @@ sub vcl_recv {
   # Default backend.
   set req.backend = F_awsorigin;
   set req.http.Fastly-Backend-Name = "awsorigin";
-  set req.http.host = "foo";
 
   
 

--- a/vcl_templates/assets.vcl.erb
+++ b/vcl_templates/assets.vcl.erb
@@ -178,7 +178,6 @@ sub vcl_recv {
   # Default backend.
   set req.backend = F_awsorigin;
   set req.http.Fastly-Backend-Name = "awsorigin";
-  set req.http.host = "<%= config.fetch('aws_origin_hostname') %>";
 
   <% if %w(staging production).include?(environment) %>
 


### PR DESCRIPTION
This change depends on a corresponding Puppet PR [1]

This removes the setting of a HTTP Host header for when Fastly is
proxying to origin. This was previously needed because there wasn't
vhosts configured for the integration and staging asset hosts, so
proxying to them would fail.

It's not necessarily bad that we change the host here, my motivation is
more based on consistency as this is behaviour we don't follow in our
other CDN configs (www and bouncer). I believe this inconsistency
contributed to a recent incident [2] and thus believe that resolving it
we reduce the risk of further surprises caused by quirky configuration.

[1]: https://github.com/alphagov/govuk-puppet/pull/11871
[2]: https://docs.google.com/document/d/18kIgL2F0PPCZSjSCLH5z0hOq3Gn8wmCwxrlR1bOPric/edit#heading=h.e85n7w4jfehw


⚠️ The changes need to be deployed manually to all relevant environments. Follow the guidance on [how to deploy Fastly](https://docs.publishing.service.gov.uk/manual/cdn.html#deploying-fastly).
