### PR TITLE
Add EKS egress addresses to cache purge ACLs.

### DIFF
--- a/spec/test-outputs/assets-eks-integration.out.vcl
+++ b/spec/test-outputs/assets-eks-integration.out.vcl
@@ -35,6 +35,12 @@ backend F_awsorigin {
 
 
 acl purge_ip_allowlist {
+  "34.248.229.46";  # AWS Integration NAT gateways
+  "34.248.44.175";
+  "52.51.97.232";
+  "18.203.77.149";  # EKS Integration NAT gateways
+  "52.212.155.150";
+  "18.202.190.16";
 }
 
 sub vcl_recv {

--- a/spec/test-outputs/assets-eks-production.out.vcl
+++ b/spec/test-outputs/assets-eks-production.out.vcl
@@ -131,9 +131,12 @@ backend F_mirrorGCS {
 
 
 acl purge_ip_allowlist {
-  "18.202.136.43";    # AWS Production
-  "34.246.209.74";    # AWS Production
-  "34.253.57.8";      # AWS Production
+  "18.202.136.43";   # AWS Production NAT gateways
+  "34.246.209.74";
+  "34.253.57.8";
+  "63.33.241.191";   # EKS Production NAT gateways
+  "52.208.193.230";
+  "54.220.6.200";
 }
 
 sub vcl_recv {

--- a/spec/test-outputs/assets-eks-staging.out.vcl
+++ b/spec/test-outputs/assets-eks-staging.out.vcl
@@ -131,9 +131,12 @@ backend F_mirrorGCS {
 
 
 acl purge_ip_allowlist {
-  "18.203.108.248";   # AWS Staging
-  "18.202.183.143";   # AWS Staging
-  "18.203.90.80";     # AWS Staging
+  "18.203.108.248";  # AWS Staging NAT gateways
+  "18.202.183.143";
+  "18.203.90.80";
+  "54.246.115.159";  # EKS Staging NAT gateways
+  "54.220.171.242";
+  "54.228.115.164";
 }
 
 sub vcl_recv {

--- a/spec/test-outputs/assets-integration.out.vcl
+++ b/spec/test-outputs/assets-integration.out.vcl
@@ -35,6 +35,12 @@ backend F_awsorigin {
 
 
 acl purge_ip_allowlist {
+  "34.248.229.46";  # AWS Integration NAT gateways
+  "34.248.44.175";
+  "52.51.97.232";
+  "18.203.77.149";  # EKS Integration NAT gateways
+  "52.212.155.150";
+  "18.202.190.16";
 }
 
 sub vcl_recv {

--- a/spec/test-outputs/assets-production.out.vcl
+++ b/spec/test-outputs/assets-production.out.vcl
@@ -131,9 +131,12 @@ backend F_mirrorGCS {
 
 
 acl purge_ip_allowlist {
-  "18.202.136.43";    # AWS Production
-  "34.246.209.74";    # AWS Production
-  "34.253.57.8";      # AWS Production
+  "18.202.136.43";   # AWS Production NAT gateways
+  "34.246.209.74";
+  "34.253.57.8";
+  "63.33.241.191";   # EKS Production NAT gateways
+  "52.208.193.230";
+  "54.220.6.200";
 }
 
 sub vcl_recv {

--- a/spec/test-outputs/assets-staging.out.vcl
+++ b/spec/test-outputs/assets-staging.out.vcl
@@ -131,9 +131,12 @@ backend F_mirrorGCS {
 
 
 acl purge_ip_allowlist {
-  "18.203.108.248";   # AWS Staging
-  "18.202.183.143";   # AWS Staging
-  "18.203.90.80";     # AWS Staging
+  "18.203.108.248";  # AWS Staging NAT gateways
+  "18.202.183.143";
+  "18.203.90.80";
+  "54.246.115.159";  # EKS Staging NAT gateways
+  "54.220.171.242";
+  "54.228.115.164";
 }
 
 sub vcl_recv {

--- a/spec/test-outputs/mirror-integration.out.vcl
+++ b/spec/test-outputs/mirror-integration.out.vcl
@@ -32,9 +32,12 @@ backend F_origin {
 
 
 acl purge_ip_allowlist {
-  "34.248.229.46";    # AWS Integration NAT gateway
-  "34.248.44.175";    # AWS Integration NAT gateway
-  "52.51.97.232";     # AWS Integration NAT gateway
+  "34.248.229.46";  # AWS Integration NAT gateways
+  "34.248.44.175";
+  "52.51.97.232";
+  "18.203.77.149";  # EKS Integration NAT gateways
+  "52.212.155.150";
+  "18.202.190.16";
 }
 
 acl allowed_ip_addresses {

--- a/spec/test-outputs/mirror-production.out.vcl
+++ b/spec/test-outputs/mirror-production.out.vcl
@@ -128,9 +128,12 @@ backend F_mirrorGCS {
 
 
 acl purge_ip_allowlist {
-  "34.246.209.74";    # AWS NAT GW1
-  "34.253.57.8";      # AWS NAT GW2
-  "18.202.136.43";    # AWS NAT GW3
+  "18.202.136.43";   # AWS Production NAT gateways
+  "34.246.209.74";
+  "34.253.57.8";
+  "63.33.241.191";   # EKS Production NAT gateways
+  "52.208.193.230";
+  "54.220.6.200";
 }
 
 acl allowed_ip_addresses {

--- a/spec/test-outputs/mirror-staging.out.vcl
+++ b/spec/test-outputs/mirror-staging.out.vcl
@@ -128,9 +128,12 @@ backend F_mirrorGCS {
 
 
 acl purge_ip_allowlist {
-  "18.202.183.143";   # AWS NAT GW1
-  "18.203.90.80";     # AWS NAT GW2
-  "18.203.108.248";   # AWS NAT GW3
+  "18.203.108.248";  # AWS Staging NAT gateways
+  "18.202.183.143";
+  "18.203.90.80";
+  "54.246.115.159";  # EKS Staging NAT gateways
+  "54.220.171.242";
+  "54.228.115.164";
 }
 
 acl allowed_ip_addresses {

--- a/vcl_templates/assets.vcl.erb
+++ b/vcl_templates/assets.vcl.erb
@@ -187,14 +187,27 @@ backend F_mirrorGCS {
 <% end %>
 
 acl purge_ip_allowlist {
-<%- if environment.start_with? 'staging' -%>
-  "18.203.108.248";   # AWS Staging
-  "18.202.183.143";   # AWS Staging
-  "18.203.90.80";     # AWS Staging
+<%- if environment.start_with? 'integration' -%>
+  "34.248.229.46";  # AWS Integration NAT gateways
+  "34.248.44.175";
+  "52.51.97.232";
+  "18.203.77.149";  # EKS Integration NAT gateways
+  "52.212.155.150";
+  "18.202.190.16";
+<%- elsif environment.start_with? 'staging' -%>
+  "18.203.108.248";  # AWS Staging NAT gateways
+  "18.202.183.143";
+  "18.203.90.80";
+  "54.246.115.159";  # EKS Staging NAT gateways
+  "54.220.171.242";
+  "54.228.115.164";
 <%- elsif environment.start_with? 'production' -%>
-  "18.202.136.43";    # AWS Production
-  "34.246.209.74";    # AWS Production
-  "34.253.57.8";      # AWS Production
+  "18.202.136.43";   # AWS Production NAT gateways
+  "34.246.209.74";
+  "34.253.57.8";
+  "63.33.241.191";   # EKS Production NAT gateways
+  "52.208.193.230";
+  "54.220.6.200";
 <%- end -%>
 }
 

--- a/vcl_templates/mirror.vcl.erb
+++ b/vcl_templates/mirror.vcl.erb
@@ -147,17 +147,26 @@ backend F_mirrorGCS {
 
 acl purge_ip_allowlist {
 <%- if environment.start_with? 'integration' -%>
-  "34.248.229.46";    # AWS Integration NAT gateway
-  "34.248.44.175";    # AWS Integration NAT gateway
-  "52.51.97.232";     # AWS Integration NAT gateway
+  "34.248.229.46";  # AWS Integration NAT gateways
+  "34.248.44.175";
+  "52.51.97.232";
+  "18.203.77.149";  # EKS Integration NAT gateways
+  "52.212.155.150";
+  "18.202.190.16";
 <%- elsif environment.start_with? 'staging' -%>
-  "18.202.183.143";   # AWS NAT GW1
-  "18.203.90.80";     # AWS NAT GW2
-  "18.203.108.248";   # AWS NAT GW3
+  "18.203.108.248";  # AWS Staging NAT gateways
+  "18.202.183.143";
+  "18.203.90.80";
+  "54.246.115.159";  # EKS Staging NAT gateways
+  "54.220.171.242";
+  "54.228.115.164";
 <%- elsif environment.start_with? 'production' -%>
-  "34.246.209.74";    # AWS NAT GW1
-  "34.253.57.8";      # AWS NAT GW2
-  "18.202.136.43";    # AWS NAT GW3
+  "18.202.136.43";   # AWS Production NAT gateways
+  "34.246.209.74";
+  "34.253.57.8";
+  "63.33.241.191";   # EKS Production NAT gateways
+  "52.208.193.230";
+  "54.220.6.200";
 <%- end -%>
 }
 


### PR DESCRIPTION
Deployment: needs manual rollout; see [playbook](https://docs.publishing.service.gov.uk/manual/cdn.html#deploying-fastly).