### PR TITLE
Fix setting cookies for AB tests

### DIFF
--- a/spec/test-outputs/www-eks-integration.out.vcl
+++ b/spec/test-outputs/www-eks-integration.out.vcl
@@ -389,15 +389,15 @@ sub vcl_deliver {
   }
 
   # Begin dynamic section
-  declare local var.expiry TIME;
-  if (req.http.Usage-Cookies-Opt-In == "true") {
-    if (table.lookup(active_ab_tests, "BankHolidaysTest") == "true") {
-      if (req.http.GOVUK-ABTest-BankHolidaysTest-Cookie != "sent_in_request" || req.url ~ "[\?\&]ABTest-BankHolidaysTest" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
-        set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "BankHolidaysTest"))));
-        add resp.http.Set-Cookie = "ABTest-BankHolidaysTest=" req.http.GOVUK-ABTest-BankHolidaysTest "; secure; expires=" var.expiry "; path=/";
-      }
+declare local var.expiry TIME;
+if (req.http.Usage-Cookies-Opt-In == "true" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
+  if (table.lookup(active_ab_tests, "BankHolidaysTest") == "true") {
+    if (req.http.GOVUK-ABTest-BankHolidaysTest-Cookie != "sent_in_request" || req.url ~ "[\?\&]ABTest-BankHolidaysTest") {
+      set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "BankHolidaysTest"))));
+      add resp.http.Set-Cookie = "ABTest-BankHolidaysTest=" req.http.GOVUK-ABTest-BankHolidaysTest "; secure; expires=" var.expiry "; path=/";
     }
   }
+}
   # End dynamic section
 
 #FASTLY deliver

--- a/spec/test-outputs/www-eks-integration.out.vcl
+++ b/spec/test-outputs/www-eks-integration.out.vcl
@@ -385,13 +385,6 @@ sub vcl_deliver {
     add resp.http.Set-Cookie = "ABTest-Example=" req.http.GOVUK-ABTest-Example "; secure; expires=" now + 1d;
   }
 
-  # Hard coded test to check things are working ok because so far things aren't
-  if (req.url ~ "^/bank-holidays"
-    && req.http.User-Agent !~ "^GOV\.UK Crawler Worker"
-    && req.http.Cookie !~ "ABTest-BankHolidaysTest") {
-    add resp.http.Set-Cookie = "ABTest-BankHolidaysTest=" req.http.GOVUK-ABTest-BankHolidaysTest "; secure; expires=" now + 1d;
-  }
-
   # Begin dynamic section
   declare local var.expiry TIME;
   if (req.http.Cookie ~ "cookies_policy") {

--- a/spec/test-outputs/www-eks-integration.out.vcl
+++ b/spec/test-outputs/www-eks-integration.out.vcl
@@ -169,6 +169,7 @@ sub vcl_recv {
 
   # Begin dynamic section
   if (req.http.Cookie ~ "cookies_policy" && req.http.Cookie:cookies_policy ~ "%22usage%22:true") {
+    set req.http.Usage-Cookies-Opt-In = "true";
     if (table.lookup(active_ab_tests, "Example") == "true") {
       if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
         set req.http.GOVUK-ABTest-Example = "A";
@@ -387,13 +388,11 @@ sub vcl_deliver {
 
   # Begin dynamic section
   declare local var.expiry TIME;
-  if (req.http.Cookie ~ "cookies_policy") {
-    if (req.http.Cookie:cookies_policy ~ "%22usage%22:true") {
-      if (table.lookup(active_ab_tests, "BankHolidaysTest") == "true") {
-        if (req.http.Cookie !~ "ABTest-BankHolidaysTest" || req.url ~ "[\?\&]ABTest-BankHolidaysTest" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
-          set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "BankHolidaysTest"))));
-          add resp.http.Set-Cookie = "ABTest-BankHolidaysTest=" req.http.GOVUK-ABTest-BankHolidaysTest "; secure; expires=" var.expiry "; path=/";
-        }
+  if (req.http.Usage-Cookies-Opt-In == "true") {
+    if (table.lookup(active_ab_tests, "BankHolidaysTest") == "true") {
+      if (req.http.Cookie !~ "ABTest-BankHolidaysTest" || req.url ~ "[\?\&]ABTest-BankHolidaysTest" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
+        set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "BankHolidaysTest"))));
+        add resp.http.Set-Cookie = "ABTest-BankHolidaysTest=" req.http.GOVUK-ABTest-BankHolidaysTest "; secure; expires=" var.expiry "; path=/";
       }
     }
   }

--- a/spec/test-outputs/www-eks-production.out.vcl
+++ b/spec/test-outputs/www-eks-production.out.vcl
@@ -356,6 +356,7 @@ sub vcl_recv {
       } else if (req.http.Cookie ~ "ABTest-Example") {
         # Set the value of the header to whatever decision was previously made
         set req.http.GOVUK-ABTest-Example = req.http.Cookie:ABTest-Example;
+        set req.http.GOVUK-ABTest-Example-Cookie = "sent_in_request";
       } else {
         declare local var.denominator_Example INTEGER;
         declare local var.denominator_Example_A INTEGER;
@@ -388,6 +389,7 @@ sub vcl_recv {
       } else if (req.http.Cookie ~ "ABTest-BankHolidaysTest") {
         # Set the value of the header to whatever decision was previously made
         set req.http.GOVUK-ABTest-BankHolidaysTest = req.http.Cookie:ABTest-BankHolidaysTest;
+        set req.http.GOVUK-ABTest-BankHolidaysTest-Cookie = "sent_in_request";
       } else {
         declare local var.denominator_BankHolidaysTest INTEGER;
         declare local var.denominator_BankHolidaysTest_A INTEGER;
@@ -553,7 +555,7 @@ sub vcl_deliver {
   # cookie.
   if (req.url ~ "^/help/ab-testing"
     && req.http.User-Agent !~ "^GOV\.UK Crawler Worker"
-    && req.http.Cookie !~ "ABTest-Example") {
+    && req.http.GOVUK-ABTest-Example-Cookie != "sent_in_request") {
     # Set a fairly short cookie expiry because this is just an A/B test demo.
     add resp.http.Set-Cookie = "ABTest-Example=" req.http.GOVUK-ABTest-Example "; secure; expires=" now + 1d;
   }
@@ -562,7 +564,7 @@ sub vcl_deliver {
   declare local var.expiry TIME;
   if (req.http.Usage-Cookies-Opt-In == "true") {
     if (table.lookup(active_ab_tests, "BankHolidaysTest") == "true") {
-      if (req.http.Cookie !~ "ABTest-BankHolidaysTest" || req.url ~ "[\?\&]ABTest-BankHolidaysTest" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
+      if (req.http.GOVUK-ABTest-BankHolidaysTest-Cookie != "sent_in_request" || req.url ~ "[\?\&]ABTest-BankHolidaysTest" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
         set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "BankHolidaysTest"))));
         add resp.http.Set-Cookie = "ABTest-BankHolidaysTest=" req.http.GOVUK-ABTest-BankHolidaysTest "; secure; expires=" var.expiry "; path=/";
       }

--- a/spec/test-outputs/www-eks-production.out.vcl
+++ b/spec/test-outputs/www-eks-production.out.vcl
@@ -561,15 +561,15 @@ sub vcl_deliver {
   }
 
   # Begin dynamic section
-  declare local var.expiry TIME;
-  if (req.http.Usage-Cookies-Opt-In == "true") {
-    if (table.lookup(active_ab_tests, "BankHolidaysTest") == "true") {
-      if (req.http.GOVUK-ABTest-BankHolidaysTest-Cookie != "sent_in_request" || req.url ~ "[\?\&]ABTest-BankHolidaysTest" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
-        set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "BankHolidaysTest"))));
-        add resp.http.Set-Cookie = "ABTest-BankHolidaysTest=" req.http.GOVUK-ABTest-BankHolidaysTest "; secure; expires=" var.expiry "; path=/";
-      }
+declare local var.expiry TIME;
+if (req.http.Usage-Cookies-Opt-In == "true" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
+  if (table.lookup(active_ab_tests, "BankHolidaysTest") == "true") {
+    if (req.http.GOVUK-ABTest-BankHolidaysTest-Cookie != "sent_in_request" || req.url ~ "[\?\&]ABTest-BankHolidaysTest") {
+      set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "BankHolidaysTest"))));
+      add resp.http.Set-Cookie = "ABTest-BankHolidaysTest=" req.http.GOVUK-ABTest-BankHolidaysTest "; secure; expires=" var.expiry "; path=/";
     }
   }
+}
   # End dynamic section
 
 #FASTLY deliver

--- a/spec/test-outputs/www-eks-production.out.vcl
+++ b/spec/test-outputs/www-eks-production.out.vcl
@@ -557,13 +557,6 @@ sub vcl_deliver {
     add resp.http.Set-Cookie = "ABTest-Example=" req.http.GOVUK-ABTest-Example "; secure; expires=" now + 1d;
   }
 
-  # Hard coded test to check things are working ok because so far things aren't
-  if (req.url ~ "^/bank-holidays"
-    && req.http.User-Agent !~ "^GOV\.UK Crawler Worker"
-    && req.http.Cookie !~ "ABTest-BankHolidaysTest") {
-    add resp.http.Set-Cookie = "ABTest-BankHolidaysTest=" req.http.GOVUK-ABTest-BankHolidaysTest "; secure; expires=" now + 1d;
-  }
-
   # Begin dynamic section
   declare local var.expiry TIME;
   if (req.http.Cookie ~ "cookies_policy") {

--- a/spec/test-outputs/www-eks-staging.out.vcl
+++ b/spec/test-outputs/www-eks-staging.out.vcl
@@ -356,6 +356,7 @@ sub vcl_recv {
       } else if (req.http.Cookie ~ "ABTest-Example") {
         # Set the value of the header to whatever decision was previously made
         set req.http.GOVUK-ABTest-Example = req.http.Cookie:ABTest-Example;
+        set req.http.GOVUK-ABTest-Example-Cookie = "sent_in_request";
       } else {
         declare local var.denominator_Example INTEGER;
         declare local var.denominator_Example_A INTEGER;
@@ -388,6 +389,7 @@ sub vcl_recv {
       } else if (req.http.Cookie ~ "ABTest-BankHolidaysTest") {
         # Set the value of the header to whatever decision was previously made
         set req.http.GOVUK-ABTest-BankHolidaysTest = req.http.Cookie:ABTest-BankHolidaysTest;
+        set req.http.GOVUK-ABTest-BankHolidaysTest-Cookie = "sent_in_request";
       } else {
         declare local var.denominator_BankHolidaysTest INTEGER;
         declare local var.denominator_BankHolidaysTest_A INTEGER;
@@ -553,7 +555,7 @@ sub vcl_deliver {
   # cookie.
   if (req.url ~ "^/help/ab-testing"
     && req.http.User-Agent !~ "^GOV\.UK Crawler Worker"
-    && req.http.Cookie !~ "ABTest-Example") {
+    && req.http.GOVUK-ABTest-Example-Cookie != "sent_in_request") {
     # Set a fairly short cookie expiry because this is just an A/B test demo.
     add resp.http.Set-Cookie = "ABTest-Example=" req.http.GOVUK-ABTest-Example "; secure; expires=" now + 1d;
   }
@@ -562,7 +564,7 @@ sub vcl_deliver {
   declare local var.expiry TIME;
   if (req.http.Usage-Cookies-Opt-In == "true") {
     if (table.lookup(active_ab_tests, "BankHolidaysTest") == "true") {
-      if (req.http.Cookie !~ "ABTest-BankHolidaysTest" || req.url ~ "[\?\&]ABTest-BankHolidaysTest" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
+      if (req.http.GOVUK-ABTest-BankHolidaysTest-Cookie != "sent_in_request" || req.url ~ "[\?\&]ABTest-BankHolidaysTest" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
         set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "BankHolidaysTest"))));
         add resp.http.Set-Cookie = "ABTest-BankHolidaysTest=" req.http.GOVUK-ABTest-BankHolidaysTest "; secure; expires=" var.expiry "; path=/";
       }

--- a/spec/test-outputs/www-eks-staging.out.vcl
+++ b/spec/test-outputs/www-eks-staging.out.vcl
@@ -561,15 +561,15 @@ sub vcl_deliver {
   }
 
   # Begin dynamic section
-  declare local var.expiry TIME;
-  if (req.http.Usage-Cookies-Opt-In == "true") {
-    if (table.lookup(active_ab_tests, "BankHolidaysTest") == "true") {
-      if (req.http.GOVUK-ABTest-BankHolidaysTest-Cookie != "sent_in_request" || req.url ~ "[\?\&]ABTest-BankHolidaysTest" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
-        set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "BankHolidaysTest"))));
-        add resp.http.Set-Cookie = "ABTest-BankHolidaysTest=" req.http.GOVUK-ABTest-BankHolidaysTest "; secure; expires=" var.expiry "; path=/";
-      }
+declare local var.expiry TIME;
+if (req.http.Usage-Cookies-Opt-In == "true" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
+  if (table.lookup(active_ab_tests, "BankHolidaysTest") == "true") {
+    if (req.http.GOVUK-ABTest-BankHolidaysTest-Cookie != "sent_in_request" || req.url ~ "[\?\&]ABTest-BankHolidaysTest") {
+      set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "BankHolidaysTest"))));
+      add resp.http.Set-Cookie = "ABTest-BankHolidaysTest=" req.http.GOVUK-ABTest-BankHolidaysTest "; secure; expires=" var.expiry "; path=/";
     }
   }
+}
   # End dynamic section
 
 #FASTLY deliver

--- a/spec/test-outputs/www-eks-staging.out.vcl
+++ b/spec/test-outputs/www-eks-staging.out.vcl
@@ -557,13 +557,6 @@ sub vcl_deliver {
     add resp.http.Set-Cookie = "ABTest-Example=" req.http.GOVUK-ABTest-Example "; secure; expires=" now + 1d;
   }
 
-  # Hard coded test to check things are working ok because so far things aren't
-  if (req.url ~ "^/bank-holidays"
-    && req.http.User-Agent !~ "^GOV\.UK Crawler Worker"
-    && req.http.Cookie !~ "ABTest-BankHolidaysTest") {
-    add resp.http.Set-Cookie = "ABTest-BankHolidaysTest=" req.http.GOVUK-ABTest-BankHolidaysTest "; secure; expires=" now + 1d;
-  }
-
   # Begin dynamic section
   declare local var.expiry TIME;
   if (req.http.Cookie ~ "cookies_policy") {

--- a/spec/test-outputs/www-eks-test.out.vcl
+++ b/spec/test-outputs/www-eks-test.out.vcl
@@ -389,15 +389,15 @@ sub vcl_deliver {
   }
 
   # Begin dynamic section
-  declare local var.expiry TIME;
-  if (req.http.Usage-Cookies-Opt-In == "true") {
-    if (table.lookup(active_ab_tests, "BankHolidaysTest") == "true") {
-      if (req.http.GOVUK-ABTest-BankHolidaysTest-Cookie != "sent_in_request" || req.url ~ "[\?\&]ABTest-BankHolidaysTest" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
-        set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "BankHolidaysTest"))));
-        add resp.http.Set-Cookie = "ABTest-BankHolidaysTest=" req.http.GOVUK-ABTest-BankHolidaysTest "; secure; expires=" var.expiry "; path=/";
-      }
+declare local var.expiry TIME;
+if (req.http.Usage-Cookies-Opt-In == "true" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
+  if (table.lookup(active_ab_tests, "BankHolidaysTest") == "true") {
+    if (req.http.GOVUK-ABTest-BankHolidaysTest-Cookie != "sent_in_request" || req.url ~ "[\?\&]ABTest-BankHolidaysTest") {
+      set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "BankHolidaysTest"))));
+      add resp.http.Set-Cookie = "ABTest-BankHolidaysTest=" req.http.GOVUK-ABTest-BankHolidaysTest "; secure; expires=" var.expiry "; path=/";
     }
   }
+}
   # End dynamic section
 
 #FASTLY deliver

--- a/spec/test-outputs/www-eks-test.out.vcl
+++ b/spec/test-outputs/www-eks-test.out.vcl
@@ -385,13 +385,6 @@ sub vcl_deliver {
     add resp.http.Set-Cookie = "ABTest-Example=" req.http.GOVUK-ABTest-Example "; secure; expires=" now + 1d;
   }
 
-  # Hard coded test to check things are working ok because so far things aren't
-  if (req.url ~ "^/bank-holidays"
-    && req.http.User-Agent !~ "^GOV\.UK Crawler Worker"
-    && req.http.Cookie !~ "ABTest-BankHolidaysTest") {
-    add resp.http.Set-Cookie = "ABTest-BankHolidaysTest=" req.http.GOVUK-ABTest-BankHolidaysTest "; secure; expires=" now + 1d;
-  }
-
   # Begin dynamic section
   declare local var.expiry TIME;
   if (req.http.Cookie ~ "cookies_policy") {

--- a/spec/test-outputs/www-eks-test.out.vcl
+++ b/spec/test-outputs/www-eks-test.out.vcl
@@ -169,6 +169,7 @@ sub vcl_recv {
 
   # Begin dynamic section
   if (req.http.Cookie ~ "cookies_policy" && req.http.Cookie:cookies_policy ~ "%22usage%22:true") {
+    set req.http.Usage-Cookies-Opt-In = "true";
     if (table.lookup(active_ab_tests, "Example") == "true") {
       if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
         set req.http.GOVUK-ABTest-Example = "A";
@@ -387,13 +388,11 @@ sub vcl_deliver {
 
   # Begin dynamic section
   declare local var.expiry TIME;
-  if (req.http.Cookie ~ "cookies_policy") {
-    if (req.http.Cookie:cookies_policy ~ "%22usage%22:true") {
-      if (table.lookup(active_ab_tests, "BankHolidaysTest") == "true") {
-        if (req.http.Cookie !~ "ABTest-BankHolidaysTest" || req.url ~ "[\?\&]ABTest-BankHolidaysTest" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
-          set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "BankHolidaysTest"))));
-          add resp.http.Set-Cookie = "ABTest-BankHolidaysTest=" req.http.GOVUK-ABTest-BankHolidaysTest "; secure; expires=" var.expiry "; path=/";
-        }
+  if (req.http.Usage-Cookies-Opt-In == "true") {
+    if (table.lookup(active_ab_tests, "BankHolidaysTest") == "true") {
+      if (req.http.Cookie !~ "ABTest-BankHolidaysTest" || req.url ~ "[\?\&]ABTest-BankHolidaysTest" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
+        set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "BankHolidaysTest"))));
+        add resp.http.Set-Cookie = "ABTest-BankHolidaysTest=" req.http.GOVUK-ABTest-BankHolidaysTest "; secure; expires=" var.expiry "; path=/";
       }
     }
   }

--- a/spec/test-outputs/www-integration.out.vcl
+++ b/spec/test-outputs/www-integration.out.vcl
@@ -389,15 +389,15 @@ sub vcl_deliver {
   }
 
   # Begin dynamic section
-  declare local var.expiry TIME;
-  if (req.http.Usage-Cookies-Opt-In == "true") {
-    if (table.lookup(active_ab_tests, "BankHolidaysTest") == "true") {
-      if (req.http.GOVUK-ABTest-BankHolidaysTest-Cookie != "sent_in_request" || req.url ~ "[\?\&]ABTest-BankHolidaysTest" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
-        set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "BankHolidaysTest"))));
-        add resp.http.Set-Cookie = "ABTest-BankHolidaysTest=" req.http.GOVUK-ABTest-BankHolidaysTest "; secure; expires=" var.expiry "; path=/";
-      }
+declare local var.expiry TIME;
+if (req.http.Usage-Cookies-Opt-In == "true" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
+  if (table.lookup(active_ab_tests, "BankHolidaysTest") == "true") {
+    if (req.http.GOVUK-ABTest-BankHolidaysTest-Cookie != "sent_in_request" || req.url ~ "[\?\&]ABTest-BankHolidaysTest") {
+      set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "BankHolidaysTest"))));
+      add resp.http.Set-Cookie = "ABTest-BankHolidaysTest=" req.http.GOVUK-ABTest-BankHolidaysTest "; secure; expires=" var.expiry "; path=/";
     }
   }
+}
   # End dynamic section
 
 #FASTLY deliver

--- a/spec/test-outputs/www-integration.out.vcl
+++ b/spec/test-outputs/www-integration.out.vcl
@@ -385,13 +385,6 @@ sub vcl_deliver {
     add resp.http.Set-Cookie = "ABTest-Example=" req.http.GOVUK-ABTest-Example "; secure; expires=" now + 1d;
   }
 
-  # Hard coded test to check things are working ok because so far things aren't
-  if (req.url ~ "^/bank-holidays"
-    && req.http.User-Agent !~ "^GOV\.UK Crawler Worker"
-    && req.http.Cookie !~ "ABTest-BankHolidaysTest") {
-    add resp.http.Set-Cookie = "ABTest-BankHolidaysTest=" req.http.GOVUK-ABTest-BankHolidaysTest "; secure; expires=" now + 1d;
-  }
-
   # Begin dynamic section
   declare local var.expiry TIME;
   if (req.http.Cookie ~ "cookies_policy") {

--- a/spec/test-outputs/www-integration.out.vcl
+++ b/spec/test-outputs/www-integration.out.vcl
@@ -169,6 +169,7 @@ sub vcl_recv {
 
   # Begin dynamic section
   if (req.http.Cookie ~ "cookies_policy" && req.http.Cookie:cookies_policy ~ "%22usage%22:true") {
+    set req.http.Usage-Cookies-Opt-In = "true";
     if (table.lookup(active_ab_tests, "Example") == "true") {
       if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
         set req.http.GOVUK-ABTest-Example = "A";
@@ -387,13 +388,11 @@ sub vcl_deliver {
 
   # Begin dynamic section
   declare local var.expiry TIME;
-  if (req.http.Cookie ~ "cookies_policy") {
-    if (req.http.Cookie:cookies_policy ~ "%22usage%22:true") {
-      if (table.lookup(active_ab_tests, "BankHolidaysTest") == "true") {
-        if (req.http.Cookie !~ "ABTest-BankHolidaysTest" || req.url ~ "[\?\&]ABTest-BankHolidaysTest" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
-          set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "BankHolidaysTest"))));
-          add resp.http.Set-Cookie = "ABTest-BankHolidaysTest=" req.http.GOVUK-ABTest-BankHolidaysTest "; secure; expires=" var.expiry "; path=/";
-        }
+  if (req.http.Usage-Cookies-Opt-In == "true") {
+    if (table.lookup(active_ab_tests, "BankHolidaysTest") == "true") {
+      if (req.http.Cookie !~ "ABTest-BankHolidaysTest" || req.url ~ "[\?\&]ABTest-BankHolidaysTest" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
+        set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "BankHolidaysTest"))));
+        add resp.http.Set-Cookie = "ABTest-BankHolidaysTest=" req.http.GOVUK-ABTest-BankHolidaysTest "; secure; expires=" var.expiry "; path=/";
       }
     }
   }

--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -549,13 +549,6 @@ sub vcl_deliver {
     add resp.http.Set-Cookie = "ABTest-Example=" req.http.GOVUK-ABTest-Example "; secure; expires=" now + 1d;
   }
 
-  # Hard coded test to check things are working ok because so far things aren't
-  if (req.url ~ "^/bank-holidays"
-    && req.http.User-Agent !~ "^GOV\.UK Crawler Worker"
-    && req.http.Cookie !~ "ABTest-BankHolidaysTest") {
-    add resp.http.Set-Cookie = "ABTest-BankHolidaysTest=" req.http.GOVUK-ABTest-BankHolidaysTest "; secure; expires=" now + 1d;
-  }
-
   # Begin dynamic section
   declare local var.expiry TIME;
   if (req.http.Cookie ~ "cookies_policy") {

--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -348,6 +348,7 @@ sub vcl_recv {
       } else if (req.http.Cookie ~ "ABTest-Example") {
         # Set the value of the header to whatever decision was previously made
         set req.http.GOVUK-ABTest-Example = req.http.Cookie:ABTest-Example;
+        set req.http.GOVUK-ABTest-Example-Cookie = "sent_in_request";
       } else {
         declare local var.denominator_Example INTEGER;
         declare local var.denominator_Example_A INTEGER;
@@ -380,6 +381,7 @@ sub vcl_recv {
       } else if (req.http.Cookie ~ "ABTest-BankHolidaysTest") {
         # Set the value of the header to whatever decision was previously made
         set req.http.GOVUK-ABTest-BankHolidaysTest = req.http.Cookie:ABTest-BankHolidaysTest;
+        set req.http.GOVUK-ABTest-BankHolidaysTest-Cookie = "sent_in_request";
       } else {
         declare local var.denominator_BankHolidaysTest INTEGER;
         declare local var.denominator_BankHolidaysTest_A INTEGER;
@@ -545,7 +547,7 @@ sub vcl_deliver {
   # cookie.
   if (req.url ~ "^/help/ab-testing"
     && req.http.User-Agent !~ "^GOV\.UK Crawler Worker"
-    && req.http.Cookie !~ "ABTest-Example") {
+    && req.http.GOVUK-ABTest-Example-Cookie != "sent_in_request") {
     # Set a fairly short cookie expiry because this is just an A/B test demo.
     add resp.http.Set-Cookie = "ABTest-Example=" req.http.GOVUK-ABTest-Example "; secure; expires=" now + 1d;
   }
@@ -554,7 +556,7 @@ sub vcl_deliver {
   declare local var.expiry TIME;
   if (req.http.Usage-Cookies-Opt-In == "true") {
     if (table.lookup(active_ab_tests, "BankHolidaysTest") == "true") {
-      if (req.http.Cookie !~ "ABTest-BankHolidaysTest" || req.url ~ "[\?\&]ABTest-BankHolidaysTest" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
+      if (req.http.GOVUK-ABTest-BankHolidaysTest-Cookie != "sent_in_request" || req.url ~ "[\?\&]ABTest-BankHolidaysTest" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
         set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "BankHolidaysTest"))));
         add resp.http.Set-Cookie = "ABTest-BankHolidaysTest=" req.http.GOVUK-ABTest-BankHolidaysTest "; secure; expires=" var.expiry "; path=/";
       }

--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -333,6 +333,7 @@ sub vcl_recv {
 
   # Begin dynamic section
   if (req.http.Cookie ~ "cookies_policy" && req.http.Cookie:cookies_policy ~ "%22usage%22:true") {
+    set req.http.Usage-Cookies-Opt-In = "true";
     if (table.lookup(active_ab_tests, "Example") == "true") {
       if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
         set req.http.GOVUK-ABTest-Example = "A";
@@ -551,13 +552,11 @@ sub vcl_deliver {
 
   # Begin dynamic section
   declare local var.expiry TIME;
-  if (req.http.Cookie ~ "cookies_policy") {
-    if (req.http.Cookie:cookies_policy ~ "%22usage%22:true") {
-      if (table.lookup(active_ab_tests, "BankHolidaysTest") == "true") {
-        if (req.http.Cookie !~ "ABTest-BankHolidaysTest" || req.url ~ "[\?\&]ABTest-BankHolidaysTest" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
-          set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "BankHolidaysTest"))));
-          add resp.http.Set-Cookie = "ABTest-BankHolidaysTest=" req.http.GOVUK-ABTest-BankHolidaysTest "; secure; expires=" var.expiry "; path=/";
-        }
+  if (req.http.Usage-Cookies-Opt-In == "true") {
+    if (table.lookup(active_ab_tests, "BankHolidaysTest") == "true") {
+      if (req.http.Cookie !~ "ABTest-BankHolidaysTest" || req.url ~ "[\?\&]ABTest-BankHolidaysTest" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
+        set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "BankHolidaysTest"))));
+        add resp.http.Set-Cookie = "ABTest-BankHolidaysTest=" req.http.GOVUK-ABTest-BankHolidaysTest "; secure; expires=" var.expiry "; path=/";
       }
     }
   }

--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -553,15 +553,15 @@ sub vcl_deliver {
   }
 
   # Begin dynamic section
-  declare local var.expiry TIME;
-  if (req.http.Usage-Cookies-Opt-In == "true") {
-    if (table.lookup(active_ab_tests, "BankHolidaysTest") == "true") {
-      if (req.http.GOVUK-ABTest-BankHolidaysTest-Cookie != "sent_in_request" || req.url ~ "[\?\&]ABTest-BankHolidaysTest" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
-        set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "BankHolidaysTest"))));
-        add resp.http.Set-Cookie = "ABTest-BankHolidaysTest=" req.http.GOVUK-ABTest-BankHolidaysTest "; secure; expires=" var.expiry "; path=/";
-      }
+declare local var.expiry TIME;
+if (req.http.Usage-Cookies-Opt-In == "true" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
+  if (table.lookup(active_ab_tests, "BankHolidaysTest") == "true") {
+    if (req.http.GOVUK-ABTest-BankHolidaysTest-Cookie != "sent_in_request" || req.url ~ "[\?\&]ABTest-BankHolidaysTest") {
+      set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "BankHolidaysTest"))));
+      add resp.http.Set-Cookie = "ABTest-BankHolidaysTest=" req.http.GOVUK-ABTest-BankHolidaysTest "; secure; expires=" var.expiry "; path=/";
     }
   }
+}
   # End dynamic section
 
 #FASTLY deliver

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -356,6 +356,7 @@ sub vcl_recv {
       } else if (req.http.Cookie ~ "ABTest-Example") {
         # Set the value of the header to whatever decision was previously made
         set req.http.GOVUK-ABTest-Example = req.http.Cookie:ABTest-Example;
+        set req.http.GOVUK-ABTest-Example-Cookie = "sent_in_request";
       } else {
         declare local var.denominator_Example INTEGER;
         declare local var.denominator_Example_A INTEGER;
@@ -388,6 +389,7 @@ sub vcl_recv {
       } else if (req.http.Cookie ~ "ABTest-BankHolidaysTest") {
         # Set the value of the header to whatever decision was previously made
         set req.http.GOVUK-ABTest-BankHolidaysTest = req.http.Cookie:ABTest-BankHolidaysTest;
+        set req.http.GOVUK-ABTest-BankHolidaysTest-Cookie = "sent_in_request";
       } else {
         declare local var.denominator_BankHolidaysTest INTEGER;
         declare local var.denominator_BankHolidaysTest_A INTEGER;
@@ -553,7 +555,7 @@ sub vcl_deliver {
   # cookie.
   if (req.url ~ "^/help/ab-testing"
     && req.http.User-Agent !~ "^GOV\.UK Crawler Worker"
-    && req.http.Cookie !~ "ABTest-Example") {
+    && req.http.GOVUK-ABTest-Example-Cookie != "sent_in_request") {
     # Set a fairly short cookie expiry because this is just an A/B test demo.
     add resp.http.Set-Cookie = "ABTest-Example=" req.http.GOVUK-ABTest-Example "; secure; expires=" now + 1d;
   }
@@ -562,7 +564,7 @@ sub vcl_deliver {
   declare local var.expiry TIME;
   if (req.http.Usage-Cookies-Opt-In == "true") {
     if (table.lookup(active_ab_tests, "BankHolidaysTest") == "true") {
-      if (req.http.Cookie !~ "ABTest-BankHolidaysTest" || req.url ~ "[\?\&]ABTest-BankHolidaysTest" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
+      if (req.http.GOVUK-ABTest-BankHolidaysTest-Cookie != "sent_in_request" || req.url ~ "[\?\&]ABTest-BankHolidaysTest" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
         set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "BankHolidaysTest"))));
         add resp.http.Set-Cookie = "ABTest-BankHolidaysTest=" req.http.GOVUK-ABTest-BankHolidaysTest "; secure; expires=" var.expiry "; path=/";
       }

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -561,15 +561,15 @@ sub vcl_deliver {
   }
 
   # Begin dynamic section
-  declare local var.expiry TIME;
-  if (req.http.Usage-Cookies-Opt-In == "true") {
-    if (table.lookup(active_ab_tests, "BankHolidaysTest") == "true") {
-      if (req.http.GOVUK-ABTest-BankHolidaysTest-Cookie != "sent_in_request" || req.url ~ "[\?\&]ABTest-BankHolidaysTest" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
-        set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "BankHolidaysTest"))));
-        add resp.http.Set-Cookie = "ABTest-BankHolidaysTest=" req.http.GOVUK-ABTest-BankHolidaysTest "; secure; expires=" var.expiry "; path=/";
-      }
+declare local var.expiry TIME;
+if (req.http.Usage-Cookies-Opt-In == "true" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
+  if (table.lookup(active_ab_tests, "BankHolidaysTest") == "true") {
+    if (req.http.GOVUK-ABTest-BankHolidaysTest-Cookie != "sent_in_request" || req.url ~ "[\?\&]ABTest-BankHolidaysTest") {
+      set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "BankHolidaysTest"))));
+      add resp.http.Set-Cookie = "ABTest-BankHolidaysTest=" req.http.GOVUK-ABTest-BankHolidaysTest "; secure; expires=" var.expiry "; path=/";
     }
   }
+}
   # End dynamic section
 
 #FASTLY deliver

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -557,13 +557,6 @@ sub vcl_deliver {
     add resp.http.Set-Cookie = "ABTest-Example=" req.http.GOVUK-ABTest-Example "; secure; expires=" now + 1d;
   }
 
-  # Hard coded test to check things are working ok because so far things aren't
-  if (req.url ~ "^/bank-holidays"
-    && req.http.User-Agent !~ "^GOV\.UK Crawler Worker"
-    && req.http.Cookie !~ "ABTest-BankHolidaysTest") {
-    add resp.http.Set-Cookie = "ABTest-BankHolidaysTest=" req.http.GOVUK-ABTest-BankHolidaysTest "; secure; expires=" now + 1d;
-  }
-
   # Begin dynamic section
   declare local var.expiry TIME;
   if (req.http.Cookie ~ "cookies_policy") {

--- a/spec/test-outputs/www-test.out.vcl
+++ b/spec/test-outputs/www-test.out.vcl
@@ -389,15 +389,15 @@ sub vcl_deliver {
   }
 
   # Begin dynamic section
-  declare local var.expiry TIME;
-  if (req.http.Usage-Cookies-Opt-In == "true") {
-    if (table.lookup(active_ab_tests, "BankHolidaysTest") == "true") {
-      if (req.http.GOVUK-ABTest-BankHolidaysTest-Cookie != "sent_in_request" || req.url ~ "[\?\&]ABTest-BankHolidaysTest" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
-        set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "BankHolidaysTest"))));
-        add resp.http.Set-Cookie = "ABTest-BankHolidaysTest=" req.http.GOVUK-ABTest-BankHolidaysTest "; secure; expires=" var.expiry "; path=/";
-      }
+declare local var.expiry TIME;
+if (req.http.Usage-Cookies-Opt-In == "true" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
+  if (table.lookup(active_ab_tests, "BankHolidaysTest") == "true") {
+    if (req.http.GOVUK-ABTest-BankHolidaysTest-Cookie != "sent_in_request" || req.url ~ "[\?\&]ABTest-BankHolidaysTest") {
+      set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "BankHolidaysTest"))));
+      add resp.http.Set-Cookie = "ABTest-BankHolidaysTest=" req.http.GOVUK-ABTest-BankHolidaysTest "; secure; expires=" var.expiry "; path=/";
     }
   }
+}
   # End dynamic section
 
 #FASTLY deliver

--- a/spec/test-outputs/www-test.out.vcl
+++ b/spec/test-outputs/www-test.out.vcl
@@ -385,13 +385,6 @@ sub vcl_deliver {
     add resp.http.Set-Cookie = "ABTest-Example=" req.http.GOVUK-ABTest-Example "; secure; expires=" now + 1d;
   }
 
-  # Hard coded test to check things are working ok because so far things aren't
-  if (req.url ~ "^/bank-holidays"
-    && req.http.User-Agent !~ "^GOV\.UK Crawler Worker"
-    && req.http.Cookie !~ "ABTest-BankHolidaysTest") {
-    add resp.http.Set-Cookie = "ABTest-BankHolidaysTest=" req.http.GOVUK-ABTest-BankHolidaysTest "; secure; expires=" now + 1d;
-  }
-
   # Begin dynamic section
   declare local var.expiry TIME;
   if (req.http.Cookie ~ "cookies_policy") {

--- a/spec/test-outputs/www-test.out.vcl
+++ b/spec/test-outputs/www-test.out.vcl
@@ -169,6 +169,7 @@ sub vcl_recv {
 
   # Begin dynamic section
   if (req.http.Cookie ~ "cookies_policy" && req.http.Cookie:cookies_policy ~ "%22usage%22:true") {
+    set req.http.Usage-Cookies-Opt-In = "true";
     if (table.lookup(active_ab_tests, "Example") == "true") {
       if (req.http.User-Agent ~ "^GOV\.UK Crawler Worker") {
         set req.http.GOVUK-ABTest-Example = "A";
@@ -387,13 +388,11 @@ sub vcl_deliver {
 
   # Begin dynamic section
   declare local var.expiry TIME;
-  if (req.http.Cookie ~ "cookies_policy") {
-    if (req.http.Cookie:cookies_policy ~ "%22usage%22:true") {
-      if (table.lookup(active_ab_tests, "BankHolidaysTest") == "true") {
-        if (req.http.Cookie !~ "ABTest-BankHolidaysTest" || req.url ~ "[\?\&]ABTest-BankHolidaysTest" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
-          set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "BankHolidaysTest"))));
-          add resp.http.Set-Cookie = "ABTest-BankHolidaysTest=" req.http.GOVUK-ABTest-BankHolidaysTest "; secure; expires=" var.expiry "; path=/";
-        }
+  if (req.http.Usage-Cookies-Opt-In == "true") {
+    if (table.lookup(active_ab_tests, "BankHolidaysTest") == "true") {
+      if (req.http.Cookie !~ "ABTest-BankHolidaysTest" || req.url ~ "[\?\&]ABTest-BankHolidaysTest" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
+        set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "BankHolidaysTest"))));
+        add resp.http.Set-Cookie = "ABTest-BankHolidaysTest=" req.http.GOVUK-ABTest-BankHolidaysTest "; secure; expires=" var.expiry "; path=/";
       }
     }
   }

--- a/vcl_templates/_multivariate_tests.vcl.erb
+++ b/vcl_templates/_multivariate_tests.vcl.erb
@@ -21,6 +21,7 @@ if (req.http.Cookie ~ "cookies_policy" && req.http.Cookie:cookies_policy ~ "%22u
     } else if (req.http.Cookie ~ "ABTest-<%= test %>") {
       # Set the value of the header to whatever decision was previously made
       set req.http.GOVUK-ABTest-<%= test %> = req.http.Cookie:ABTest-<%= test %>;
+      set req.http.GOVUK-ABTest-<%= test %>-Cookie = "sent_in_request";
     } else {
       declare local var.denominator_<%= test %> INTEGER;
 <% variants.each do |variant| -%>

--- a/vcl_templates/_multivariate_tests.vcl.erb
+++ b/vcl_templates/_multivariate_tests.vcl.erb
@@ -5,6 +5,7 @@
 # Begin dynamic section
 <% if ab_tests -%>
 if (req.http.Cookie ~ "cookies_policy" && req.http.Cookie:cookies_policy ~ "%22usage%22:true") {
+  set req.http.Usage-Cookies-Opt-In = "true";
 <% ab_tests.each do |test_config| -%>
 <%# test_config is a hash like { "MyTest" => ['foo', 'bar', 'baz'] } -%>
 <% test_config.each do |test, variants| -%>

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -527,7 +527,7 @@ sub vcl_deliver {
   # cookie.
   if (req.url ~ "^/help/ab-testing"
     && req.http.User-Agent !~ "^GOV\.UK Crawler Worker"
-    && req.http.Cookie !~ "ABTest-Example") {
+    && req.http.GOVUK-ABTest-Example-Cookie != "sent_in_request") {
     # Set a fairly short cookie expiry because this is just an A/B test demo.
     add resp.http.Set-Cookie = "ABTest-Example=" req.http.GOVUK-ABTest-Example "; secure; expires=" now + 1d;
   }
@@ -540,7 +540,7 @@ sub vcl_deliver {
 <% unless test == "Example" -%>
   if (req.http.Usage-Cookies-Opt-In == "true") {
     if (table.lookup(active_ab_tests, "<%= test %>") == "true") {
-      if (req.http.Cookie !~ "ABTest-<%= test %>" || req.url ~ "[\?\&]ABTest-<%= test %>" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
+      if (req.http.GOVUK-ABTest-<%= test %>-Cookie != "sent_in_request" || req.url ~ "[\?\&]ABTest-<%= test %>" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
         set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "<%= test %>"))));
         add resp.http.Set-Cookie = "ABTest-<%= test %>=" req.http.GOVUK-ABTest-<%= test %> "; secure; expires=" var.expiry "; path=/";
       }

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -532,13 +532,6 @@ sub vcl_deliver {
     add resp.http.Set-Cookie = "ABTest-Example=" req.http.GOVUK-ABTest-Example "; secure; expires=" now + 1d;
   }
 
-  # Hard coded test to check things are working ok because so far things aren't
-  if (req.url ~ "^/bank-holidays"
-    && req.http.User-Agent !~ "^GOV\.UK Crawler Worker"
-    && req.http.Cookie !~ "ABTest-BankHolidaysTest") {
-    add resp.http.Set-Cookie = "ABTest-BankHolidaysTest=" req.http.GOVUK-ABTest-BankHolidaysTest "; secure; expires=" now + 1d;
-  }
-
   # Begin dynamic section
 <% if ab_tests -%>
   declare local var.expiry TIME;

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -534,21 +534,21 @@ sub vcl_deliver {
 
   # Begin dynamic section
 <% if ab_tests -%>
-  declare local var.expiry TIME;
+declare local var.expiry TIME;
+if (req.http.Usage-Cookies-Opt-In == "true" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
 <% ab_tests.each do |test_config| -%>
 <% test_config.each do |test, _| -%>
 <% unless test == "Example" -%>
-  if (req.http.Usage-Cookies-Opt-In == "true") {
-    if (table.lookup(active_ab_tests, "<%= test %>") == "true") {
-      if (req.http.GOVUK-ABTest-<%= test %>-Cookie != "sent_in_request" || req.url ~ "[\?\&]ABTest-<%= test %>" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
-        set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "<%= test %>"))));
-        add resp.http.Set-Cookie = "ABTest-<%= test %>=" req.http.GOVUK-ABTest-<%= test %> "; secure; expires=" var.expiry "; path=/";
-      }
+  if (table.lookup(active_ab_tests, "<%= test %>") == "true") {
+    if (req.http.GOVUK-ABTest-<%= test %>-Cookie != "sent_in_request" || req.url ~ "[\?\&]ABTest-<%= test %>") {
+      set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "<%= test %>"))));
+      add resp.http.Set-Cookie = "ABTest-<%= test %>=" req.http.GOVUK-ABTest-<%= test %> "; secure; expires=" var.expiry "; path=/";
     }
   }
 <% end # unless -%>
 <% end # test_config.each -%>
 <% end # ab_tests.each -%>
+}
 <% end # if -%>
   # End dynamic section
 

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -538,13 +538,11 @@ sub vcl_deliver {
 <% ab_tests.each do |test_config| -%>
 <% test_config.each do |test, _| -%>
 <% unless test == "Example" -%>
-  if (req.http.Cookie ~ "cookies_policy") {
-    if (req.http.Cookie:cookies_policy ~ "%22usage%22:true") {
-      if (table.lookup(active_ab_tests, "<%= test %>") == "true") {
-        if (req.http.Cookie !~ "ABTest-<%= test %>" || req.url ~ "[\?\&]ABTest-<%= test %>" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
-          set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "<%= test %>"))));
-          add resp.http.Set-Cookie = "ABTest-<%= test %>=" req.http.GOVUK-ABTest-<%= test %> "; secure; expires=" var.expiry "; path=/";
-        }
+  if (req.http.Usage-Cookies-Opt-In == "true") {
+    if (table.lookup(active_ab_tests, "<%= test %>") == "true") {
+      if (req.http.Cookie !~ "ABTest-<%= test %>" || req.url ~ "[\?\&]ABTest-<%= test %>" && req.http.User-Agent !~ "^GOV\.UK Crawler Worker") {
+        set var.expiry = time.add(now, std.integer2time(std.atoi(table.lookup(ab_test_expiries, "<%= test %>"))));
+        add resp.http.Set-Cookie = "ABTest-<%= test %>=" req.http.GOVUK-ABTest-<%= test %> "; secure; expires=" var.expiry "; path=/";
       }
     }
   }


### PR DESCRIPTION
⚠️ The changes need to be deployed manually to all relevant environments. Follow the guidance on [how to deploy Fastly](https://docs.publishing.service.gov.uk/manual/cdn.html#deploying-fastly).

# What stopped working?

The dynamic code used to generate cookies for AB tests first checks
that the user has consented to cookies. This value is stored in a
cookie called `cookie_policy`. If the `cookie_policy` cookie doesn't
contain a value, the code won't execute. That's what was happening
here, and had the effect of the AB test cookies not being created.

The Example AB test doesn't check the value of the `cookie_policy`
cookie, so that cookie was being set as expected.

# Why did it stop working?

When a request is made to Fastly for a page, the header contains the
cookie information. However, if there's a cache-miss and we need to
call the application on origin (as there is when a cookie needs to be
set), we need to make sure that we don't send the cookies to Origin.

We do this to prevent the risk of applications caching user information
from the cookie and accidently sharing it with other users. Instead the
application reads the test variant that the user is in from the request
header. This header value is added by Fastly when it receives the request.

In the old world, pre-replatforming, there was another layer that sat
between Fastly and Origin; Varnish. As well as being another caching
layer, Varnish also did the work to strip the cookie information before
sending the request on to the application.

As the cookie stripping was happening in the Varnish layer, Fastly
always had access to the cookie information. That means that when the
request came back from Origin via Varnish, Fastly was still able to look
up the `cookie_policy` value and set the AB Test cookies.

The Varnish layer was removed with replatforming. This meant that the
cookies had to be stripped elsewhere before the request was sent to
Origin. As Fastly talks to Origin directly now, the cookie stripping
was added to Fastly [before being sent] to Origin. This initial test of
the cookie stripping occurred in integration and it was found that it
stopped AB Tests from working as it ran before the code to set the
AB test variant in the header (called from the multivariant
partial).

So the cookie stripping was moved to [after the header] value was
added. As the code now seemed to set the header correctly, it was
applied to all environments.

However the way VCL is structured and when each bit of the code is
executed means that setting cookies for AB tests stopped working.

Even though all of the generated VCL code is created in the same place,
it actually runs at the different times in the [life of a request].

The code to strip the cookies is in the `vcl_recv` function and is run
when the request is received.

The code that sets AB test cookies is in the `vcl_deliver` function and
is run against the response from Origin before delivering that response
to the user. By the time this code runs the cookie information from the
request is long gone.

Ideally, the cookie information pertaining to cookie consent in the
`cookie_policy` cookie, and any existing AB test cookies needs to be
preserved in Fastly so that the "deliver" code can access it.

# How has it been fixed?

It hasn't been fixed, not completely.

A variable has been created to persist the `cookie_policy`. Having this
variable means that the AB Test cookies can be created.

However, this hasn't completely fixed the problem. As the rest of the
cookie information has been lost, it means that any code in the
`vcl_deliver` function that checks the value of `req.http.Cookie` will
always return `(null)`. That means that this check will always be
true:

```
req.http.Cookie !~ "ABTest-<%= test %>"
```

The consequence of this is that everytime the user visits a page in an
AB test, a new cookie will always be set for them. This renders the
cookie expiry time as useless, and means that it's likely that the user
could see or interact with multiple variants of a page. This is not
ideal in terms of user journey, or for testing user behaviour.

# What are the next steps?

We need to find a way to stop generating an AB test cookie every time a
user visits the page, most likely by preserving the AB test cookie data
in `req.http.Cookie` before it's purged, but without having to hardcode
the AB test name everytime a new one is added.

It also looks like the value could be read from the header, as the value is
set from the cookie:

```
else if (req.http.Cookie ~ "ABTest-<%= test %>") {
      # Set the value of the header to whatever decision was previously made
      set req.http.GOVUK-ABTest-<%= test %> = req.http.Cookie:ABTest-<%= test %>;
```

[before being sent]: https://github.com/alphagov/govuk-cdn-config/commit/4330a2530bbd6878cfba6c4093f9e2e847633feb
[after the header]: https://github.com/alphagov/govuk-cdn-config/commit/ad64a8a4afdd3d951a3fc67101ad4d5b050b0f6b
[life of a request]: https://developer.fastly.com/learning/vcl/using/
