### PR TITLE
Add security.txt to the assets and bouncer services

### DIFF
--- a/spec/test-outputs/assets-eks-production.out.vcl
+++ b/spec/test-outputs/assets-eks-production.out.vcl
@@ -177,6 +177,11 @@ sub vcl_recv {
      error 801 "Force SSL";
   }
 
+  # Redirect to security.txt for "/.well-known/security.txt" or "/security.txt"
+  if (req.url.path ~ "(?i)^(?:/\.well[-_]known)?/security\.txt$") {
+    error 805 "security.txt";
+  }
+
   # Serve from stale for 24 hours if origin is sick
   set req.grace = 24h;
 
@@ -323,6 +328,16 @@ sub vcl_error {
     set obj.status = 301;
     set obj.response = "Moved Permanently";
     set obj.http.Location = "https://" req.http.host req.url;
+    synthetic {""};
+    return (deliver);
+  }
+
+# Error 805
+  # 302 redirect to vdp.cabinetoffice.gov.uk called from vcl_recv.
+  if (obj.status == 805) {
+    set obj.status = 302;
+    set obj.http.Location = "https://vdp.cabinetoffice.gov.uk/.well-known/security.txt";
+    set obj.response = "Moved";
     synthetic {""};
     return (deliver);
   }

--- a/spec/test-outputs/assets-eks-staging.out.vcl
+++ b/spec/test-outputs/assets-eks-staging.out.vcl
@@ -177,6 +177,11 @@ sub vcl_recv {
      error 801 "Force SSL";
   }
 
+  # Redirect to security.txt for "/.well-known/security.txt" or "/security.txt"
+  if (req.url.path ~ "(?i)^(?:/\.well[-_]known)?/security\.txt$") {
+    error 805 "security.txt";
+  }
+
   # Serve from stale for 24 hours if origin is sick
   set req.grace = 24h;
 
@@ -323,6 +328,16 @@ sub vcl_error {
     set obj.status = 301;
     set obj.response = "Moved Permanently";
     set obj.http.Location = "https://" req.http.host req.url;
+    synthetic {""};
+    return (deliver);
+  }
+
+# Error 805
+  # 302 redirect to vdp.cabinetoffice.gov.uk called from vcl_recv.
+  if (obj.status == 805) {
+    set obj.status = 302;
+    set obj.http.Location = "https://vdp.cabinetoffice.gov.uk/.well-known/security.txt";
+    set obj.response = "Moved";
     synthetic {""};
     return (deliver);
   }

--- a/spec/test-outputs/assets-eks-test.out.vcl
+++ b/spec/test-outputs/assets-eks-test.out.vcl
@@ -75,6 +75,11 @@ sub vcl_recv {
      error 801 "Force SSL";
   }
 
+  # Redirect to security.txt for "/.well-known/security.txt" or "/security.txt"
+  if (req.url.path ~ "(?i)^(?:/\.well[-_]known)?/security\.txt$") {
+    error 805 "security.txt";
+  }
+
   # Serve from stale for 24 hours if origin is sick
   set req.grace = 24h;
 
@@ -170,6 +175,16 @@ sub vcl_error {
     set obj.status = 301;
     set obj.response = "Moved Permanently";
     set obj.http.Location = "https://" req.http.host req.url;
+    synthetic {""};
+    return (deliver);
+  }
+
+# Error 805
+  # 302 redirect to vdp.cabinetoffice.gov.uk called from vcl_recv.
+  if (obj.status == 805) {
+    set obj.status = 302;
+    set obj.http.Location = "https://vdp.cabinetoffice.gov.uk/.well-known/security.txt";
+    set obj.response = "Moved";
     synthetic {""};
     return (deliver);
   }

--- a/spec/test-outputs/assets-production.out.vcl
+++ b/spec/test-outputs/assets-production.out.vcl
@@ -177,6 +177,11 @@ sub vcl_recv {
      error 801 "Force SSL";
   }
 
+  # Redirect to security.txt for "/.well-known/security.txt" or "/security.txt"
+  if (req.url.path ~ "(?i)^(?:/\.well[-_]known)?/security\.txt$") {
+    error 805 "security.txt";
+  }
+
   # Serve from stale for 24 hours if origin is sick
   set req.grace = 24h;
 
@@ -323,6 +328,16 @@ sub vcl_error {
     set obj.status = 301;
     set obj.response = "Moved Permanently";
     set obj.http.Location = "https://" req.http.host req.url;
+    synthetic {""};
+    return (deliver);
+  }
+
+# Error 805
+  # 302 redirect to vdp.cabinetoffice.gov.uk called from vcl_recv.
+  if (obj.status == 805) {
+    set obj.status = 302;
+    set obj.http.Location = "https://vdp.cabinetoffice.gov.uk/.well-known/security.txt";
+    set obj.response = "Moved";
     synthetic {""};
     return (deliver);
   }

--- a/spec/test-outputs/assets-staging.out.vcl
+++ b/spec/test-outputs/assets-staging.out.vcl
@@ -177,6 +177,11 @@ sub vcl_recv {
      error 801 "Force SSL";
   }
 
+  # Redirect to security.txt for "/.well-known/security.txt" or "/security.txt"
+  if (req.url.path ~ "(?i)^(?:/\.well[-_]known)?/security\.txt$") {
+    error 805 "security.txt";
+  }
+
   # Serve from stale for 24 hours if origin is sick
   set req.grace = 24h;
 
@@ -323,6 +328,16 @@ sub vcl_error {
     set obj.status = 301;
     set obj.response = "Moved Permanently";
     set obj.http.Location = "https://" req.http.host req.url;
+    synthetic {""};
+    return (deliver);
+  }
+
+# Error 805
+  # 302 redirect to vdp.cabinetoffice.gov.uk called from vcl_recv.
+  if (obj.status == 805) {
+    set obj.status = 302;
+    set obj.http.Location = "https://vdp.cabinetoffice.gov.uk/.well-known/security.txt";
+    set obj.response = "Moved";
     synthetic {""};
     return (deliver);
   }

--- a/spec/test-outputs/assets-test.out.vcl
+++ b/spec/test-outputs/assets-test.out.vcl
@@ -75,6 +75,11 @@ sub vcl_recv {
      error 801 "Force SSL";
   }
 
+  # Redirect to security.txt for "/.well-known/security.txt" or "/security.txt"
+  if (req.url.path ~ "(?i)^(?:/\.well[-_]known)?/security\.txt$") {
+    error 805 "security.txt";
+  }
+
   # Serve from stale for 24 hours if origin is sick
   set req.grace = 24h;
 
@@ -170,6 +175,16 @@ sub vcl_error {
     set obj.status = 301;
     set obj.response = "Moved Permanently";
     set obj.http.Location = "https://" req.http.host req.url;
+    synthetic {""};
+    return (deliver);
+  }
+
+# Error 805
+  # 302 redirect to vdp.cabinetoffice.gov.uk called from vcl_recv.
+  if (obj.status == 805) {
+    set obj.status = 302;
+    set obj.http.Location = "https://vdp.cabinetoffice.gov.uk/.well-known/security.txt";
+    set obj.response = "Moved";
     synthetic {""};
     return (deliver);
   }

--- a/spec/test-outputs/bouncer-integration.out.vcl
+++ b/spec/test-outputs/bouncer-integration.out.vcl
@@ -71,6 +71,11 @@ sub vcl_recv {
     error 804 "Not Found";
   }
 
+  # Redirect to security.txt for "/.well-known/security.txt" or "/security.txt"
+  if (req.url.path ~ "(?i)^(?:/\.well[-_]known)?/security\.txt$") {
+    error 805 "security.txt";
+  }
+
   # Keep stale.
   set req.grace = 86400s;
 
@@ -169,6 +174,16 @@ sub vcl_error {
         </body>
       </html>"};
 
+    return (deliver);
+  }
+
+# Error 805
+  # 302 redirect to vdp.cabinetoffice.gov.uk called from vcl_recv.
+  if (obj.status == 805) {
+    set obj.status = 302;
+    set obj.http.Location = "https://vdp.cabinetoffice.gov.uk/.well-known/security.txt";
+    set obj.response = "Moved";
+    synthetic {""};
     return (deliver);
   }
 

--- a/spec/test-outputs/bouncer-integration.out.vcl
+++ b/spec/test-outputs/bouncer-integration.out.vcl
@@ -76,8 +76,8 @@ sub vcl_recv {
     error 805 "security.txt";
   }
 
-  # Keep stale.
-  set req.grace = 86400s;
+  # Serve from stale for 24 hours if origin is sick
+  set req.grace = 24h;
 
   # Default backend.
   set req.backend = F_origin0;

--- a/spec/test-outputs/bouncer-production.out.vcl
+++ b/spec/test-outputs/bouncer-production.out.vcl
@@ -71,6 +71,11 @@ sub vcl_recv {
     error 804 "Not Found";
   }
 
+  # Redirect to security.txt for "/.well-known/security.txt" or "/security.txt"
+  if (req.url.path ~ "(?i)^(?:/\.well[-_]known)?/security\.txt$") {
+    error 805 "security.txt";
+  }
+
   # Keep stale.
   set req.grace = 86400s;
 
@@ -169,6 +174,16 @@ sub vcl_error {
         </body>
       </html>"};
 
+    return (deliver);
+  }
+
+# Error 805
+  # 302 redirect to vdp.cabinetoffice.gov.uk called from vcl_recv.
+  if (obj.status == 805) {
+    set obj.status = 302;
+    set obj.http.Location = "https://vdp.cabinetoffice.gov.uk/.well-known/security.txt";
+    set obj.response = "Moved";
+    synthetic {""};
     return (deliver);
   }
 

--- a/spec/test-outputs/bouncer-production.out.vcl
+++ b/spec/test-outputs/bouncer-production.out.vcl
@@ -76,8 +76,8 @@ sub vcl_recv {
     error 805 "security.txt";
   }
 
-  # Keep stale.
-  set req.grace = 86400s;
+  # Serve from stale for 24 hours if origin is sick
+  set req.grace = 24h;
 
   # Default backend.
   set req.backend = F_origin0;

--- a/spec/test-outputs/bouncer-staging.out.vcl
+++ b/spec/test-outputs/bouncer-staging.out.vcl
@@ -71,6 +71,11 @@ sub vcl_recv {
     error 804 "Not Found";
   }
 
+  # Redirect to security.txt for "/.well-known/security.txt" or "/security.txt"
+  if (req.url.path ~ "(?i)^(?:/\.well[-_]known)?/security\.txt$") {
+    error 805 "security.txt";
+  }
+
   # Keep stale.
   set req.grace = 86400s;
 
@@ -169,6 +174,16 @@ sub vcl_error {
         </body>
       </html>"};
 
+    return (deliver);
+  }
+
+# Error 805
+  # 302 redirect to vdp.cabinetoffice.gov.uk called from vcl_recv.
+  if (obj.status == 805) {
+    set obj.status = 302;
+    set obj.http.Location = "https://vdp.cabinetoffice.gov.uk/.well-known/security.txt";
+    set obj.response = "Moved";
+    synthetic {""};
     return (deliver);
   }
 

--- a/spec/test-outputs/bouncer-staging.out.vcl
+++ b/spec/test-outputs/bouncer-staging.out.vcl
@@ -76,8 +76,8 @@ sub vcl_recv {
     error 805 "security.txt";
   }
 
-  # Keep stale.
-  set req.grace = 86400s;
+  # Serve from stale for 24 hours if origin is sick
+  set req.grace = 24h;
 
   # Default backend.
   set req.backend = F_origin0;

--- a/spec/test-outputs/bouncer-test.out.vcl
+++ b/spec/test-outputs/bouncer-test.out.vcl
@@ -71,6 +71,11 @@ sub vcl_recv {
     error 804 "Not Found";
   }
 
+  # Redirect to security.txt for "/.well-known/security.txt" or "/security.txt"
+  if (req.url.path ~ "(?i)^(?:/\.well[-_]known)?/security\.txt$") {
+    error 805 "security.txt";
+  }
+
   # Keep stale.
   set req.grace = 86400s;
 
@@ -169,6 +174,16 @@ sub vcl_error {
         </body>
       </html>"};
 
+    return (deliver);
+  }
+
+# Error 805
+  # 302 redirect to vdp.cabinetoffice.gov.uk called from vcl_recv.
+  if (obj.status == 805) {
+    set obj.status = 302;
+    set obj.http.Location = "https://vdp.cabinetoffice.gov.uk/.well-known/security.txt";
+    set obj.response = "Moved";
+    synthetic {""};
     return (deliver);
   }
 

--- a/spec/test-outputs/bouncer-test.out.vcl
+++ b/spec/test-outputs/bouncer-test.out.vcl
@@ -76,8 +76,8 @@ sub vcl_recv {
     error 805 "security.txt";
   }
 
-  # Keep stale.
-  set req.grace = 86400s;
+  # Serve from stale for 24 hours if origin is sick
+  set req.grace = 24h;
 
   # Default backend.
   set req.backend = F_origin0;

--- a/spec/test-outputs/www-eks-integration.out.vcl
+++ b/spec/test-outputs/www-eks-integration.out.vcl
@@ -460,6 +460,7 @@ sub vcl_error {
     return (deliver);
   }
 
+# Error 805
   # 302 redirect to vdp.cabinetoffice.gov.uk called from vcl_recv.
   if (obj.status == 805) {
     set obj.status = 302;

--- a/spec/test-outputs/www-eks-production.out.vcl
+++ b/spec/test-outputs/www-eks-production.out.vcl
@@ -629,6 +629,7 @@ sub vcl_error {
     return (deliver);
   }
 
+# Error 805
   # 302 redirect to vdp.cabinetoffice.gov.uk called from vcl_recv.
   if (obj.status == 805) {
     set obj.status = 302;

--- a/spec/test-outputs/www-eks-staging.out.vcl
+++ b/spec/test-outputs/www-eks-staging.out.vcl
@@ -629,6 +629,7 @@ sub vcl_error {
     return (deliver);
   }
 
+# Error 805
   # 302 redirect to vdp.cabinetoffice.gov.uk called from vcl_recv.
   if (obj.status == 805) {
     set obj.status = 302;

--- a/spec/test-outputs/www-eks-test.out.vcl
+++ b/spec/test-outputs/www-eks-test.out.vcl
@@ -460,6 +460,7 @@ sub vcl_error {
     return (deliver);
   }
 
+# Error 805
   # 302 redirect to vdp.cabinetoffice.gov.uk called from vcl_recv.
   if (obj.status == 805) {
     set obj.status = 302;

--- a/spec/test-outputs/www-integration.out.vcl
+++ b/spec/test-outputs/www-integration.out.vcl
@@ -460,6 +460,7 @@ sub vcl_error {
     return (deliver);
   }
 
+# Error 805
   # 302 redirect to vdp.cabinetoffice.gov.uk called from vcl_recv.
   if (obj.status == 805) {
     set obj.status = 302;

--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -621,6 +621,7 @@ sub vcl_error {
     return (deliver);
   }
 
+# Error 805
   # 302 redirect to vdp.cabinetoffice.gov.uk called from vcl_recv.
   if (obj.status == 805) {
     set obj.status = 302;

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -629,6 +629,7 @@ sub vcl_error {
     return (deliver);
   }
 
+# Error 805
   # 302 redirect to vdp.cabinetoffice.gov.uk called from vcl_recv.
   if (obj.status == 805) {
     set obj.status = 302;

--- a/spec/test-outputs/www-test.out.vcl
+++ b/spec/test-outputs/www-test.out.vcl
@@ -460,6 +460,7 @@ sub vcl_error {
     return (deliver);
   }
 
+# Error 805
   # 302 redirect to vdp.cabinetoffice.gov.uk called from vcl_recv.
   if (obj.status == 805) {
     set obj.status = 302;

--- a/vcl_templates/_security_txt_request.vcl.erb
+++ b/vcl_templates/_security_txt_request.vcl.erb
@@ -1,0 +1,4 @@
+# Redirect to security.txt for "/.well-known/security.txt" or "/security.txt"
+if (req.url.path ~ "(?i)^(?:/\.well[-_]known)?/security\.txt$") {
+  error 805 "security.txt";
+}

--- a/vcl_templates/_security_txt_response.vcl.erb
+++ b/vcl_templates/_security_txt_response.vcl.erb
@@ -1,0 +1,8 @@
+# 302 redirect to vdp.cabinetoffice.gov.uk called from vcl_recv.
+if (obj.status == 805) {
+  set obj.status = 302;
+  set obj.http.Location = "https://vdp.cabinetoffice.gov.uk/.well-known/security.txt";
+  set obj.response = "Moved";
+  synthetic {""};
+  return (deliver);
+}

--- a/vcl_templates/assets.vcl.erb
+++ b/vcl_templates/assets.vcl.erb
@@ -234,6 +234,8 @@ sub vcl_recv {
      error 801 "Force SSL";
   }
 
+<%= render_partial("security_txt_request", indentation: "  ") %>
+
   # Serve from stale for 24 hours if origin is sick
   set req.grace = 24h;
 
@@ -383,6 +385,9 @@ sub vcl_error {
     synthetic {""};
     return (deliver);
   }
+
+# Error 805
+<%= render_partial("security_txt_response", indentation: "  ") %>
 
   # Serve stale from error subroutine as recommended in:
   # https://docs.fastly.com/guides/performance-tuning/serving-stale-content

--- a/vcl_templates/bouncer.vcl.erb
+++ b/vcl_templates/bouncer.vcl.erb
@@ -58,8 +58,8 @@ sub vcl_recv {
 
 <%= render_partial("security_txt_request", indentation: "  ") %>
 
-  # Keep stale.
-  set req.grace = 86400s;
+  # Serve from stale for 24 hours if origin is sick
+  set req.grace = 24h;
 
   # Default backend.
   set req.backend = F_origin0;

--- a/vcl_templates/bouncer.vcl.erb
+++ b/vcl_templates/bouncer.vcl.erb
@@ -56,6 +56,8 @@ sub vcl_recv {
     error 804 "Not Found";
   }
 
+<%= render_partial("security_txt_request", indentation: "  ") %>
+
   # Keep stale.
   set req.grace = 86400s;
 
@@ -156,6 +158,9 @@ sub vcl_error {
 
     return (deliver);
   }
+
+# Error 805
+<%= render_partial("security_txt_response", indentation: "  ") %>
 
   # Assume we've hit vcl_error() because the backend is unavailable
   if (req.restarts < 2) {

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -644,6 +644,7 @@ sub vcl_error {
     return (deliver);
   }
 
+# Error 805
 <%= render_partial("security_txt_response", indentation: "  ") %>
 
   <% if config['basic_authentication'] %>

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -272,10 +272,7 @@ sub vcl_recv {
     error 804 "Not Found";
   }
 
-  # Redirect to security.txt for "/.well-known/security.txt" or "/security.txt"
-  if (req.url.path ~ "(?i)^(?:/\.well[-_]known)?/security\.txt$") {
-    error 805 "security.txt";
-  }
+<%= render_partial("security_txt_request", indentation: "  ") %>
 
   # Sort query params (improve cache hit rate)
   set req.url = querystring.sort(req.url);
@@ -647,14 +644,7 @@ sub vcl_error {
     return (deliver);
   }
 
-  # 302 redirect to vdp.cabinetoffice.gov.uk called from vcl_recv.
-  if (obj.status == 805) {
-    set obj.status = 302;
-    set obj.http.Location = "https://vdp.cabinetoffice.gov.uk/.well-known/security.txt";
-    set obj.response = "Moved";
-    synthetic {""};
-    return (deliver);
-  }
+<%= render_partial("security_txt_response", indentation: "  ") %>
 
   <% if config['basic_authentication'] %>
   if (obj.status == 401) {


### PR DESCRIPTION
This configuration redirects requests for the security.txt file to Cabinet Office's vulnerability disclosure program.

We want to add this feature to assets.publishing.service.gov.uk and all of the sites that bouncer caters for.

The configuration is identical to that for www.gov.uk, so I've extracted that as a partial and reused it across the services.

Bouncer had its stale cache grace time of 1 day specified in seconds, so I've tweaked that to `24h` so that it's the same as the other two.

I regenerated the specs with each commit to keep the config changes connected.

DGU's config is held in the govuk-aws repo, but that will be included in this work. 

https://trello.com/c/VLBjBTMe/313-put-securitytxt-on-bouncer-and-dgu

⚠️ The changes need to be deployed manually to all relevant environments. Follow the guidance on [how to deploy Fastly](https://docs.publishing.service.gov.uk/manual/cdn.html#deploying-fastly).
