### PR TITLE
Add hard coded setting of BankHolidaysTest cookie

### DIFF
--- a/spec/test-outputs/www-eks-integration.out.vcl
+++ b/spec/test-outputs/www-eks-integration.out.vcl
@@ -385,6 +385,13 @@ sub vcl_deliver {
     add resp.http.Set-Cookie = "ABTest-Example=" req.http.GOVUK-ABTest-Example "; secure; expires=" now + 1d;
   }
 
+  # Hard coded test to check things are working ok because so far things aren't
+  if (req.url ~ "^/bank-holidays"
+    && req.http.User-Agent !~ "^GOV\.UK Crawler Worker"
+    && req.http.Cookie !~ "ABTest-BankHolidaysTest") {
+    add resp.http.Set-Cookie = "ABTest-BankHolidaysTest=" req.http.GOVUK-ABTest-BankHolidaysTest "; secure; expires=" now + 1d;
+  }
+
   # Begin dynamic section
   declare local var.expiry TIME;
   if (req.http.Cookie ~ "cookies_policy") {

--- a/spec/test-outputs/www-eks-production.out.vcl
+++ b/spec/test-outputs/www-eks-production.out.vcl
@@ -557,6 +557,13 @@ sub vcl_deliver {
     add resp.http.Set-Cookie = "ABTest-Example=" req.http.GOVUK-ABTest-Example "; secure; expires=" now + 1d;
   }
 
+  # Hard coded test to check things are working ok because so far things aren't
+  if (req.url ~ "^/bank-holidays"
+    && req.http.User-Agent !~ "^GOV\.UK Crawler Worker"
+    && req.http.Cookie !~ "ABTest-BankHolidaysTest") {
+    add resp.http.Set-Cookie = "ABTest-BankHolidaysTest=" req.http.GOVUK-ABTest-BankHolidaysTest "; secure; expires=" now + 1d;
+  }
+
   # Begin dynamic section
   declare local var.expiry TIME;
   if (req.http.Cookie ~ "cookies_policy") {

--- a/spec/test-outputs/www-eks-staging.out.vcl
+++ b/spec/test-outputs/www-eks-staging.out.vcl
@@ -557,6 +557,13 @@ sub vcl_deliver {
     add resp.http.Set-Cookie = "ABTest-Example=" req.http.GOVUK-ABTest-Example "; secure; expires=" now + 1d;
   }
 
+  # Hard coded test to check things are working ok because so far things aren't
+  if (req.url ~ "^/bank-holidays"
+    && req.http.User-Agent !~ "^GOV\.UK Crawler Worker"
+    && req.http.Cookie !~ "ABTest-BankHolidaysTest") {
+    add resp.http.Set-Cookie = "ABTest-BankHolidaysTest=" req.http.GOVUK-ABTest-BankHolidaysTest "; secure; expires=" now + 1d;
+  }
+
   # Begin dynamic section
   declare local var.expiry TIME;
   if (req.http.Cookie ~ "cookies_policy") {

--- a/spec/test-outputs/www-eks-test.out.vcl
+++ b/spec/test-outputs/www-eks-test.out.vcl
@@ -385,6 +385,13 @@ sub vcl_deliver {
     add resp.http.Set-Cookie = "ABTest-Example=" req.http.GOVUK-ABTest-Example "; secure; expires=" now + 1d;
   }
 
+  # Hard coded test to check things are working ok because so far things aren't
+  if (req.url ~ "^/bank-holidays"
+    && req.http.User-Agent !~ "^GOV\.UK Crawler Worker"
+    && req.http.Cookie !~ "ABTest-BankHolidaysTest") {
+    add resp.http.Set-Cookie = "ABTest-BankHolidaysTest=" req.http.GOVUK-ABTest-BankHolidaysTest "; secure; expires=" now + 1d;
+  }
+
   # Begin dynamic section
   declare local var.expiry TIME;
   if (req.http.Cookie ~ "cookies_policy") {

--- a/spec/test-outputs/www-integration.out.vcl
+++ b/spec/test-outputs/www-integration.out.vcl
@@ -385,6 +385,13 @@ sub vcl_deliver {
     add resp.http.Set-Cookie = "ABTest-Example=" req.http.GOVUK-ABTest-Example "; secure; expires=" now + 1d;
   }
 
+  # Hard coded test to check things are working ok because so far things aren't
+  if (req.url ~ "^/bank-holidays"
+    && req.http.User-Agent !~ "^GOV\.UK Crawler Worker"
+    && req.http.Cookie !~ "ABTest-BankHolidaysTest") {
+    add resp.http.Set-Cookie = "ABTest-BankHolidaysTest=" req.http.GOVUK-ABTest-BankHolidaysTest "; secure; expires=" now + 1d;
+  }
+
   # Begin dynamic section
   declare local var.expiry TIME;
   if (req.http.Cookie ~ "cookies_policy") {

--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -549,6 +549,13 @@ sub vcl_deliver {
     add resp.http.Set-Cookie = "ABTest-Example=" req.http.GOVUK-ABTest-Example "; secure; expires=" now + 1d;
   }
 
+  # Hard coded test to check things are working ok because so far things aren't
+  if (req.url ~ "^/bank-holidays"
+    && req.http.User-Agent !~ "^GOV\.UK Crawler Worker"
+    && req.http.Cookie !~ "ABTest-BankHolidaysTest") {
+    add resp.http.Set-Cookie = "ABTest-BankHolidaysTest=" req.http.GOVUK-ABTest-BankHolidaysTest "; secure; expires=" now + 1d;
+  }
+
   # Begin dynamic section
   declare local var.expiry TIME;
   if (req.http.Cookie ~ "cookies_policy") {

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -557,6 +557,13 @@ sub vcl_deliver {
     add resp.http.Set-Cookie = "ABTest-Example=" req.http.GOVUK-ABTest-Example "; secure; expires=" now + 1d;
   }
 
+  # Hard coded test to check things are working ok because so far things aren't
+  if (req.url ~ "^/bank-holidays"
+    && req.http.User-Agent !~ "^GOV\.UK Crawler Worker"
+    && req.http.Cookie !~ "ABTest-BankHolidaysTest") {
+    add resp.http.Set-Cookie = "ABTest-BankHolidaysTest=" req.http.GOVUK-ABTest-BankHolidaysTest "; secure; expires=" now + 1d;
+  }
+
   # Begin dynamic section
   declare local var.expiry TIME;
   if (req.http.Cookie ~ "cookies_policy") {

--- a/spec/test-outputs/www-test.out.vcl
+++ b/spec/test-outputs/www-test.out.vcl
@@ -385,6 +385,13 @@ sub vcl_deliver {
     add resp.http.Set-Cookie = "ABTest-Example=" req.http.GOVUK-ABTest-Example "; secure; expires=" now + 1d;
   }
 
+  # Hard coded test to check things are working ok because so far things aren't
+  if (req.url ~ "^/bank-holidays"
+    && req.http.User-Agent !~ "^GOV\.UK Crawler Worker"
+    && req.http.Cookie !~ "ABTest-BankHolidaysTest") {
+    add resp.http.Set-Cookie = "ABTest-BankHolidaysTest=" req.http.GOVUK-ABTest-BankHolidaysTest "; secure; expires=" now + 1d;
+  }
+
   # Begin dynamic section
   declare local var.expiry TIME;
   if (req.http.Cookie ~ "cookies_policy") {

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -532,6 +532,13 @@ sub vcl_deliver {
     add resp.http.Set-Cookie = "ABTest-Example=" req.http.GOVUK-ABTest-Example "; secure; expires=" now + 1d;
   }
 
+  # Hard coded test to check things are working ok because so far things aren't
+  if (req.url ~ "^/bank-holidays"
+    && req.http.User-Agent !~ "^GOV\.UK Crawler Worker"
+    && req.http.Cookie !~ "ABTest-BankHolidaysTest") {
+    add resp.http.Set-Cookie = "ABTest-BankHolidaysTest=" req.http.GOVUK-ABTest-BankHolidaysTest "; secure; expires=" now + 1d;
+  }
+
   # Begin dynamic section
 <% if ab_tests -%>
   declare local var.expiry TIME;


### PR DESCRIPTION
We're not seeing a cookie being set in various environments and just want to check that the logic snippet isn't the issue as the AB-EXample works.

⚠️ The changes need to be deployed manually to all relevant environments. Follow the guidance on [how to deploy Fastly](https://docs.publishing.service.gov.uk/manual/cdn.html#deploying-fastly).
