### PR TITLE
Strip cookies after using setting up A/B test

### DIFF
--- a/spec/test-outputs/www-eks-integration.out.vcl
+++ b/spec/test-outputs/www-eks-integration.out.vcl
@@ -200,6 +200,7 @@ sub vcl_recv {
   }
   # End dynamic section
 
+
   return(lookup);
 }
 

--- a/spec/test-outputs/www-eks-production.out.vcl
+++ b/spec/test-outputs/www-eks-production.out.vcl
@@ -369,6 +369,7 @@ sub vcl_recv {
   }
   # End dynamic section
 
+
   return(lookup);
 }
 

--- a/spec/test-outputs/www-eks-staging.out.vcl
+++ b/spec/test-outputs/www-eks-staging.out.vcl
@@ -369,6 +369,7 @@ sub vcl_recv {
   }
   # End dynamic section
 
+
   return(lookup);
 }
 

--- a/spec/test-outputs/www-eks-test.out.vcl
+++ b/spec/test-outputs/www-eks-test.out.vcl
@@ -200,6 +200,7 @@ sub vcl_recv {
   }
   # End dynamic section
 
+
   return(lookup);
 }
 

--- a/spec/test-outputs/www-integration.out.vcl
+++ b/spec/test-outputs/www-integration.out.vcl
@@ -200,6 +200,7 @@ sub vcl_recv {
   }
   # End dynamic section
 
+
   return(lookup);
 }
 

--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -361,6 +361,7 @@ sub vcl_recv {
   }
   # End dynamic section
 
+
   return(lookup);
 }
 

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -369,6 +369,7 @@ sub vcl_recv {
   }
   # End dynamic section
 
+
   return(lookup);
 }
 

--- a/spec/test-outputs/www-test.out.vcl
+++ b/spec/test-outputs/www-test.out.vcl
@@ -200,6 +200,7 @@ sub vcl_recv {
   }
   # End dynamic section
 
+
   return(lookup);
 }
 

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -384,17 +384,6 @@ sub vcl_recv {
     set req.http.Authorization = "Basic <%= config['basic_authentication'] %>";
   }
 <% end -%>
-<% if config['origin_hostname'].include? "eks" -%>
-  # Strip cookies from inbound requests. Corresponding rule in vcl_fetch{}
-  # For simplicity and security most applications should not use cookies.
-  # With the exception of:
-  #   - Licensing
-  #   - email-alert-frontend (for subscription management)
-  #   - sign-in (digital identity) callback
-  if (req.url !~ "^/(apply-for-a-licence|email|sign-in/callback)") {
-    unset req.http.Cookie;
-  }
-<% end -%>
 #FASTLY recv
 
   # GOV.UK accounts
@@ -416,6 +405,18 @@ sub vcl_recv {
   }
 
 <%= render_partial("multivariate_tests", indentation: "  ", locals: { ab_tests: ab_tests }) %>
+
+<% if config['origin_hostname'].include? "eks" -%>
+  # Strip cookies from inbound requests. Corresponding rule in vcl_fetch{}
+  # For simplicity and security most applications should not use cookies.
+  # With the exception of:
+  #   - Licensing
+  #   - email-alert-frontend (for subscription management)
+  #   - sign-in (digital identity) callback
+  if (req.url !~ "^/(apply-for-a-licence|email|sign-in/callback)") {
+    unset req.http.Cookie;
+  }
+<% end -%>
 
   return(lookup);
 }


### PR DESCRIPTION
This moves the logic to strip cookie after the logic for setting up the A/B test in the recv vcl routine. This is because the A/B tests need access to the cookie to understand whether a user has already been assigned a variant.
