### PR TITLE
Set traffic split ratio to 1:1

### DIFF
--- a/vcl_templates/assets.vcl.erb
+++ b/vcl_templates/assets.vcl.erb
@@ -75,7 +75,7 @@ backend F_eks_origin {
 
 director D_traffic_split client {
     { .backend = F_awsorigin; .weight = 1; }
-    { .backend = F_eks_origin; .weight = 999; }
+    { .backend = F_eks_origin; .weight = 1; }
 }
 <%- end %>
 

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -85,7 +85,7 @@ backend F_eks_origin {
 
 director D_traffic_split client {
   { .backend = F_origin; .weight = 1; }
-  { .backend = F_eks_origin; .weight = 999; }
+  { .backend = F_eks_origin; .weight = 1; }
 }
 <%- end %>
 


### PR DESCRIPTION
⚠️ The changes need to be deployed manually to all relevant environments. Follow the guidance on [how to deploy Fastly](https://docs.publishing.service.gov.uk/manual/cdn.html#deploying-fastly).
