### PR TITLE
Use max weight to start traffic split

### DIFF
--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -84,7 +84,7 @@ backend F_eks_origin {
 }
 
 director D_traffic_split client {
-  { .backend = F_origin; .weight = 19; }
+  { .backend = F_origin; .weight = 1000000; }
   { .backend = F_eks_origin; .weight = 1; }
 }
 <%- end %>


### PR DESCRIPTION
To test the fastly config change whether it causes initial set of errors.

⚠️ The changes need to be deployed manually to all relevant environments. Follow the guidance on [how to deploy Fastly](https://docs.publishing.service.gov.uk/manual/cdn.html#deploying-fastly).
