### PR TITLE
Use healthcheck hostname for probes instead of origin hostname for EKS backend

### DIFF
--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -64,7 +64,7 @@ backend F_eks_origin {
     .probe = {
         .request =
             "HEAD <%= config['probe'] %> HTTP/1.1"
-            "Host: <%= config.fetch('origin_hostname') %>"
+            "Host: <%= config.fetch('healthcheck_hostname', config['eks_origin_hostname']) %>"
             "User-Agent: Fastly healthcheck (git version: <%= config['git_version'] %>)"
 <% if config['rate_limit_token'] -%>
             "Rate-Limit-Token: <%= config['rate_limit_token'] %>"


### PR DESCRIPTION
⚠️ The changes need to be deployed manually to all relevant environments. Follow the guidance on [how to deploy Fastly](https://docs.publishing.service.gov.uk/manual/cdn.html#deploying-fastly).
