### PR TITLE
Set traffic split for www and assets to 10%

### DIFF
--- a/vcl_templates/assets.vcl.erb
+++ b/vcl_templates/assets.vcl.erb
@@ -74,7 +74,7 @@ backend F_eks_origin {
 }
 
 director D_traffic_split client {
-    { .backend = F_awsorigin; .weight = 19; }
+    { .backend = F_awsorigin; .weight = 9; }
     { .backend = F_eks_origin; .weight = 1; }
 }
 <%- end %>

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -84,7 +84,7 @@ backend F_eks_origin {
 }
 
 director D_traffic_split client {
-  { .backend = F_origin; .weight = 19; }
+  { .backend = F_origin; .weight = 9; }
   { .backend = F_eks_origin; .weight = 1; }
 }
 <%- end %>


### PR DESCRIPTION
⚠️ The changes need to be deployed manually to all relevant environments. Follow the guidance on [how to deploy Fastly](https://docs.publishing.service.gov.uk/manual/cdn.html#deploying-fastly).
