### PR TITLE
Add 'Backend-Override' header to select backend

### DIFF
--- a/spec/test-outputs/www-eks-integration.out.vcl
+++ b/spec/test-outputs/www-eks-integration.out.vcl
@@ -38,6 +38,8 @@ acl allowed_ip_addresses {
 
 
 sub vcl_recv {
+  declare local var.backend_override STRING;
+
   # Protect header from modification at the edge of the Fastly network
   # https://developer.fastly.com/reference/http-headers/Fastly-Client-IP
   if (fastly.ff.visits_this_service == 0 && req.restarts == 0) {

--- a/spec/test-outputs/www-eks-staging.out.vcl
+++ b/spec/test-outputs/www-eks-staging.out.vcl
@@ -137,6 +137,8 @@ acl allowed_ip_addresses {
 
 
 sub vcl_recv {
+  declare local var.backend_override STRING;
+
   # Protect header from modification at the edge of the Fastly network
   # https://developer.fastly.com/reference/http-headers/Fastly-Client-IP
   if (fastly.ff.visits_this_service == 0 && req.restarts == 0) {
@@ -250,8 +252,12 @@ sub vcl_recv {
     set req.http.original-url = req.url;
   }
 
+  
+  set var.backend_override = req.http.Backend-Override;
+  
+
   # Common config when failover to mirror buckets
-  if (req.restarts > 0) {
+  if (req.restarts > 0 || std.prefixof(var.backend_override, "mirror")) {
     set req.url = req.http.original-url;
 
     # Don't serve from stale for mirrors
@@ -270,39 +276,39 @@ sub vcl_recv {
     if (req.url !~ "^([^#\?\s]+)\.(atom|chm|css|csv|diff|doc|docx|dot|dxf|eps|gif|gml|html|ico|ics|jpeg|jpg|JPG|js|json|kml|odp|ods|odt|pdf|PDF|png|ppt|pptx|ps|rdf|rtf|sch|txt|wsdl|xls|xlsm|xlsx|xlt|xml|xsd|xslt|zip)([\?#]+.*)?$") {
       set req.url = regsub(req.url, "^([^#\?\s]+)([\?#]+.*)?$", "\1.html\2");
     }
-  }
 
-  # Failover to primary s3 mirror.
-  if (req.restarts == 1) {
-      set req.backend = F_mirrorS3;
-      set req.http.host = "bar";
-      set req.http.Fastly-Backend-Name = "mirrorS3";
+    # Failover to primary s3 mirror.
+    if (req.restarts == 1  || var.backend_override == "mirrorS3") {
+        set req.backend = F_mirrorS3;
+        set req.http.host = "bar";
+        set req.http.Fastly-Backend-Name = "mirrorS3";
+
+        # Add bucket directory prefix to all the requests
+        set req.url = "/foo_" req.url;
+    }
+
+    # Failover to replica s3 mirror.
+    if (req.restarts == 2 || var.backend_override == "mirrorS3Replica") {
+      set req.backend = F_mirrorS3Replica;
+      set req.http.host = "s3-mirror-replica.aws.com";
+      set req.http.Fastly-Backend-Name = "mirrorS3Replica";
 
       # Add bucket directory prefix to all the requests
-      set req.url = "/foo_" req.url;
-  }
+      set req.url = "/s3-mirror-replica" req.url;
+    }
 
-  # Failover to replica s3 mirror.
-  if (req.restarts == 2) {
-    set req.backend = F_mirrorS3Replica;
-    set req.http.host = "s3-mirror-replica.aws.com";
-    set req.http.Fastly-Backend-Name = "mirrorS3Replica";
+    # Failover to GCS mirror.
+    if (req.restarts > 2 || var.backend_override == "mirrorGCS") {
+      set req.backend = F_mirrorGCS;
+      set req.http.host = "gcs-mirror.google.com";
+      set req.http.Fastly-Backend-Name = "mirrorGCS";
 
-    # Add bucket directory prefix to all the requests
-    set req.url = "/s3-mirror-replica" req.url;
-  }
+      # Add bucket directory prefix to all the requests
+      set req.url = "/gcs-mirror" req.url;
 
-  # Failover to GCS mirror.
-  if (req.restarts > 2) {
-    set req.backend = F_mirrorGCS;
-    set req.http.host = "gcs-mirror.google.com";
-    set req.http.Fastly-Backend-Name = "mirrorGCS";
-
-    # Add bucket directory prefix to all the requests
-    set req.url = "/gcs-mirror" req.url;
-
-    set req.http.Date = now;
-    set req.http.Authorization = "AWS gcs-mirror-access-id:" digest.hmac_sha1_base64("gcs-mirror-secret-key", "GET" LF LF LF now LF "/gcs-bucket" req.url.path);
+      set req.http.Date = now;
+      set req.http.Authorization = "AWS gcs-mirror-access-id:" digest.hmac_sha1_base64("gcs-mirror-secret-key", "GET" LF LF LF now LF "/gcs-bucket" req.url.path);
+    }
   }
 
   # Add normalization vcl for Brotli support

--- a/spec/test-outputs/www-eks-test.out.vcl
+++ b/spec/test-outputs/www-eks-test.out.vcl
@@ -38,6 +38,8 @@ acl allowed_ip_addresses {
 
 
 sub vcl_recv {
+  declare local var.backend_override STRING;
+
   # Protect header from modification at the edge of the Fastly network
   # https://developer.fastly.com/reference/http-headers/Fastly-Client-IP
   if (fastly.ff.visits_this_service == 0 && req.restarts == 0) {

--- a/spec/test-outputs/www-integration.out.vcl
+++ b/spec/test-outputs/www-integration.out.vcl
@@ -38,6 +38,8 @@ acl allowed_ip_addresses {
 
 
 sub vcl_recv {
+  declare local var.backend_override STRING;
+
   # Protect header from modification at the edge of the Fastly network
   # https://developer.fastly.com/reference/http-headers/Fastly-Client-IP
   if (fastly.ff.visits_this_service == 0 && req.restarts == 0) {

--- a/spec/test-outputs/www-production.out.vcl
+++ b/spec/test-outputs/www-production.out.vcl
@@ -134,6 +134,8 @@ backend F_mirrorGCS {
 
 
 sub vcl_recv {
+  declare local var.backend_override STRING;
+
   # Protect header from modification at the edge of the Fastly network
   # https://developer.fastly.com/reference/http-headers/Fastly-Client-IP
   if (fastly.ff.visits_this_service == 0 && req.restarts == 0) {
@@ -242,8 +244,10 @@ sub vcl_recv {
     set req.http.original-url = req.url;
   }
 
+  
+
   # Common config when failover to mirror buckets
-  if (req.restarts > 0) {
+  if (req.restarts > 0 || std.prefixof(var.backend_override, "mirror")) {
     set req.url = req.http.original-url;
 
     # Don't serve from stale for mirrors
@@ -262,39 +266,39 @@ sub vcl_recv {
     if (req.url !~ "^([^#\?\s]+)\.(atom|chm|css|csv|diff|doc|docx|dot|dxf|eps|gif|gml|html|ico|ics|jpeg|jpg|JPG|js|json|kml|odp|ods|odt|pdf|PDF|png|ppt|pptx|ps|rdf|rtf|sch|txt|wsdl|xls|xlsm|xlsx|xlt|xml|xsd|xslt|zip)([\?#]+.*)?$") {
       set req.url = regsub(req.url, "^([^#\?\s]+)([\?#]+.*)?$", "\1.html\2");
     }
-  }
 
-  # Failover to primary s3 mirror.
-  if (req.restarts == 1) {
-      set req.backend = F_mirrorS3;
-      set req.http.host = "bar";
-      set req.http.Fastly-Backend-Name = "mirrorS3";
+    # Failover to primary s3 mirror.
+    if (req.restarts == 1  || var.backend_override == "mirrorS3") {
+        set req.backend = F_mirrorS3;
+        set req.http.host = "bar";
+        set req.http.Fastly-Backend-Name = "mirrorS3";
+
+        # Add bucket directory prefix to all the requests
+        set req.url = "/foo_" req.url;
+    }
+
+    # Failover to replica s3 mirror.
+    if (req.restarts == 2 || var.backend_override == "mirrorS3Replica") {
+      set req.backend = F_mirrorS3Replica;
+      set req.http.host = "s3-mirror-replica.aws.com";
+      set req.http.Fastly-Backend-Name = "mirrorS3Replica";
 
       # Add bucket directory prefix to all the requests
-      set req.url = "/foo_" req.url;
-  }
+      set req.url = "/s3-mirror-replica" req.url;
+    }
 
-  # Failover to replica s3 mirror.
-  if (req.restarts == 2) {
-    set req.backend = F_mirrorS3Replica;
-    set req.http.host = "s3-mirror-replica.aws.com";
-    set req.http.Fastly-Backend-Name = "mirrorS3Replica";
+    # Failover to GCS mirror.
+    if (req.restarts > 2 || var.backend_override == "mirrorGCS") {
+      set req.backend = F_mirrorGCS;
+      set req.http.host = "gcs-mirror.google.com";
+      set req.http.Fastly-Backend-Name = "mirrorGCS";
 
-    # Add bucket directory prefix to all the requests
-    set req.url = "/s3-mirror-replica" req.url;
-  }
+      # Add bucket directory prefix to all the requests
+      set req.url = "/gcs-mirror" req.url;
 
-  # Failover to GCS mirror.
-  if (req.restarts > 2) {
-    set req.backend = F_mirrorGCS;
-    set req.http.host = "gcs-mirror.google.com";
-    set req.http.Fastly-Backend-Name = "mirrorGCS";
-
-    # Add bucket directory prefix to all the requests
-    set req.url = "/gcs-mirror" req.url;
-
-    set req.http.Date = now;
-    set req.http.Authorization = "AWS gcs-mirror-access-id:" digest.hmac_sha1_base64("gcs-mirror-secret-key", "GET" LF LF LF now LF "/gcs-bucket" req.url.path);
+      set req.http.Date = now;
+      set req.http.Authorization = "AWS gcs-mirror-access-id:" digest.hmac_sha1_base64("gcs-mirror-secret-key", "GET" LF LF LF now LF "/gcs-bucket" req.url.path);
+    }
   }
 
   # Add normalization vcl for Brotli support

--- a/spec/test-outputs/www-staging.out.vcl
+++ b/spec/test-outputs/www-staging.out.vcl
@@ -137,6 +137,8 @@ acl allowed_ip_addresses {
 
 
 sub vcl_recv {
+  declare local var.backend_override STRING;
+
   # Protect header from modification at the edge of the Fastly network
   # https://developer.fastly.com/reference/http-headers/Fastly-Client-IP
   if (fastly.ff.visits_this_service == 0 && req.restarts == 0) {
@@ -250,8 +252,12 @@ sub vcl_recv {
     set req.http.original-url = req.url;
   }
 
+  
+  set var.backend_override = req.http.Backend-Override;
+  
+
   # Common config when failover to mirror buckets
-  if (req.restarts > 0) {
+  if (req.restarts > 0 || std.prefixof(var.backend_override, "mirror")) {
     set req.url = req.http.original-url;
 
     # Don't serve from stale for mirrors
@@ -270,39 +276,39 @@ sub vcl_recv {
     if (req.url !~ "^([^#\?\s]+)\.(atom|chm|css|csv|diff|doc|docx|dot|dxf|eps|gif|gml|html|ico|ics|jpeg|jpg|JPG|js|json|kml|odp|ods|odt|pdf|PDF|png|ppt|pptx|ps|rdf|rtf|sch|txt|wsdl|xls|xlsm|xlsx|xlt|xml|xsd|xslt|zip)([\?#]+.*)?$") {
       set req.url = regsub(req.url, "^([^#\?\s]+)([\?#]+.*)?$", "\1.html\2");
     }
-  }
 
-  # Failover to primary s3 mirror.
-  if (req.restarts == 1) {
-      set req.backend = F_mirrorS3;
-      set req.http.host = "bar";
-      set req.http.Fastly-Backend-Name = "mirrorS3";
+    # Failover to primary s3 mirror.
+    if (req.restarts == 1  || var.backend_override == "mirrorS3") {
+        set req.backend = F_mirrorS3;
+        set req.http.host = "bar";
+        set req.http.Fastly-Backend-Name = "mirrorS3";
+
+        # Add bucket directory prefix to all the requests
+        set req.url = "/foo_" req.url;
+    }
+
+    # Failover to replica s3 mirror.
+    if (req.restarts == 2 || var.backend_override == "mirrorS3Replica") {
+      set req.backend = F_mirrorS3Replica;
+      set req.http.host = "s3-mirror-replica.aws.com";
+      set req.http.Fastly-Backend-Name = "mirrorS3Replica";
 
       # Add bucket directory prefix to all the requests
-      set req.url = "/foo_" req.url;
-  }
+      set req.url = "/s3-mirror-replica" req.url;
+    }
 
-  # Failover to replica s3 mirror.
-  if (req.restarts == 2) {
-    set req.backend = F_mirrorS3Replica;
-    set req.http.host = "s3-mirror-replica.aws.com";
-    set req.http.Fastly-Backend-Name = "mirrorS3Replica";
+    # Failover to GCS mirror.
+    if (req.restarts > 2 || var.backend_override == "mirrorGCS") {
+      set req.backend = F_mirrorGCS;
+      set req.http.host = "gcs-mirror.google.com";
+      set req.http.Fastly-Backend-Name = "mirrorGCS";
 
-    # Add bucket directory prefix to all the requests
-    set req.url = "/s3-mirror-replica" req.url;
-  }
+      # Add bucket directory prefix to all the requests
+      set req.url = "/gcs-mirror" req.url;
 
-  # Failover to GCS mirror.
-  if (req.restarts > 2) {
-    set req.backend = F_mirrorGCS;
-    set req.http.host = "gcs-mirror.google.com";
-    set req.http.Fastly-Backend-Name = "mirrorGCS";
-
-    # Add bucket directory prefix to all the requests
-    set req.url = "/gcs-mirror" req.url;
-
-    set req.http.Date = now;
-    set req.http.Authorization = "AWS gcs-mirror-access-id:" digest.hmac_sha1_base64("gcs-mirror-secret-key", "GET" LF LF LF now LF "/gcs-bucket" req.url.path);
+      set req.http.Date = now;
+      set req.http.Authorization = "AWS gcs-mirror-access-id:" digest.hmac_sha1_base64("gcs-mirror-secret-key", "GET" LF LF LF now LF "/gcs-bucket" req.url.path);
+    }
   }
 
   # Add normalization vcl for Brotli support

--- a/spec/test-outputs/www-test.out.vcl
+++ b/spec/test-outputs/www-test.out.vcl
@@ -38,6 +38,8 @@ acl allowed_ip_addresses {
 
 
 sub vcl_recv {
+  declare local var.backend_override STRING;
+
   # Protect header from modification at the edge of the Fastly network
   # https://developer.fastly.com/reference/http-headers/Fastly-Client-IP
   if (fastly.ff.visits_this_service == 0 && req.restarts == 0) {

--- a/vcl_templates/www.vcl.erb
+++ b/vcl_templates/www.vcl.erb
@@ -165,6 +165,8 @@ acl allowed_ip_addresses {
 <% end %>
 
 sub vcl_recv {
+  declare local var.backend_override STRING;
+
 <%= render_partial("boundary_headers", indentation: "  ") %>
 
   # Require authentication for PURGE requests
@@ -267,8 +269,12 @@ sub vcl_recv {
     set req.http.original-url = req.url;
   }
 
+  <% if "staging" == environment %>
+  set var.backend_override = req.http.Backend-Override;
+  <% end %>
+
   # Common config when failover to mirror buckets
-  if (req.restarts > 0) {
+  if (req.restarts > 0 || std.prefixof(var.backend_override, "mirror")) {
     set req.url = req.http.original-url;
 
     # Don't serve from stale for mirrors
@@ -287,39 +293,39 @@ sub vcl_recv {
     if (req.url !~ "^([^#\?\s]+)\.(atom|chm|css|csv|diff|doc|docx|dot|dxf|eps|gif|gml|html|ico|ics|jpeg|jpg|JPG|js|json|kml|odp|ods|odt|pdf|PDF|png|ppt|pptx|ps|rdf|rtf|sch|txt|wsdl|xls|xlsm|xlsx|xlt|xml|xsd|xslt|zip)([\?#]+.*)?$") {
       set req.url = regsub(req.url, "^([^#\?\s]+)([\?#]+.*)?$", "\1.html\2");
     }
-  }
 
-  # Failover to primary s3 mirror.
-  if (req.restarts == 1) {
-      set req.backend = F_mirrorS3;
-      set req.http.host = "<%= config.fetch('s3_mirror_hostname') %>";
-      set req.http.Fastly-Backend-Name = "mirrorS3";
+    # Failover to primary s3 mirror.
+    if (req.restarts == 1  || var.backend_override == "mirrorS3") {
+        set req.backend = F_mirrorS3;
+        set req.http.host = "<%= config.fetch('s3_mirror_hostname') %>";
+        set req.http.Fastly-Backend-Name = "mirrorS3";
+
+        # Add bucket directory prefix to all the requests
+        set req.url = "/<%= config.fetch('s3_mirror_prefix') %>" req.url;
+    }
+
+    # Failover to replica s3 mirror.
+    if (req.restarts == 2 || var.backend_override == "mirrorS3Replica") {
+      set req.backend = F_mirrorS3Replica;
+      set req.http.host = "<%= config.fetch('s3_mirror_replica_hostname') %>";
+      set req.http.Fastly-Backend-Name = "mirrorS3Replica";
 
       # Add bucket directory prefix to all the requests
-      set req.url = "/<%= config.fetch('s3_mirror_prefix') %>" req.url;
-  }
+      set req.url = "/<%= config.fetch('s3_mirror_replica_prefix') %>" req.url;
+    }
 
-  # Failover to replica s3 mirror.
-  if (req.restarts == 2) {
-    set req.backend = F_mirrorS3Replica;
-    set req.http.host = "<%= config.fetch('s3_mirror_replica_hostname') %>";
-    set req.http.Fastly-Backend-Name = "mirrorS3Replica";
+    # Failover to GCS mirror.
+    if (req.restarts > 2 || var.backend_override == "mirrorGCS") {
+      set req.backend = F_mirrorGCS;
+      set req.http.host = "<%= config.fetch('gcs_mirror_hostname') %>";
+      set req.http.Fastly-Backend-Name = "mirrorGCS";
 
-    # Add bucket directory prefix to all the requests
-    set req.url = "/<%= config.fetch('s3_mirror_replica_prefix') %>" req.url;
-  }
+      # Add bucket directory prefix to all the requests
+      set req.url = "/<%= config.fetch('gcs_mirror_prefix') %>" req.url;
 
-  # Failover to GCS mirror.
-  if (req.restarts > 2) {
-    set req.backend = F_mirrorGCS;
-    set req.http.host = "<%= config.fetch('gcs_mirror_hostname') %>";
-    set req.http.Fastly-Backend-Name = "mirrorGCS";
-
-    # Add bucket directory prefix to all the requests
-    set req.url = "/<%= config.fetch('gcs_mirror_prefix') %>" req.url;
-
-    set req.http.Date = now;
-    set req.http.Authorization = "AWS <%= config.fetch('gcs_mirror_access_id') %>:" digest.hmac_sha1_base64("<%= config.fetch('gcs_mirror_secret_key') %>", "GET" LF LF LF now LF "/<%= config.fetch('gcs_mirror_bucket_name') %>" req.url.path);
+      set req.http.Date = now;
+      set req.http.Authorization = "AWS <%= config.fetch('gcs_mirror_access_id') %>:" digest.hmac_sha1_base64("<%= config.fetch('gcs_mirror_secret_key') %>", "GET" LF LF LF now LF "/<%= config.fetch('gcs_mirror_bucket_name') %>" req.url.path);
+    }
   }
 
   # Add normalization vcl for Brotli support


### PR DESCRIPTION
This allows you to override the default backend and have the request served by a mirror. Helpful to check if the mirrors are working. This header only works in Staging.

Might be easier to review using the Split View.

⚠️ The changes need to be deployed manually to all relevant environments. Follow the guidance on [how to deploy Fastly](https://docs.publishing.service.gov.uk/manual/cdn.html#deploying-fastly).
