### PR TITLE
Remove Licensify TLS hack

### DIFF
--- a/spec/test-outputs/mirror-integration.out.vcl
+++ b/spec/test-outputs/mirror-integration.out.vcl
@@ -103,12 +103,6 @@ sub vcl_recv {
 
   
 
-  # Set a TLSversion request header for requests going to the Licensify application
-  # This is used to block unsecure requests at the application level for payment security reasons and an absence of caching in Licensify
-  if (req.url ~ "^/apply-for-a-licence/.*") {
-    set req.http.TLSversion = tls.client.protocol;
-  }
-
 
 #FASTLY recv
 

--- a/spec/test-outputs/mirror-production.out.vcl
+++ b/spec/test-outputs/mirror-production.out.vcl
@@ -260,12 +260,6 @@ sub vcl_recv {
   }
   
 
-  # Set a TLSversion request header for requests going to the Licensify application
-  # This is used to block unsecure requests at the application level for payment security reasons and an absence of caching in Licensify
-  if (req.url ~ "^/apply-for-a-licence/.*") {
-    set req.http.TLSversion = tls.client.protocol;
-  }
-
 
 #FASTLY recv
 

--- a/spec/test-outputs/mirror-staging.out.vcl
+++ b/spec/test-outputs/mirror-staging.out.vcl
@@ -260,12 +260,6 @@ sub vcl_recv {
   }
   
 
-  # Set a TLSversion request header for requests going to the Licensify application
-  # This is used to block unsecure requests at the application level for payment security reasons and an absence of caching in Licensify
-  if (req.url ~ "^/apply-for-a-licence/.*") {
-    set req.http.TLSversion = tls.client.protocol;
-  }
-
 
 #FASTLY recv
 

--- a/spec/test-outputs/mirror-test.out.vcl
+++ b/spec/test-outputs/mirror-test.out.vcl
@@ -97,12 +97,6 @@ sub vcl_recv {
 
   
 
-  # Set a TLSversion request header for requests going to the Licensify application
-  # This is used to block unsecure requests at the application level for payment security reasons and an absence of caching in Licensify
-  if (req.url ~ "^/apply-for-a-licence/.*") {
-    set req.http.TLSversion = tls.client.protocol;
-  }
-
 
 #FASTLY recv
 

--- a/spec/test-outputs/www-eks-integration.out.vcl
+++ b/spec/test-outputs/www-eks-integration.out.vcl
@@ -141,12 +141,6 @@ sub vcl_recv {
 
   
 
-  # Set a TLSversion request header for requests going to the Licensify application
-  # This is used to block unsecure requests at the application level for payment security reasons and an absence of caching in Licensify
-  if (req.url ~ "^/apply-for-a-licence/.*") {
-    set req.http.TLSversion = tls.client.protocol;
-  }
-
 #FASTLY recv
 
   # GOV.UK accounts

--- a/spec/test-outputs/www-eks-production.out.vcl
+++ b/spec/test-outputs/www-eks-production.out.vcl
@@ -313,12 +313,6 @@ sub vcl_recv {
   }
   
 
-  # Set a TLSversion request header for requests going to the Licensify application
-  # This is used to block unsecure requests at the application level for payment security reasons and an absence of caching in Licensify
-  if (req.url ~ "^/apply-for-a-licence/.*") {
-    set req.http.TLSversion = tls.client.protocol;
-  }
-
 #FASTLY recv
 
   # GOV.UK accounts

--- a/spec/test-outputs/www-eks-staging.out.vcl
+++ b/spec/test-outputs/www-eks-staging.out.vcl
@@ -313,12 +313,6 @@ sub vcl_recv {
   }
   
 
-  # Set a TLSversion request header for requests going to the Licensify application
-  # This is used to block unsecure requests at the application level for payment security reasons and an absence of caching in Licensify
-  if (req.url ~ "^/apply-for-a-licence/.*") {
-    set req.http.TLSversion = tls.client.protocol;
-  }
-
 #FASTLY recv
 
   # GOV.UK accounts

--- a/spec/test-outputs/www-eks-test.out.vcl
+++ b/spec/test-outputs/www-eks-test.out.vcl
@@ -141,12 +141,6 @@ sub vcl_recv {
 
   
 
-  # Set a TLSversion request header for requests going to the Licensify application
-  # This is used to block unsecure requests at the application level for payment security reasons and an absence of caching in Licensify
-  if (req.url ~ "^/apply-for-a-licence/.*") {
-    set req.http.TLSversion = tls.client.protocol;
-  }
-
 #FASTLY recv
 
   # GOV.UK accounts

--- a/spec/test-outputs/www-integration.out.vcl
+++ b/spec/test-outputs/www-integration.out.vcl
@@ -141,12 +141,6 @@ sub vcl_recv {
 
   
 
-  # Set a TLSversion request header for requests going to the Licensify application
-  # This is used to block unsecure requests at the application level for payment security reasons and an absence of caching in Licensify
-  if (req.url ~ "^/apply-for-a-licence/.*") {
-    set req.http.TLSversion = tls.client.protocol;
-  }
-
 #FASTLY recv
 
   # GOV.UK accounts

--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -305,12 +305,6 @@ sub vcl_recv {
   }
   
 
-  # Set a TLSversion request header for requests going to the Licensify application
-  # This is used to block unsecure requests at the application level for payment security reasons and an absence of caching in Licensify
-  if (req.url ~ "^/apply-for-a-licence/.*") {
-    set req.http.TLSversion = tls.client.protocol;
-  }
-
 #FASTLY recv
 
   # GOV.UK accounts

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -313,12 +313,6 @@ sub vcl_recv {
   }
   
 
-  # Set a TLSversion request header for requests going to the Licensify application
-  # This is used to block unsecure requests at the application level for payment security reasons and an absence of caching in Licensify
-  if (req.url ~ "^/apply-for-a-licence/.*") {
-    set req.http.TLSversion = tls.client.protocol;
-  }
-
 #FASTLY recv
 
   # GOV.UK accounts

--- a/spec/test-outputs/www-test.out.vcl
+++ b/spec/test-outputs/www-test.out.vcl
@@ -141,12 +141,6 @@ sub vcl_recv {
 
   
 
-  # Set a TLSversion request header for requests going to the Licensify application
-  # This is used to block unsecure requests at the application level for payment security reasons and an absence of caching in Licensify
-  if (req.url ~ "^/apply-for-a-licence/.*") {
-    set req.http.TLSversion = tls.client.protocol;
-  }
-
 #FASTLY recv
 
   # GOV.UK accounts

--- a/vcl_templates/mirror.vcl.erb
+++ b/vcl_templates/mirror.vcl.erb
@@ -294,12 +294,6 @@ sub vcl_recv {
   }
   <% end %>
 
-  # Set a TLSversion request header for requests going to the Licensify application
-  # This is used to block unsecure requests at the application level for payment security reasons and an absence of caching in Licensify
-  if (req.url ~ "^/apply-for-a-licence/.*") {
-    set req.http.TLSversion = tls.client.protocol;
-  }
-
 <% if config['basic_authentication'] -%>
   if (req.backend == F_origin) {
     set req.http.Authorization = "Basic <%= config['basic_authentication'] %>";

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -330,12 +330,6 @@ sub vcl_recv {
   }
   <% end %>
 
-  # Set a TLSversion request header for requests going to the Licensify application
-  # This is used to block unsecure requests at the application level for payment security reasons and an absence of caching in Licensify
-  if (req.url ~ "^/apply-for-a-licence/.*") {
-    set req.http.TLSversion = tls.client.protocol;
-  }
-
 <% if config['basic_authentication'] -%>
   if (req.backend == F_origin) {
     set req.http.Authorization = "Basic <%= config['basic_authentication'] %>";


### PR DESCRIPTION
In March 2018, in 26a0edb0c1138b5cbedd741e396d942cf117cd8c, code was added to intercept requests for URLs beginning with "/apply-for-a-licence/", which:

> Added a request header containing the TLS version number for requests to the Licensify app
> (This is so we can block requests with TLS versions below 1.2 from submitting, for payment security reasons)

However, in December 2022, in
https://github.com/alphagov/govuk-puppet/pull/11931/commits/46d98aaec4eaf664f8a078ea12d2ec03ada4b18c, we dropped TLS 1 and 1.1 support at the nginx level. So the special case added just for Licensify is no longer necessary.

This was uncovered as part of the following Trello card: https://trello.com/c/TbvosEgo/3101-staging-test-define-list-of-features-that-wont-currently-work-on-cloudfront

⚠️ The changes need to be deployed manually to all relevant environments. Follow the guidance on [how to deploy Fastly](https://docs.publishing.service.gov.uk/manual/cdn.html#deploying-fastly).
