### PR TITLE
Enable traffic split for asset services

### DIFF
--- a/spec/test-outputs/assets-eks-integration.out.vcl
+++ b/spec/test-outputs/assets-eks-integration.out.vcl
@@ -32,6 +32,8 @@ backend F_awsorigin {
 
 
 
+
+
 acl purge_ip_allowlist {
 }
 

--- a/spec/test-outputs/assets-eks-production.out.vcl
+++ b/spec/test-outputs/assets-eks-production.out.vcl
@@ -31,6 +31,8 @@ backend F_awsorigin {
 }
 
 
+
+
 # Mirror backend for S3
 backend F_mirrorS3 {
     .connect_timeout = 1s;

--- a/spec/test-outputs/assets-eks-staging.out.vcl
+++ b/spec/test-outputs/assets-eks-staging.out.vcl
@@ -31,6 +31,8 @@ backend F_awsorigin {
 }
 
 
+
+
 # Mirror backend for S3
 backend F_mirrorS3 {
     .connect_timeout = 1s;

--- a/spec/test-outputs/assets-eks-test.out.vcl
+++ b/spec/test-outputs/assets-eks-test.out.vcl
@@ -32,6 +32,8 @@ backend F_awsorigin {
 
 
 
+
+
 acl purge_ip_allowlist {
 }
 

--- a/spec/test-outputs/assets-integration.out.vcl
+++ b/spec/test-outputs/assets-integration.out.vcl
@@ -32,6 +32,8 @@ backend F_awsorigin {
 
 
 
+
+
 acl purge_ip_allowlist {
 }
 

--- a/spec/test-outputs/assets-production.out.vcl
+++ b/spec/test-outputs/assets-production.out.vcl
@@ -31,6 +31,8 @@ backend F_awsorigin {
 }
 
 
+
+
 # Mirror backend for S3
 backend F_mirrorS3 {
     .connect_timeout = 1s;

--- a/spec/test-outputs/assets-staging.out.vcl
+++ b/spec/test-outputs/assets-staging.out.vcl
@@ -31,6 +31,8 @@ backend F_awsorigin {
 }
 
 
+
+
 # Mirror backend for S3
 backend F_mirrorS3 {
     .connect_timeout = 1s;

--- a/spec/test-outputs/assets-test.out.vcl
+++ b/spec/test-outputs/assets-test.out.vcl
@@ -32,6 +32,8 @@ backend F_awsorigin {
 
 
 
+
+
 acl purge_ip_allowlist {
 }
 

--- a/vcl_templates/assets.vcl.erb
+++ b/vcl_templates/assets.vcl.erb
@@ -35,6 +35,50 @@ backend F_awsorigin {
       }
 }
 
+<%- if config['replatforming_traffic_split'] %>
+backend F_eks_origin {
+    .connect_timeout = 5s;
+    .dynamic = true;
+    .port = "443";
+    .host = "<%= config.fetch('eks_origin_hostname') %>";
+    .first_byte_timeout = 15s;
+    .max_connections = 200;
+    .between_bytes_timeout = 10s;
+    .share_key = "<%= config.fetch('service_id') %>";
+
+    .ssl = true;
+    .ssl_check_cert = <%= config['disable_tls_validation'] ? 'never' : 'always' %>;
+    .min_tls_version = "<%= config.fetch('min_tls_version', '1.2') %>";
+    <%- if config['ssl_ciphers'] -%>
+    .ssl_ciphers = "<%= config['ssl_ciphers'] -%>";
+    <%- end -%>
+    .ssl_cert_hostname = "<%= config.fetch('aws_ssl_cert_hostname', config.fetch('eks_origin_hostname')) %>";
+    .ssl_sni_hostname = "<%= config.fetch('aws_ssl_sni_hostname', config.fetch('eks_origin_hostname')) %>";
+
+    .probe = {
+        .request =
+            "HEAD /__canary__ HTTP/1.1"
+            "Host: <%= config.fetch('eks_origin_hostname') %>"
+            "User-Agent: Fastly healthcheck (git version: <%= config['git_version'] %>)"
+<% if config['rate_limit_token'] %>
+            "Rate-Limit-Token: <%= config['rate_limit_token'] %>"
+<% end %>
+            "Connection: close";
+        .threshold = 1;
+        .window = 2;
+        .timeout = 5s;
+        .initial = 1;
+        .expected_response = 200;
+        .interval = 10s;
+      }
+}
+
+director D_traffic_split client {
+    { .backend = F_awsorigin; .weight = 19; }
+    { .backend = F_eks_origin; .weight = 1; }
+}
+<%- end %>
+
 <% if %w(staging production).include?(environment) %>
 # Mirror backend for S3
 backend F_mirrorS3 {
@@ -176,7 +220,7 @@ sub vcl_recv {
   set req.grace = 24h;
 
   # Default backend.
-  set req.backend = F_awsorigin;
+  set req.backend = <%= config['replatforming_traffic_split'] ? 'D_traffic_split' : 'F_awsorigin' %>;
   set req.http.Fastly-Backend-Name = "awsorigin";
 
   <% if %w(staging production).include?(environment) %>


### PR DESCRIPTION
This adds config to enable split traffic for the asset services to send traffic to the EKS cluster. This is to be used for our live traffic experiments.
